### PR TITLE
fix: avoid defining rabbitmq-system namespace twice

### DIFF
--- a/operators/messaging-topology-operator/kustomization.yaml
+++ b/operators/messaging-topology-operator/kustomization.yaml
@@ -1,6 +1,13 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/rabbitmq/messaging-topology-operator/releases/download/v1.13.0/messaging-topology-operator-with-certmanager.yaml
+- https://github.com/rabbitmq/messaging-topology-operator/releases/download/v1.13.0/messaging-topology-operator-with-certmanager.yaml
+
+patches:
+- patch: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: rabbitmq-system
+    $patch: delete


### PR DESCRIPTION
The RabbitMQ operator defines the namespace and the messaging topology operator defines it as well. This causes ArgoCD to fight over which Application deployment owns the namespace. Since the messaging topology operator depends on the RabbitMQ operator, just define it there once. fixes PUC-170