### PR TITLE
Adds creation of argocd namespace for bootstrap

### DIFF
--- a/bootstrap/argocd/kustomization.yaml
+++ b/bootstrap/argocd/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+resources:
+- namespace.yaml
+
 helmGlobals:
   chartHome: ../../charts/
 

--- a/bootstrap/argocd/namespace.yaml
+++ b/bootstrap/argocd/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd


### PR DESCRIPTION
I got errors when bootstrapping with:
```
kubectl kustomize --enable-helm bootstrap | kubectl apply --server-side -f -
```
Due to missing argocd namespace:
```
Error from server (NotFound): namespaces "argocd" not found
```
This adds creating the argocd namespace as part of the bootstrap process.