### PR TITLE
fix: documentation and easy mode secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,15 @@ kubectl -n argocd apply -k apps/operators/
 
 ### Secrets
 
-Visit [/components/01-secrets/README.md](./components/01-secrets/README.md) and follow the steps there to
-generate the secrets you'll need. And then load them.
+To make it possible to utilize GitOps, we need to have our secrets pre-created
+and not randomly generated. A better solution for secrets will ultimately be
+needed but for now we can generate them easily for a dev environment and
+deploy them. Visit [/components/01-secrets/README.md](./components/01-secrets/README.md)
+for specific steps.  Otherwise just follow the steps below.
 
 ```bash
+# generate secrets
+./scripts/easy-secrets-gen.sh
 # make the namespaces where the secrets will live
 kubectl apply -k components/00-namespaces/
 # load the secrets

--- a/bootstrap/kustomization.yaml
+++ b/bootstrap/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 
 resources:
 - cert-manager/
+- sealed-secrets/
 - argocd/

--- a/components/10-keystone/README.md
+++ b/components/10-keystone/README.md
@@ -59,7 +59,7 @@ You can run an OpenStack client in the cluster to validate it is running correct
 
 ```bash
 # start up a pod with the client
-kubectl -n openstack apply -f https://github.com/rackerlabs/genestack/blob/main/manifests/utils/utils-openstack-client-admin.yaml
+kubectl -n openstack apply -f https://raw.githubusercontent.com/rackerlabs/genestack/main/manifests/utils/utils-openstack-client-admin.yaml
 ```
 
 Show the catalog list

--- a/scripts/easy-secrets-gen.sh
+++ b/scripts/easy-secrets-gen.sh
@@ -1,0 +1,92 @@
+#!/bin/bash -x
+
+cd $(git rev-parse --show-toplevel)
+
+kubectl --namespace openstack \
+    create secret generic mariadb \
+    --dry-run \
+    -o yaml \
+    --type Opaque \
+    --from-literal=root-password="$(./scripts/pwgen.sh)" \
+    --from-literal=password="$(./scripts/pwgen.sh)" \
+    > secret-mariadb.yaml
+
+kubectl --namespace nautobot \
+    create secret generic nautobot-env \
+    --dry-run \
+    -o yaml \
+    --type Opaque \
+    --from-literal=NAUTOBOT_SECRET_KEY="$(./scripts/pwgen.sh)" \
+    --from-literal=NAUTOBOT_SUPERUSER_API_TOKEN="$(./scripts/pwgen.sh)" \
+    --from-literal=NAUTOBOT_SUPERUSER_PASSWORD="$(./scripts/pwgen.sh)" \
+    > secret-nautobot-env.yaml
+
+kubectl --namespace nautobot \
+    create secret generic nautobot-redis \
+    --dry-run \
+    -o yaml \
+    --type Opaque \
+    --from-literal=redis-password="$(./scripts/pwgen.sh)" \
+    > secret-nautobot-redis.yaml
+
+kubectl --namespace openstack \
+    create secret generic keystone-rabbitmq-password \
+    --type Opaque \
+    --from-literal=username="keystone" \
+    --from-literal=password="$($(git rev-parse --show-toplevel)/scripts/pwgen.sh)" \
+    --dry-run -o yaml \
+    > secret-keystone-rabbitmq-password.yaml
+kubectl --namespace openstack \
+    create secret generic keystone-db-password \
+    --type Opaque \
+    --from-literal=password="$($(git rev-parse --show-toplevel)/scripts/pwgen.sh)" \
+    --dry-run -o yaml \
+    > secret-keystone-db-password.yaml
+kubectl --namespace openstack \
+    create secret generic keystone-admin \
+    --type Opaque \
+    --from-literal=password="$($(git rev-parse --show-toplevel)/scripts/pwgen.sh)" \
+    --dry-run -o yaml \
+    > secret-keystone-admin.yaml
+kubectl --namespace openstack \
+    create secret generic keystone-credential-keys \
+    --type Opaque \
+    --from-literal=password="$($(git rev-parse --show-toplevel)/scripts/pwgen.sh)" \
+    --dry-run -o yaml \
+    > secret-keystone-credential-keys.yaml
+
+kubeseal \
+    --scope cluster-wide \
+    --allow-empty-data \
+    -o yaml \
+    -f secret-mariadb.yaml \
+    -w components/01-secrets/encrypted-mariadb.yaml
+
+kubeseal \
+    --scope cluster-wide \
+    --allow-empty-data \
+    -o yaml \
+    -f secret-nautobot-env.yaml \
+    -w components/01-secrets/encrypted-nautobot-env.yaml
+
+kubeseal \
+    --scope cluster-wide \
+    --allow-empty-data \
+    -o yaml \
+    -f secret-nautobot-redis.yaml \
+    -w components/01-secrets/encrypted-nautobot-redis.yaml
+
+for skrt in $(find . -name "secret-keystone*.yaml" -depth 1); do
+    encskrt=$(echo "${skrt}" | sed -e 's/secret-/components\/01-secrets\/encrypted-/')
+    kubeseal \
+        --scope cluster-wide \
+        --allow-empty-data \
+        -o yaml \
+        -f "${skrt}" \
+        -w "${encskrt}"
+done
+
+cd components/01-secrets/
+rm -f kustomization.yaml
+kustomize create --autodetect
+cd ../..


### PR DESCRIPTION
Added a helper to make it easier to deploy secrets. Fix the fact that sealed-secrets wasn't deployed. Fix the URL for the OpenStack client pod.