### PR TITLE
feat: add ingress-nginx and enable argocd and nautobot to use it

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -4,5 +4,6 @@ These are the bare minimum steps required to bootstrap your cluster up to ArgoCD
 
 Each component is installed with a manifest referenced in a child directory.  The components at this time are:
 
+- [ingress-nginx](https://kubernetes.github.io/ingress-nginx/)
 - [cert-manager](https://cert-manager.io/docs/)
 - [ArgoCD](https://argo-cd.readthedocs.io/en/stable/)

--- a/bootstrap/argocd/ingress.yaml
+++ b/bootstrap/argocd/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd
+  namespace: argocd
+  annotations:
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: argo-cd-argocd-server
+            port:
+              name: http
+    host: argocd.local
+  tls:
+  - hosts:
+    - argocd.local
+    secretName: argocd-ingress-tls

--- a/bootstrap/argocd/kustomization.yaml
+++ b/bootstrap/argocd/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
 - namespace.yaml
+- ingress.yaml
 
 helmGlobals:
   chartHome: ../../charts/

--- a/bootstrap/cert-manager/issuer-kube-system-self-signed.yaml
+++ b/bootstrap/cert-manager/issuer-kube-system-self-signed.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-cluster-issuer
+spec:
+  selfSigned: {}

--- a/bootstrap/cert-manager/kustomization.yaml
+++ b/bootstrap/cert-manager/kustomization.yaml
@@ -2,5 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kube-system
+
 resources:
 - https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
+- issuer-kube-system-self-signed.yaml

--- a/bootstrap/ingress-nginx/kustomization.yaml
+++ b/bootstrap/ingress-nginx/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+
+helmGlobals:
+  chartHome: ../../charts/
+helmCharts:
+- name: ingress-nginx
+  namespace: ingress-nginx
+  includeCRDs: true
+  valuesFile: values.yaml
+  releaseName: ingress-nginx
+  version: 4.9.1
+  repo: https://kubernetes.github.io/ingress-nginx

--- a/bootstrap/ingress-nginx/namespace.yaml
+++ b/bootstrap/ingress-nginx/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx

--- a/bootstrap/ingress-nginx/values.yaml
+++ b/bootstrap/ingress-nginx/values.yaml
@@ -1,0 +1,2 @@
+controller:
+  replicaCount: 1

--- a/bootstrap/kustomization.yaml
+++ b/bootstrap/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 
 resources:
 - cert-manager/
+- ingress-nginx/
 - sealed-secrets/
 - argocd/

--- a/components/09-nautobot/base/kustomization.yaml
+++ b/components/09-nautobot/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - nautobot/templates/nginx-configmap.yaml
 - nautobot/templates/service-account.yaml
 - nautobot/templates/service.yaml
+- nautobot/templates/ingress.yaml

--- a/components/09-nautobot/base/nautobot/templates/ingress.yaml
+++ b/components/09-nautobot/base/nautobot/templates/ingress.yaml
@@ -1,0 +1,33 @@
+---
+# Source: nautobot/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nautobot
+  namespace: "nautobot"
+  labels:
+    app.kubernetes.io/name: nautobot
+    helm.sh/chart: nautobot-2.0.5
+    app.kubernetes.io/instance: nautobot
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "2.0.5"
+  annotations:
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+spec:
+  ingressClassName: "nginx"
+  rules:
+    - host: nautobot.local
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: nautobot-default
+                port:
+                  name: https
+  tls:
+    - hosts:
+        - nautobot.local
+      secretName: nautobot-ingress-tls

--- a/components/09-nautobot/values.yaml
+++ b/components/09-nautobot/values.yaml
@@ -25,3 +25,12 @@ postgresql:
 
 redis:
   enabled: false
+
+ingress:
+  enabled: true
+  ingressClassName: "nginx"
+  tls: true
+  secretName: "nautobot-ingress-tls"
+  annotations:
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS


### PR DESCRIPTION
Adds ingress-nginx to be deployed into a cluster and enables Nautobot and ArgoCD to use it