### PR TITLE
fix: Hacking on ironic component

### DIFF
--- a/components/13-ironic/README.md
+++ b/components/13-ironic/README.md
@@ -36,6 +36,14 @@ Secrets Reference:
   executed by the rabbitmq-queues component. The name stems from the RabbitMQ
   cluster from the rabbitmq-cluster component. `${CLUSTER_NAME}-default-user`
 
+### Create the rabbitmq and mariadb instances
+
+```bash
+kubectl -n openstack apply -k components/13-ironic
+```
+
+### Apply the ironic helm template with our custom aio-values.yaml
+
 ```bash
 helm --namespace openstack template \
     ironic \
@@ -45,12 +53,13 @@ helm --namespace openstack template \
     --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.keystone.password="$(kubectl --namespace openstack get secret keystone-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret openstack-default-user -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.oslo_messaging.hosts.default="openstack" \
     --set endpoints.oslo_messaging.auth.keystone.password="$(kubectl --namespace openstack get secret keystone-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
     --post-renderer $(git rev-parse --show-toplevel)/scripts/openstack-helm-sealed-secrets.sh \
     | kubectl -n openstack apply -f -
 ```
 
-At this point Keystone will go through some initialization and start uo.
+At this point Ironic will go through some initialization and start up.
 
 ## Validating Keystone
 

--- a/components/13-ironic/README.md
+++ b/components/13-ironic/README.md
@@ -1,0 +1,74 @@
+# OpenStack Ironic
+
+So unfortunately OpenStack Helm doesn't publish helm charts that can be consumed like
+regular helm charts. You must instead clone two of their git repos side by side and
+build the dependencies manually. They additionally don't split out secrets but instead
+template them into giant config files or even executable scripts that then get stored
+as secrets, a clear violation of <https://12factor.net>. As a result we cannot store
+a declarative config of Keystone and allow users to supply their own secrets.
+
+Due to the above issues, for now we'll skip the ArgoCD ability for this deployment.
+
+## Get OpenStack Helm Ready
+
+You may have done this for another OpenStack component and can share the same
+git clones. This assumes you're doing this from the top level of this repo.
+
+```bash
+# clone the two repos because they reference the infra one as a relative path
+# so you can't use real helm commands
+git clone https://github.com/openstack/openstack-helm
+git clone https://github.com/openstack/openstack-helm-infra
+# update the dependencies cause we can't use real helm references
+./scripts/openstack-helm-depend-sync.sh ironic
+```
+
+## Deploy Ironic
+
+Since we cannot refer to the secrets by name, we must look them up live from the cluster
+so that we can injected them into the templated configs. Upstream should really allow
+secrets to be passed by reference. As a result of this we cannot use GitOps to generate
+these charts and have them applied to the cluster.
+
+Secrets Reference:
+
+- openstack-default-user is created by the messaging-topology-operator which is
+  executed by the rabbitmq-queues component. The name stems from the RabbitMQ
+  cluster from the rabbitmq-cluster component. `${CLUSTER_NAME}-default-user`
+
+```bash
+helm --namespace openstack template \
+    ironic \
+    ./openstack-helm/ironic/ \
+    -f components/13-ironic/aio-values.yaml \
+    --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
+    --set endpoints.oslo_db.auth.keystone.password="$(kubectl --namespace openstack get secret keystone-db-password -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret openstack-default-user -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.oslo_messaging.auth.keystone.password="$(kubectl --namespace openstack get secret keystone-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
+    --post-renderer $(git rev-parse --show-toplevel)/scripts/openstack-helm-sealed-secrets.sh \
+    | kubectl -n openstack apply -f -
+```
+
+At this point Keystone will go through some initialization and start uo.
+
+## Validating Keystone
+
+You can run an OpenStack client in the cluster to validate it is running correctly.
+
+```bash
+# start up a pod with the client
+kubectl -n openstack apply -f https://raw.githubusercontent.com/rackerlabs/genestack/main/manifests/utils/utils-openstack-client-admin.yaml
+```
+
+Show the catalog list
+
+```bash
+kubectl exec -it openstack-admin-client -n openstack -- openstack catalog list
+```
+
+Show the service list
+
+```bash
+kubectl exec -it openstack-admin-client -n openstack -- openstack service list
+```

--- a/components/13-ironic/aio-values.yaml
+++ b/components/13-ironic/aio-values.yaml
@@ -45,6 +45,15 @@ conf:
   ironic:
     ironic_conductor:
       automated_clean: false
+    conductor:
+      automated_clean: false
+    dhcp:
+      dhcp_provider: none
+  logging:
+    logger_root:
+      level: DEBUG
+    logger_ironic:
+      level: DEBUG
 
 endpoints:
   identity:
@@ -62,6 +71,8 @@ network:
     external_policy_local: false
     node_port:
       enabled: false
+  pxe:
+    device: ens1f0
 
 dependencies:
   dynamic:

--- a/components/13-ironic/aio-values.yaml
+++ b/components/13-ironic/aio-values.yaml
@@ -1,0 +1,96 @@
+---
+
+images:
+  tags:
+    ironic_manage_cleaning_network: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ironic_retrive_cleaning_network: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ironic_retrive_swift_config: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    bootstrap: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    db_init: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    db_drop: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ironic_db_sync: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_api: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_conductor: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_pxe: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_pxe_init: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_pxe_http: docker.io/nginx:1.13.3
+    ks_user: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ks_service: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ks_endpoints: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    rabbit_init: docker.io/rabbitmq:3.7-management
+    dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
+    image_repo_sync: docker.io/docker:17.07.0
+  pull_policy: "IfNotPresent"
+  local_registry:
+    active: false
+    exclude:
+      - dep_check
+      - image_repo_sync
+
+bootstrap:
+  image:
+    enabled: false
+    openstack:
+      enabled: false
+  network:
+    enabled: false
+    openstack:
+      enabled: false
+  object_store:
+    enabled: false
+    openstack:
+      enabled: false
+
+conf:
+  ironic:
+    ironic_conductor:
+      automated_clean: false
+
+endpoints:
+  identity:
+    name: keystone
+
+network:
+  api:
+    ingress:
+      public: true
+      classes:
+        namespace: "nginx"
+        cluster: "nginx-openstack"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+    external_policy_local: false
+    node_port:
+      enabled: false
+
+dependencies:
+  dynamic:
+    common:
+      local_image_registry:
+        jobs: null
+  static:
+    api:
+      jobs:
+        - ironic-db-sync
+        - ironic-ks-user
+        - ironic-ks-endpoints
+      services:
+        - endpoint: internal
+          service: oslo_db
+        - endpoint: internal
+          service: oslo_messaging
+    conductor:
+      jobs:
+        - ironic-db-sync
+        - ironic-ks-user
+        - ironic-ks-endpoints
+      services:
+        - endpoint: internal
+          service: oslo_db
+        - endpoint: internal
+          service: oslo_messaging
+
+manifests:
+  job_manage_cleaning_network: false
+  job_rabbit_init: false
+  secret_registry: false

--- a/components/13-ironic/ironic-mariadb-db.yaml
+++ b/components/13-ironic/ironic-mariadb-db.yaml
@@ -2,7 +2,7 @@
 apiVersion: mariadb.mmontes.io/v1alpha1
 kind: Database
 metadata:
-  name: keystone
+  name: ironic
   namespace: openstack
 spec:
   # If you want the database to be created with a different name than the resource name
@@ -17,7 +17,7 @@ spec:
 apiVersion: mariadb.mmontes.io/v1alpha1
 kind: User
 metadata:
-  name: keystone
+  name: ironic
   namespace: openstack
 spec:
   # If you want the user to be created with a different name than the resource name
@@ -26,7 +26,7 @@ spec:
     name: mariadb  # name of the MariaDB kind
     waitForIt: true
   passwordSecretKeyRef:
-    name: keystone-db-password
+    name: ironic-db-password
     key: password
   # This field is immutable and defaults to 10, 0 means unlimited.
   maxUserConnections: 0
@@ -36,7 +36,7 @@ spec:
 apiVersion: mariadb.mmontes.io/v1alpha1
 kind: Grant
 metadata:
-  name: keystone-grant
+  name: ironic-grant
   namespace: openstack
 spec:
   mariaDbRef:
@@ -44,9 +44,9 @@ spec:
     waitForIt: true
   privileges:
     - "ALL"
-  database: "keystone"
+  database: "ironic"
   table: "*"
-  username: keystone
+  username: ironic
   grantOption: true
   host: "%"
   retryInterval: 5s

--- a/components/13-ironic/ironic-mariadb-db.yaml
+++ b/components/13-ironic/ironic-mariadb-db.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: mariadb.mmontes.io/v1alpha1
+kind: Database
+metadata:
+  name: keystone
+  namespace: openstack
+spec:
+  # If you want the database to be created with a different name than the resource name
+  # name: data-custom
+  mariaDbRef:
+    name: mariadb  # name of the MariaDB kind
+    waitForIt: true
+  characterSet: utf8
+  collate: utf8_general_ci
+  retryInterval: 5s
+---
+apiVersion: mariadb.mmontes.io/v1alpha1
+kind: User
+metadata:
+  name: keystone
+  namespace: openstack
+spec:
+  # If you want the user to be created with a different name than the resource name
+  # name: user-custom
+  mariaDbRef:
+    name: mariadb  # name of the MariaDB kind
+    waitForIt: true
+  passwordSecretKeyRef:
+    name: keystone-db-password
+    key: password
+  # This field is immutable and defaults to 10, 0 means unlimited.
+  maxUserConnections: 0
+  host: "%"
+  retryInterval: 5s
+---
+apiVersion: mariadb.mmontes.io/v1alpha1
+kind: Grant
+metadata:
+  name: keystone-grant
+  namespace: openstack
+spec:
+  mariaDbRef:
+    name: mariadb  # name of the MariaDB kind
+    waitForIt: true
+  privileges:
+    - "ALL"
+  database: "keystone"
+  table: "*"
+  username: keystone
+  grantOption: true
+  host: "%"
+  retryInterval: 5s

--- a/components/13-ironic/ironic-rabbit-queue.yaml
+++ b/components/13-ironic/ironic-rabbit-queue.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: keystone
+  namespace: openstack
+spec:
+  tags:
+  - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+  - policymaker
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+  importCredentialsSecret:
+    name: keystone-rabbitmq-password
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: keystone-vhost
+  namespace: openstack
+spec:
+  name: "keystone" # vhost name; required and cannot be updated
+  defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: keystone-queue
+  namespace: openstack
+spec:
+  name: keystone-qq # name of the queue
+  vhost: "keystone" # default to '/' if not provided
+  type: quorum # without providing a queue type, rabbitmq creates a classic queue
+  autoDelete: false
+  durable: true # seting 'durable' to false means this queue won't survive a server restart
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Permission
+metadata:
+  name: keystone-permission
+  namespace: openstack
+spec:
+  vhost: "keystone" # name of a vhost
+  userReference:
+    name: "keystone" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
+  permissions:
+    write: ".*"
+    configure: ".*"
+    read: ".*"
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack

--- a/components/13-ironic/ironic-rabbitmq-queue.yaml
+++ b/components/13-ironic/ironic-rabbitmq-queue.yaml
@@ -2,7 +2,7 @@
 apiVersion: rabbitmq.com/v1beta1
 kind: User
 metadata:
-  name: keystone
+  name: ironic
   namespace: openstack
 spec:
   tags:
@@ -12,15 +12,15 @@ spec:
     name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
   importCredentialsSecret:
-    name: keystone-rabbitmq-password
+    name: ironic-rabbitmq-password
 ---
 apiVersion: rabbitmq.com/v1beta1
 kind: Vhost
 metadata:
-  name: keystone-vhost
+  name: ironic-vhost
   namespace: openstack
 spec:
-  name: "keystone" # vhost name; required and cannot be updated
+  name: "ironic" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
   rabbitmqClusterReference:
     name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
@@ -29,11 +29,11 @@ spec:
 apiVersion: rabbitmq.com/v1beta1
 kind: Queue
 metadata:
-  name: keystone-queue
+  name: ironic-queue
   namespace: openstack
 spec:
-  name: keystone-qq # name of the queue
-  vhost: "keystone" # default to '/' if not provided
+  name: ironic-qq # name of the queue
+  vhost: "ironic" # default to '/' if not provided
   type: quorum # without providing a queue type, rabbitmq creates a classic queue
   autoDelete: false
   durable: true # seting 'durable' to false means this queue won't survive a server restart
@@ -44,12 +44,12 @@ spec:
 apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
-  name: keystone-permission
+  name: ironic-permission
   namespace: openstack
 spec:
-  vhost: "keystone" # name of a vhost
+  vhost: "ironic" # name of a vhost
   userReference:
-    name: "keystone" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
+    name: "ironic" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
   permissions:
     write: ".*"
     configure: ".*"

--- a/components/13-ironic/ironic-rabbitmq-queue.yaml
+++ b/components/13-ironic/ironic-rabbitmq-queue.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: openstack
 spec:
   tags:
-  - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+  - management  # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
   - policymaker
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
   importCredentialsSecret:
     name: ironic-rabbitmq-password
@@ -20,10 +20,10 @@ metadata:
   name: ironic-vhost
   namespace: openstack
 spec:
-  name: "ironic" # vhost name; required and cannot be updated
-  defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
+  name: "ironic"  # vhost name; required and cannot be updated
+  defaultQueueType: quorum  # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
@@ -32,13 +32,13 @@ metadata:
   name: ironic-queue
   namespace: openstack
 spec:
-  name: ironic-qq # name of the queue
-  vhost: "ironic" # default to '/' if not provided
-  type: quorum # without providing a queue type, rabbitmq creates a classic queue
+  name: ironic-qq  # name of the queue
+  vhost: "ironic"  # default to '/' if not provided
+  type: quorum  # without providing a queue type, rabbitmq creates a classic queue
   autoDelete: false
-  durable: true # seting 'durable' to false means this queue won't survive a server restart
+  durable: true  # seting 'durable' to false means this queue won't survive a server restart
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
@@ -47,13 +47,13 @@ metadata:
   name: ironic-permission
   namespace: openstack
 spec:
-  vhost: "ironic" # name of a vhost
+  vhost: "ironic"  # name of a vhost
   userReference:
-    name: "ironic" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
+    name: "ironic"  # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
   permissions:
     write: ".*"
     configure: ".*"
     read: ".*"
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack

--- a/components/13-ironic/kustomization.yaml
+++ b/components/13-ironic/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ironic-mariadb-db.yaml
+  - ironic-rabbitmq-queue.yaml


### PR DESCRIPTION
My changes to get it to progress the deployment. The ironic-api starts, but ironic-conductor fails to start:
```
  kubectl exec -it ironic-conductor-0 /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulted container "ironic-conductor" out of: ironic-conductor, ironic-conductor-pxe, ironic-conductor-http, init (init), ironic-conductor-pxe-init (init), ironic-conductor-init (init), ironic-conductor-http-init (init)
root@xs0002:/# ironic-conductor --config-file /etc/ironic/ironic.conf --config-file /tmp/pod-shared/conductor-local-ip.conf
2024-02-26 17:07:15.873 18 DEBUG ironic.common.service [-] Guru meditation reporting is disabled because oslo.reports is not installed prepare_service /var/lib/openstack/lib/python3.10/site-packages/ironic/common/service.py:64
2024-02-26 17:07:16.704 18 DEBUG ironic.conductor.base_manager [None req-650cbb5a-d53e-4182-95b7-b5aff562f6a1 - - - - - -] Initializing database client for xs0002.b0013.ord.ohthree.com. prepare_host /var/lib/openstack/lib/python3.10/site-packages/ironic/conductor/base_manager.py:82
2024-02-26 17:07:16.704 18 DEBUG ironic.conductor.base_manager [None req-650cbb5a-d53e-4182-95b7-b5aff562f6a1 - - - - - -] Removing stale locks from the database matching this conductor's hostname: xs0002.b0013.ord.ohthree.com prepare_host /var/lib/openstack/lib/python3.10/site-packages/ironic/conductor/base_manager.py:84
root@xs0002:/# echo $?
1
```