### PR TITLE
feat: DexIDP Integration for Nautobot

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ ArgoCD should successfully get Nautobot deployed. Now come the OpenStack
 components which aren't working with GitOps methods at this time.
 
 [Install Keystone](./components/10-keystone/README.md)
+
+[Configure environment for Keystone/Dex auth](./components/13-dexidp/README.md).

--- a/apps/components/dexidp.yaml
+++ b/apps/components/dexidp.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dexidp
+spec:
+  project: understack
+  source:
+    repoURL: https://github.com/rackerlabs/understack.git
+    path: components/13-dexidp/
+    targetRevision: HEAD
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: dex
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/components/09-nautobot/base/kustomization.yaml
+++ b/components/09-nautobot/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - nautobot/templates/service-account.yaml
 - nautobot/templates/service.yaml
 - nautobot/templates/ingress.yaml
+- nautobot/templates/dexauth-cm.yaml

--- a/components/09-nautobot/base/nautobot/templates/configmap.yaml
+++ b/components/09-nautobot/base/nautobot/templates/configmap.yaml
@@ -111,3 +111,517 @@ data:
     ; For larger installations, certain API calls (example: Relationships, GraphQL) can have a length of query parameters that go over uWSGI default limit.
     ; Setting the buffer size to larger than default (4096) can have an impact on memory utilization, but can be set as high as the header limit of 65535.
     buffer-size = 4096
+  nautobot_config.py: |
+    import os
+    import sys
+
+    from nautobot.core.settings import *  # noqa F401,F403
+    from nautobot.core.settings_funcs import is_truthy, parse_redis_connection
+
+    #########################
+    #                       #
+    #   Required settings   #
+    #                       #
+    #########################
+
+    # This is a list of valid fully-qualified domain names (FQDNs) for the Nautobot server. Nautobot will not permit write
+    # access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
+    #
+    # Example: ALLOWED_HOSTS = ['nautobot.example.com', 'nautobot.internal.local']
+    #
+    # ALLOWED_HOSTS = os.getenv("NAUTOBOT_ALLOWED_HOSTS", "").split(" ")
+
+    # The django-redis cache is used to establish concurrent locks using Redis.
+    #
+    # CACHES = {
+    #     "default": {
+    #         "BACKEND": os.getenv(
+    #             "NAUTOBOT_CACHES_BACKEND",
+    #             "django_prometheus.cache.backends.redis.RedisCache" if METRICS_ENABLED else "django_redis.cache.RedisCache",
+    #         ),
+    #         "LOCATION": parse_redis_connection(redis_database=1),
+    #         "TIMEOUT": 300,
+    #         "OPTIONS": {
+    #             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+    #             "PASSWORD": "",
+    #         },
+    #     }
+    # }
+
+    # Number of seconds to cache ContentType lookups. Set to 0 to disable caching.
+    # CONTENT_TYPE_CACHE_TIMEOUT = int(os.getenv("NAUTOBOT_CONTENT_TYPE_CACHE_TIMEOUT", "0"))
+
+    # Celery broker URL used to tell workers where queues are located
+    #
+    # CELERY_BROKER_URL = os.getenv("NAUTOBOT_CELERY_BROKER_URL", parse_redis_connection(redis_database=0))
+
+    # Database configuration. See the Django documentation for a complete list of available parameters:
+    #   https://docs.djangoproject.com/en/stable/ref/settings/#databases
+    #
+    # DATABASES = {
+    #     "default": {
+    #         "NAME": os.getenv("NAUTOBOT_DB_NAME", "nautobot"),  # Database name
+    #         "USER": os.getenv("NAUTOBOT_DB_USER", ""),  # Database username
+    #         "PASSWORD": os.getenv("NAUTOBOT_DB_PASSWORD", ""),  # Database password
+    #         "HOST": os.getenv("NAUTOBOT_DB_HOST", "localhost"),  # Database server
+    #         "PORT": os.getenv("NAUTOBOT_DB_PORT", ""),  # Database port (leave blank for default)
+    #         "CONN_MAX_AGE": int(os.getenv("NAUTOBOT_DB_TIMEOUT", "300")),  # Database timeout
+    #         "ENGINE": os.getenv(
+    #             "NAUTOBOT_DB_ENGINE",
+    #             "django_prometheus.db.backends.postgresql" if METRICS_ENABLED else "django.db.backends.postgresql",
+    #         ),  # Database driver ("mysql" or "postgresql")
+    #     }
+    # }
+
+    # Ensure proper Unicode handling for MySQL
+    #
+    if DATABASES["default"]["ENGINE"].endswith("mysql"):
+        DATABASES["default"]["OPTIONS"] = {"charset": "utf8mb4"}
+
+    # This key is used for secure generation of random numbers and strings. It must never be exposed outside of this file.
+    # For optimal security, SECRET_KEY should be at least 50 characters in length and contain a mix of letters, numbers, and
+    # symbols. Nautobot will not run without this defined. For more information, see
+    # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SECRET_KEY
+    SECRET_KEY = os.getenv("NAUTOBOT_SECRET_KEY")
+
+    #####################################
+    #                                   #
+    #   Optional Django core settings   #
+    #                                   #
+    #####################################
+
+    # Specify one or more name and email address tuples representing Nautobot administrators.
+    # These people will be notified of application errors (assuming correct email settings are provided).
+    #
+    # ADMINS = [
+    #     ['John Doe', 'jdoe@example.com'],
+    # ]
+
+    # FQDNs that are considered trusted origins for secure, cross-domain, requests such as HTTPS POST.
+    # If running Nautobot under a single domain, you may not need to set this variable;
+    # if running on multiple domains, you *may* need to set this variable to more or less the same as ALLOWED_HOSTS above.
+    # https://docs.djangoproject.com/en/stable/ref/settings/#csrf-trusted-origins
+    #
+    # CSRF_TRUSTED_ORIGINS = []
+
+    # Date/time formatting. See the following link for supported formats:
+    # https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
+    #
+    # DATE_FORMAT = os.getenv("NAUTOBOT_DATE_FORMAT", "N j, Y")
+    # SHORT_DATE_FORMAT = os.getenv("NAUTOBOT_SHORT_DATE_FORMAT", "Y-m-d")
+    # TIME_FORMAT = os.getenv("NAUTOBOT_TIME_FORMAT", "g:i a")
+    # SHORT_TIME_FORMAT = os.getenv("NAUTOBOT_SHORT_TIME_FORMAT", "H:i:s")
+    # DATETIME_FORMAT = os.getenv("NAUTOBOT_DATETIME_FORMAT", "N j, Y g:i a")
+    # SHORT_DATETIME_FORMAT = os.getenv("NAUTOBOT_SHORT_DATETIME_FORMAT", "Y-m-d H:i")
+
+    # Set to True to enable server debugging. WARNING: Debugging introduces a substantial performance penalty and may reveal
+    # sensitive information about your installation. Only enable debugging while performing testing. Never enable debugging
+    # on a production system.
+    #
+    # DEBUG = is_truthy(os.getenv("NAUTOBOT_DEBUG", "False"))
+
+    # If hosting Nautobot in a subdirectory, you must set this value to match the base URL prefix configured in your
+    # HTTP server (e.g. `/nautobot/`). When not set, URLs will default to being prefixed by `/`.
+    #
+    # FORCE_SCRIPT_NAME = None
+
+    # IP addresses recognized as internal to the system.
+    #
+    # INTERNAL_IPS = ("127.0.0.1", "::1")
+
+    # Enable custom logging. Please see the Django documentation for detailed guidance on configuring custom logs:
+    #   https://docs.djangoproject.com/en/stable/topics/logging/
+    #
+    # LOGGING = {
+    #     "version": 1,
+    #     "disable_existing_loggers": False,
+    #     "formatters": {
+    #         "normal": {
+    #             "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)s :\n  %(message)s",
+    #             "datefmt": "%H:%M:%S",
+    #         },
+    #         "verbose": {
+    #             "format": "%(asctime)s.%(msecs)03d %(levelname)-7s %(name)-20s %(filename)-15s %(funcName)30s() :\n  %(message)s",
+    #             "datefmt": "%H:%M:%S",
+    #         },
+    #     },
+    #     "handlers": {
+    #         "normal_console": {
+    #             "level": "INFO",
+    #             "class": "logging.StreamHandler",
+    #             "formatter": "normal",
+    #         },
+    #         "verbose_console": {
+    #             "level": "DEBUG",
+    #             "class": "logging.StreamHandler",
+    #             "formatter": "verbose",
+    #         },
+    #     },
+    #     "loggers": {
+    #         "django": {"handlers": ["normal_console"], "level": "INFO"},
+    #         "nautobot": {
+    #             "handlers": ["verbose_console" if DEBUG else "normal_console"],
+    #             "level": "DEBUG" if DEBUG else "INFO",
+    #         },
+    #     },
+    # }
+
+    # The file path where uploaded media such as image attachments are stored. A trailing slash is not needed.
+    #
+    # MEDIA_ROOT = os.path.join(NAUTOBOT_ROOT, "media").rstrip("/")
+
+    # Set to True to use session cookies instead of persistent cookies.
+    # Session cookies will expire when a browser is closed.
+    #
+    # SESSION_EXPIRE_AT_BROWSER_CLOSE = is_truthy(os.getenv("NAUTOBOT_SESSION_EXPIRE_AT_BROWSER_CLOSE", "False"))
+
+    # The length of time (in seconds) for which a user will remain logged into the web UI before being prompted to
+    # re-authenticate. (Default: 1209600 [14 days])
+    #
+    # SESSION_COOKIE_AGE = int(os.getenv("NAUTOBOT_SESSION_COOKIE_AGE", "1209600"))  # 2 weeks, in seconds
+
+    # Where Nautobot stores user session data.
+    #
+    # SESSION_ENGINE = "django.contrib.sessions.backends.db"
+
+    # By default, Nautobot will store session data in the database. Alternatively, a file path can be specified here to use
+    # local file storage instead. (This can be useful for enabling authentication on a standby instance with read-only
+    # database access.) Note that the user as which Nautobot runs must have read and write permissions to this path.
+    #
+    # SESSION_FILE_PATH = os.getenv("NAUTOBOT_SESSION_FILE_PATH", None)
+
+    # Where static files (CSS, JavaScript, etc.) are stored
+    #
+    # STATIC_ROOT = os.path.join(NAUTOBOT_ROOT, "static")
+
+    # Time zone (default: UTC)
+    #
+    # TIME_ZONE = os.getenv("NAUTOBOT_TIME_ZONE", "UTC")
+
+    ###################################################################
+    #                                                                 #
+    #   Optional settings specific to Nautobot and its related apps   #
+    #                                                                 #
+    ###################################################################
+
+    # URL schemes that are allowed within links in Nautobot
+    #
+    # ALLOWED_URL_SCHEMES = (
+    #     "file",
+    #     "ftp",
+    #     "ftps",
+    #     "http",
+    #     "https",
+    #     "irc",
+    #     "mailto",
+    #     "sftp",
+    #     "ssh",
+    #     "tel",
+    #     "telnet",
+    #     "tftp",
+    #     "vnc",
+    #     "xmpp",
+    # )
+
+    # Banners (HTML is permitted) to display at the top and/or bottom of all Nautobot pages, and on the login page itself.
+    #
+    # BANNER_BOTTOM = ""
+    # BANNER_LOGIN = ""
+    # BANNER_TOP = ""
+
+    # Branding logo locations. The logo takes the place of the Nautobot logo in the top right of the nav bar.
+    # The filepath should be relative to the `MEDIA_ROOT`.
+    #
+    # BRANDING_FILEPATHS = {
+    #     "logo": os.getenv("NAUTOBOT_BRANDING_FILEPATHS_LOGO", None),  # Navbar logo
+    #     "favicon": os.getenv("NAUTOBOT_BRANDING_FILEPATHS_FAVICON", None),  # Browser favicon
+    #     "icon_16": os.getenv("NAUTOBOT_BRANDING_FILEPATHS_ICON_16", None),  # 16x16px icon
+    #     "icon_32": os.getenv("NAUTOBOT_BRANDING_FILEPATHS_ICON_32", None),  # 32x32px icon
+    #     "icon_180": os.getenv(
+    #         "NAUTOBOT_BRANDING_FILEPATHS_ICON_180", None
+    #     ),  # 180x180px icon - used for the apple-touch-icon header
+    #     "icon_192": os.getenv("NAUTOBOT_BRANDING_FILEPATHS_ICON_192", None),  # 192x192px icon
+    #     "icon_mask": os.getenv(
+    #         "NAUTOBOT_BRANDING_FILEPATHS_ICON_MASK", None
+    #     ),  # mono-chrome icon used for the mask-icon header
+    #     "header_bullet": os.getenv(
+    #         "NAUTOBOT_BRANDING_FILEPATHS_HEADER_BULLET", None
+    #     ),  # bullet image used for various view headers
+    #     "nav_bullet": os.getenv("NAUTOBOT_BRANDING_FILEPATHS_NAV_BULLET", None),  # bullet image used for nav menu headers
+    # }
+
+    # Prepended to CSV, YAML and export template filenames (i.e. `nautobot_device.yml`)
+    #
+    # BRANDING_PREPENDED_FILENAME = os.getenv("NAUTOBOT_BRANDING_PREPENDED_FILENAME", "nautobot_")
+
+    # Title to use in place of "Nautobot"
+    #
+    # BRANDING_TITLE = os.getenv("NAUTOBOT_BRANDING_TITLE", "Nautobot")
+
+    # Branding URLs (links in the bottom right of the footer)
+    #
+    # BRANDING_URLS = {
+    #     "code": os.getenv("NAUTOBOT_BRANDING_URLS_CODE", "https://github.com/nautobot/nautobot"),
+    #     "docs": os.getenv("NAUTOBOT_BRANDING_URLS_DOCS", None),
+    #     "help": os.getenv("NAUTOBOT_BRANDING_URLS_HELP", "https://github.com/nautobot/nautobot/wiki"),
+    # }
+
+    # Options to pass to the Celery broker transport, for example when using Celery with Redis Sentinel.
+    #
+    # CELERY_BROKER_TRANSPORT_OPTIONS = {}
+
+    # Default celery queue name that will be used by workers and tasks if no queue is specified
+    # CELERY_TASK_DEFAULT_QUEUE = os.getenv("NAUTOBOT_CELERY_TASK_DEFAULT_QUEUE", "default")
+
+    # Global task time limits (seconds)
+    # Exceeding the soft limit will result in a SoftTimeLimitExceeded exception,
+    # while exceeding the hard limit will result in a SIGKILL.
+    #
+    # CELERY_TASK_SOFT_TIME_LIMIT = int(os.getenv("NAUTOBOT_CELERY_TASK_SOFT_TIME_LIMIT", str(5 * 60)))
+    # CELERY_TASK_TIME_LIMIT = int(os.getenv("NAUTOBOT_CELERY_TASK_TIME_LIMIT", str(10 * 60)))
+
+    # Ports for prometheus metric HTTP server running on the celery worker.
+    # Normally this should be set to a single port, unless you have multiple workers running on a single machine, i.e.
+    # sharing the same available ports. In that case you need to specify a range of ports greater than or equal to the
+    # highest amount of workers you are running on a single machine (comma-separated, like "8080,8081,8082"). You can then
+    # use the `target_limit` parameter to the Prometheus `scrape_config` to ensure you are not getting duplicate metrics in
+    # that case. Set this to an empty string to disable it.
+    # CELERY_WORKER_PROMETHEUS_PORTS = []
+    # if os.getenv("NAUTOBOT_CELERY_WORKER_PROMETHEUS_PORTS"):
+    #     CELERY_WORKER_PROMETHEUS_PORTS = [
+    #         int(value) for value in os.getenv("NAUTOBOT_CELERY_WORKER_PROMETHEUS_PORTS").split(",")
+    #     ]
+
+
+    # Number of days to retain changelog entries. Set to 0 to retain changes indefinitely.
+    #
+    # CHANGELOG_RETENTION = 90
+
+    # If True, all origins will be allowed. Other settings restricting allowed origins will be ignored.
+    # Defaults to False. Setting this to True can be dangerous, as it allows any website to make
+    # cross-origin requests to yours. Generally you'll want to restrict the list of allowed origins with
+    # CORS_ALLOWED_ORIGINS or CORS_ALLOWED_ORIGIN_REGEXES.
+    #
+    # CORS_ALLOW_ALL_ORIGINS = is_truthy(os.getenv("NAUTOBOT_CORS_ALLOW_ALL_ORIGINS", "False"))
+
+    # A list of origins that are authorized to make cross-site HTTP requests. Defaults to [].
+    #
+    # CORS_ALLOWED_ORIGINS = [
+    #     'https://hostname.example.com',
+    # ]
+
+    # A list of strings representing regexes that match Origins that are authorized to make cross-site
+    # HTTP requests. Defaults to [].
+    #
+    # CORS_ALLOWED_ORIGIN_REGEXES = [
+    #     r'^(https?://)?(\w+\.)?example\.com$',
+    # ]
+
+    # Device names are not guaranteed globally-unique by Nautobot but in practice they often are.
+    # Set this to True to use the device name alone as the natural key for Device objects.
+    # Set this to False to use the sequence (name, tenant, location) as the natural key instead.
+    #
+    # DEVICE_NAME_AS_NATURAL_KEY = False
+
+    # Set to True to disable rendering of the IP prefix hierarchy in the the IPAM prefix list view.
+    # Useful in case of poor performance when rendering this page.
+    #
+    # DISABLE_PREFIX_LIST_HIERARCHY = False
+
+    # Exempt certain models from the enforcement of view permissions. Models listed here will be viewable by all users and
+    # by anonymous users. List models in the form `<app>.<model>`. Add '*' to this list to exempt all models.
+    # Defaults to [].
+    #
+    # EXEMPT_VIEW_PERMISSIONS = [
+    #     'dcim.location',
+    #     'ipam.prefix',
+    # ]
+
+    # Global 3rd-party authentication settings
+    #
+    # EXTERNAL_AUTH_DEFAULT_GROUPS = []
+    # EXTERNAL_AUTH_DEFAULT_PERMISSIONS = {}
+
+    # Directory where cloned Git repositories will be stored.
+    #
+    # GIT_ROOT = os.getenv("NAUTOBOT_GIT_ROOT", os.path.join(NAUTOBOT_ROOT, "git").rstrip("/"))
+
+    # Prefixes to use for custom fields, relationships, and computed fields in GraphQL representation of data.
+    #
+    # GRAPHQL_COMPUTED_FIELD_PREFIX = "cpf"
+    # GRAPHQL_CUSTOM_FIELD_PREFIX = "cf"
+    # GRAPHQL_RELATIONSHIP_PREFIX = "rel"
+
+    # HTTP proxies Nautobot should use when sending outbound HTTP requests (e.g. for webhooks).
+    #
+    # HTTP_PROXIES = {
+    #     'http': 'http://10.10.1.10:3128',
+    #     'https': 'http://10.10.1.10:1080',
+    # }
+
+    # Send anonymized installation metrics when `nautobot-server post_upgrade` command is run.
+    #
+    INSTALLATION_METRICS_ENABLED = is_truthy(os.getenv("NAUTOBOT_INSTALLATION_METRICS_ENABLED", "True"))
+
+    # Storage backend to use for Job input files and Job output files.
+    #
+    # Note: the default is for backwards compatibility and it is recommended to change it if possible for your deployment.
+    #
+    # JOB_FILE_IO_STORAGE = os.getenv("NAUTOBOT_JOB_FILE_IO_STORAGE", "db_file_storage.storage.DatabaseFileStorage")
+
+    # Maximum size in bytes of any single file created by Job.create_file().
+    #
+    # JOB_CREATE_FILE_MAX_SIZE = 10 << 20
+
+    # Directory where Jobs can be discovered.
+    #
+    # JOBS_ROOT = os.getenv("NAUTOBOT_JOBS_ROOT", os.path.join(NAUTOBOT_ROOT, "jobs").rstrip("/"))
+
+    # Location names are not guaranteed globally-unique by Nautobot but in practice they often are.
+    # Set this to True to use the location name alone as the natural key for Location objects.
+    # Set this to False to use the sequence (name, parent__name, parent__parent__name, ...) as the natural key instead.
+    #
+    # LOCATION_NAME_AS_NATURAL_KEY = False
+
+    # Log Nautobot deprecation warnings. Note that this setting is ignored (deprecation logs always enabled) if DEBUG = True
+    #
+    # LOG_DEPRECATION_WARNINGS = is_truthy(os.getenv("NAUTOBOT_LOG_DEPRECATION_WARNINGS", "False"))
+
+    # Setting this to True will display a "maintenance mode" banner at the top of every page.
+    #
+    # MAINTENANCE_MODE = is_truthy(os.getenv("NAUTOBOT_MAINTENANCE_MODE", "False"))
+
+    # Maximum number of objects that the UI and API will retrieve in a single request.
+    #
+    # MAX_PAGE_SIZE = 1000
+
+    # Expose Prometheus monitoring metrics at the HTTP endpoint '/metrics'
+    #
+    # METRICS_ENABLED = is_truthy(os.getenv("NAUTOBOT_METRICS_ENABLED", "False"))
+
+    # Credentials that Nautobot will uses to authenticate to devices when connecting via NAPALM.
+    #
+    # NAPALM_USERNAME = os.getenv("NAUTOBOT_NAPALM_USERNAME", "")
+    # NAPALM_PASSWORD = os.getenv("NAUTOBOT_NAPALM_PASSWORD", "")
+
+    # NAPALM timeout (in seconds). (Default: 30)
+    #
+    # NAPALM_TIMEOUT = int(os.getenv("NAUTOBOT_NAPALM_TIMEOUT", "30"))
+
+    # NAPALM optional arguments (see https://napalm.readthedocs.io/en/latest/support/#optional-arguments). Arguments must
+    # be provided as a dictionary.
+    #
+    # NAPALM_ARGS = {}
+
+    # Default number of objects to display per page of the UI and REST API.
+    #
+    # PAGINATE_COUNT = 50
+
+    # Options given in the web UI for the number of objects to display per page.
+    #
+    # PER_PAGE_DEFAULTS = [25, 50, 100, 250, 500, 1000]
+
+    # Enable installed plugins. Add the name of each plugin to the list.
+    #
+    # PLUGINS = []
+
+    # Plugins configuration settings. These settings are used by various plugins that the user may have installed.
+    # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
+    #
+    # PLUGINS_CONFIG = {
+    #     'my_plugin': {
+    #         'foo': 'bar',
+    #         'buzz': 'bazz'
+    #     }
+    # }
+
+    # Prefer IPv6 addresses or IPv4 addresses in selecting a device's primary IP address?
+    #
+    # PREFER_IPV4 = False
+
+    # Default height and width in pixels of a single rack unit in rendered rack elevations.
+    #
+    # RACK_ELEVATION_DEFAULT_UNIT_HEIGHT = 22
+    # RACK_ELEVATION_DEFAULT_UNIT_WIDTH = 220
+
+    # Sets an age out timer of redis lock. This is NOT implicitly applied to locks, must be added
+    # to a lock creation as `timeout=settings.REDIS_LOCK_TIMEOUT`
+    #
+    # REDIS_LOCK_TIMEOUT = int(os.getenv("NAUTOBOT_REDIS_LOCK_TIMEOUT", "600"))
+
+    # How frequently to check for a new Nautobot release on GitHub, and the URL to check for this information.
+    #
+    # RELEASE_CHECK_TIMEOUT = 24 * 3600
+    # RELEASE_CHECK_URL = None
+
+    # Remote auth backend settings
+    #
+    # REMOTE_AUTH_AUTO_CREATE_USER = False
+    # REMOTE_AUTH_HEADER = "HTTP_REMOTE_USER"
+
+    # Job log entry sanitization and similar
+    #
+    # SANITIZER_PATTERNS = [
+    #     # General removal of username-like and password-like tokens
+    #     (re.compile(r"(https?://)?\S+\s*@", re.IGNORECASE), r"\1{replacement}@"),
+    #     (re.compile(r"(username|password|passwd|pwd)((?:\s+is.?|:)?\s+)\S+", re.IGNORECASE), r"\1\2{replacement}"),
+    # ]
+
+    # Configure SSO, for more information see docs/configuration/authentication/sso.md
+    #
+    # SOCIAL_AUTH_POSTGRES_JSONFIELD = False
+    AUTHENTICATION_BACKENDS = [
+        "social_core.backends.open_id_connect.OpenIdConnectAuth",
+        "nautobot.core.authentication.ObjectPermissionBackend",
+    ]
+
+    SOCIAL_AUTH_OIDC_SSL_PROTOCOL = None
+    # TODO: until we figure out how to add local CA to python trusted CAs
+    SOCIAL_AUTH_OIDC_VERIFY_SSL = False
+    SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = "http://dexidp.local"
+    SOCIAL_AUTH_OIDC_USERNAME_KEY = 'name'
+    SOCIAL_AUTH_OIDC_KEY = 'nautobot'
+    SOCIAL_AUTH_OIDC_SECRET = 'verysecret'
+
+    # By default uploaded media is stored on the local filesystem. Using Django-storages is also supported. Provide the
+    # class path of the storage driver in STORAGE_BACKEND and any configuration options in STORAGE_CONFIG.
+    # These default to None and {} respectively.
+    #
+    # STORAGE_BACKEND = 'storages.backends.s3boto3.S3Boto3Storage'
+    # STORAGE_CONFIG = {
+    #     'AWS_ACCESS_KEY_ID': 'Key ID',
+    #     'AWS_SECRET_ACCESS_KEY': 'Secret',
+    #     'AWS_STORAGE_BUCKET_NAME': 'nautobot',
+    #     'AWS_S3_REGION_NAME': 'eu-west-1',
+    # }
+
+    # Reject invalid UI/API filter parameters, or discard them while logging a warning?
+    #
+    # STRICT_FILTERING = is_truthy(os.getenv("NAUTOBOT_STRICT_FILTERING", "True"))
+
+    # Custom message to display on 4xx and 5xx error pages. Markdown is supported.
+    #
+    # SUPPORT_MESSAGE = (
+    #     "If further assistance is required, please join the `#nautobot` channel "
+    #     "on [Network to Code's Slack community](https://slack.networktocode.com) and post your question."
+    # )
+
+    # UI_RACK_VIEW_TRUNCATE_FUNCTION
+    #
+    # def UI_RACK_VIEW_TRUNCATE_FUNCTION(device_display_name):
+    #     """Given device display name, truncate to fit the rack elevation view.
+    #
+    #     :param device_display_name: Full display name of the device attempting to be rendered in the rack elevation.
+    #     :type device_display_name: str
+    #
+    #     :return: Truncated device name
+    #     :type: str
+    #     """
+    #     return str(device_display_name).split(".")[0]
+
+    # A list of strings designating all applications that are enabled in this Django installation.
+    # Each string should be a dotted Python path to an application configuration class (preferred),
+    # or a package containing an application.
+    # https://docs.nautobot.com/projects/core/en/latest/configuration/optional-settings/#extra-applications
+    # EXTRA_INSTALLED_APPS = []
+

--- a/components/09-nautobot/base/nautobot/templates/configmap.yaml
+++ b/components/09-nautobot/base/nautobot/templates/configmap.yaml
@@ -47,8 +47,8 @@ data:
   uwsgi.ini: |
     [uwsgi]
     ; The IP address (typically localhost) and port that the WSGI process should listen on
-    http = 0.0.0.0:8080
-    https = 0.0.0.0:8443,/opt/nautobot/nautobot.crt,/opt/nautobot/nautobot.key
+    http-socket = 0.0.0.0:8080
+    https-socket = 0.0.0.0:8443,/opt/nautobot/nautobot.crt,/opt/nautobot/nautobot.key
 
 
     ; Fail to start if any parameter in the configuration file isn’t explicitly understood by uWSGI

--- a/components/09-nautobot/base/nautobot/templates/configmap.yaml
+++ b/components/09-nautobot/base/nautobot/templates/configmap.yaml
@@ -582,6 +582,23 @@ data:
     SOCIAL_AUTH_OIDC_USERNAME_KEY = 'name'
     SOCIAL_AUTH_OIDC_KEY = 'nautobot'
     SOCIAL_AUTH_OIDC_SECRET = 'verysecret'
+    # The “openid”, “profile” and “email” are requested by default,
+    # below *adds* scope.
+    SOCIAL_AUTH_OIDC_SCOPE = ['groups']
+
+    # include custom auth pipeline to sync groups
+    SOCIAL_AUTH_PIPELINE = (
+      "social_core.pipeline.social_auth.social_details",
+      "social_core.pipeline.social_auth.social_uid",
+      "social_core.pipeline.social_auth.auth_allowed",
+      "social_core.pipeline.social_auth.social_user",
+      "social_core.pipeline.user.get_username",
+      "social_core.pipeline.user.create_user",
+      "social_core.pipeline.social_auth.associate_user",
+      "social_core.pipeline.social_auth.load_extra_data",
+      "social_core.pipeline.user.user_details",
+      "dexauth.group_sync",
+    )
 
     # By default uploaded media is stored on the local filesystem. Using Django-storages is also supported. Provide the
     # class path of the storage driver in STORAGE_BACKEND and any configuration options in STORAGE_CONFIG.
@@ -624,4 +641,3 @@ data:
     # or a package containing an application.
     # https://docs.nautobot.com/projects/core/en/latest/configuration/optional-settings/#extra-applications
     # EXTRA_INSTALLED_APPS = []
-

--- a/components/09-nautobot/base/nautobot/templates/dexauth-cm.yaml
+++ b/components/09-nautobot/base/nautobot/templates/dexauth-cm.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+data:
+  dexauth.py: |
+    """Additional functions to process an Azure user."""
+    import logging
+    import os
+
+    from django.contrib.auth.models import Group
+
+
+    def _env_list(field: str) -> list[str]:
+        data = os.getenv(field)
+        if not data:
+            return []
+        if not isinstance(data, str):
+            return []
+        return data.split(",")
+
+
+    logger = logging.getLogger("auth.Dex")
+    GROUPS_ATTR_NAME = "groups"
+    SUPERUSER_GROUPS = _env_list("RAX_SUPERUSER_GROUPS")
+    STAFF_GROUPS = _env_list("RAX_STAFF_GROUPS")
+
+
+    def group_sync(
+        uid, user=None, response=None, *args, **kwargs
+    ):  # pylint: disable=keyword-arg-before-vararg, unused-argument
+        """Sync the users groups from Azure and set staff/superuser as
+        appropriate"""
+        if user and response and response.get(GROUPS_ATTR_NAME, False):
+            group_memberships = response.get(GROUPS_ATTR_NAME)
+            is_staff = False
+            is_superuser = False
+            logger.debug(
+                "User %s is a member of %s", uid, {", ".join(group_memberships)}
+            )
+            # Make sure all groups exist in Nautobot
+            group_ids = []
+            for group in group_memberships:
+                if group in SUPERUSER_GROUPS:
+                    is_superuser = True
+                if group in STAFF_GROUPS:
+                    is_staff = True
+                group_ids.append(Group.objects.get_or_create(name=group)[0].id)
+            user.groups.set(group_ids)
+            user.is_superuser = is_superuser
+            user.is_staff = is_staff
+            user.save()
+        else:
+            logger.debug("Did not receive groups from Dex, response: %s", response)
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: dexauth

--- a/components/09-nautobot/base/nautobot/templates/nautobot-deployment.yaml
+++ b/components/09-nautobot/base/nautobot/templates/nautobot-deployment.yaml
@@ -100,6 +100,9 @@ spec:
             - name: "nautobot-config"
               mountPath: "/opt/nautobot/uwsgi.ini"
               subPath: "uwsgi.ini"
+            - name: "nautobot-config"
+              mountPath: "/opt/nautobot/nautobot_config.py"
+              subPath: "nautobot_config.py"
       containers:
         - name: nautobot
           tty: true
@@ -169,6 +172,9 @@ spec:
             - name: "nautobot-config"
               mountPath: "/opt/nautobot/uwsgi.ini"
               subPath: "uwsgi.ini"
+            - name: "nautobot-config"
+              mountPath: "/opt/nautobot/nautobot_config.py"
+              subPath: "nautobot_config.py"
           ports:
             - name: "https"
               containerPort: 8443

--- a/components/09-nautobot/base/nautobot/templates/nautobot-deployment.yaml
+++ b/components/09-nautobot/base/nautobot/templates/nautobot-deployment.yaml
@@ -175,6 +175,9 @@ spec:
             - name: "nautobot-config"
               mountPath: "/opt/nautobot/nautobot_config.py"
               subPath: "nautobot_config.py"
+            - name: "nautobot-dexauth"
+              mountPath: "/opt/nautobot/dexauth.py"
+              subPath: "dexauth.py"
           ports:
             - name: "https"
               containerPort: 8443
@@ -190,3 +193,6 @@ spec:
         - name: "nautobot-config"
           configMap:
             name: nautobot-config
+        - name: "nautobot-dexauth"
+          configMap:
+            name: dexauth

--- a/components/13-dexidp/README.md
+++ b/components/13-dexidp/README.md
@@ -1,0 +1,74 @@
+## Overview
+
+The [Dex IDP](https://dexidp.io/) is deployed to act as an OAuth2/OpenID
+Connect identity provider for Nautobot and potentially other applications in
+the environment. With the default setup, it is backed by the
+[Keystone][keystone] component where the
+actual accounts are stored. Having it setup this way, we do not have to
+manually sync the accounts across components. It should also allow us to
+configure SSO with systems other than Keystone by using one of [multiple Dex
+connectors][connectors].
+
+[keystone]: https://docs.openstack.org/keystone/latest/
+[connectors]: https://dexidp.io/docs/connectors/
+
+## Nautobot setup
+
+In order to use dexidp as the authentication system we needed to make bunch of
+adjustments on the Nautobot side. In summary, this creates following
+requirements:
+
+- `nautobot_config.py` needs to be adjusted, so that it:
+    1. Uses [OIDC Social Auth][socialauth] backend.
+    2. Has a configuration pointing to the Dex [OpenID Discovery][disco] URL.
+    3. Injects custom authentication pipeline step that is responsible for
+       synchronizing the `Groups` from the information provided by Dex.
+- custom auth pipeline needs to be created and injected into environemtn
+
+Unfortunately, these Nautobot changes alone are not enough to have
+authentication working in most setups. We also need to make sure that every
+step of [authorziation code grant][authzcodegrant] can be completed. Given that
+we use ephemeral clusters for development and they use `.local` domain,
+following needs to work:
+
+- Nautobot container can reach the Dex using the issuer URL (`https://dexidp.local`).
+- End-user's browser must be able to reach Dex using exactly the same URL.
+- Nautobot needs to be reachable using the DNS name, i.e. `https://nautobot.local`
+- All of these needs to happen over HTTPS.
+
+When Dex and Nautobot are hosted in the same cluster, by default they will try
+to communicate over the internal networking and plain HTTP. This clearly
+violates the requirements listed above, so we have to force the communication
+between the pods to happen over the Ingress (which provides TLS termination and
+stable hostname).
+
+### Fixing DNS on development cluster
+
+In development cluster, this can be done by reconfiguring [CoreDNS][coredns]
+component. We have provided
+[`scripts/patch-coredns.sh`](../../scripts/patch-coredns.sh) script to make the
+necessary changes automatically.
+
+```shell
+$ ./scripts/patch-coredns.sh
+[*] Patching coredns ConfigMap
+configmap/coredns replaced
+[*] Restarting CoreDNS
+deployment.apps/coredns restarted
+$
+```
+
+### Making components accessible from your machine If running development
+
+cluster on your machine, you may need to create  create an entry in
+your `/etc/hosts` file that looks similiar to this:
+
+```hosts
+# Nautobot kind cluster
+127.0.0.1 argocd.local nautobot.local keystone keystone.openstack dexidp.local
+```
+
+[socialauth]: https://python-social-auth.readthedocs.io/en/latest/backends/oidc.html
+[disco]: https://openid.net/specs/openid-connect-discovery-1_0.html
+[authzcodegrant]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1
+[coredns]: https://kubernetes.io/docs/tasks/administer-cluster/coredns/#about-coredns

--- a/components/13-dexidp/kustomization.yaml
+++ b/components/13-dexidp/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+
+namespace: dex
+helmGlobals:
+  chartHome: ../../charts/
+
+helmCharts:
+- name: dex
+  includeCRDs: true
+  namespace: dex
+  valuesFile: values.yaml
+  releaseName: dex
+  version: 0.16.0
+  repo: https://charts.dexidp.io

--- a/components/13-dexidp/namespace.yaml
+++ b/components/13-dexidp/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dex

--- a/components/13-dexidp/values.yaml
+++ b/components/13-dexidp/values.yaml
@@ -1,0 +1,58 @@
+# Full documentation available at
+# https://github.com/dexidp/helm-charts/tree/master/charts/dex#values
+#
+
+replicaCount: 1
+config:
+  # Set it to a valid URL
+  issuer: https://dexidp.local
+
+  # See https://dexidp.io/docs/storage/ for more options
+  # We probably want 'postgres' or 'crd' in production
+  storage:
+    type: kubernetes
+    config:
+      inCluster: true
+
+  # Enable at least one connector
+  # See https://dexidp.io/docs/connectors/ for more options
+  enablePasswordDB: false
+  connectors:
+    - type: keystone
+      # Required field for connector id.
+      id: keystone_internal
+      # Required field for connector name.
+      name: Keystone
+      config:
+        # Required, without v3 suffix.
+        keystoneHost: http://keystone-api.openstack.svc.cluster.local:5000
+        # Required, admin user credentials to connect to keystone.
+        domain: default
+        keystoneUsername: demo
+        keystonePassword: DEMO_PASS
+  logger:
+    level: info
+
+  staticClients:
+    - id: nautobot
+      secret: verysecret
+      name: "Undercloud Nautobot"
+      redirectURIs:
+        - "http://localhost:8000/complete/oidc/"
+        - "https://nautobot.local/complete/oidc/"
+
+ingress:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+  className: "nginx"
+  hosts:
+    - host: dexidp.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+      - dexidp.local
+      secretName: dex-ingress-tls

--- a/scripts/patch-coredns.sh
+++ b/scripts/patch-coredns.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+EXISTING_COREFILE=$(kubectl -n kube-system get cm coredns -o jsonpath='{.data.Corefile}')
+
+ADD_LINE="    rewrite name dexidp.local ingress-nginx-controller.ingress-nginx.svc.cluster.local"
+
+if grep -q "$ADD_LINE" <(echo "$EXISTING_COREFILE"); then
+  echo "Configmap already patched."
+  exit 0
+fi
+# shellcheck disable=SC2001
+PATCHED_COREFILE=$(echo "$EXISTING_COREFILE" | sed -e "s/^}$/${ADD_LINE}\n\}/")
+
+
+echo "[*] Patching coredns ConfigMap"
+kubectl -n kube-system --dry-run=client create cm coredns  \
+  --from-literal=Corefile="$PATCHED_COREFILE" -o yaml \
+  | kubectl -n kube-system replace -f -
+
+echo "[*] Restarting CoreDNS"
+kubectl -n kube-system rollout restart deployment coredns


### PR DESCRIPTION
Adds Dex IDP and lets Nautobot use it to authenticate users against Keystone so the same users are used across the entire stack. Closes https://rackspace.atlassian.net/browse/PUC-167