### PR TITLE
fix: Revert "bootstrap/cert-manager: add patch to inject CA cert into corr…

### DIFF
--- a/bootstrap/cert-manager/kustomization.yaml
+++ b/bootstrap/cert-manager/kustomization.yaml
@@ -1,26 +1,7 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
 - https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
 - issuer-kube-system-self-signed.yaml
-
-patches:
-- patch: |-
-    - op: replace
-      path: /metadata/annotations/cert-manager.io~1inject-ca-from-secret
-      value: kube-system/cert-manager-webhook-ca
-  target:
-    group: admissionregistration.k8s.io
-    kind: ValidatingWebhookConfiguration
-    name: cert-manager-webhook
-    version: v1
-- patch: |-
-    - op: replace
-      path: /metadata/annotations/cert-manager.io~1inject-ca-from-secret
-      value: kube-system/cert-manager-webhook-ca
-  target:
-    group: admissionregistration.k8s.io
-    kind: MutatingWebhookConfiguration
-    name: cert-manager-webhook
-    version: v1


### PR DESCRIPTION
…ect namespace"

This reverts commit d6001e3854f87b222c8f71cbf6eb99de2bcf9974.

These kustomizations are no longer neccessary because it was already fixed in 5034d9453cd1f815b3b6618e025450d90e6480bc and d6001e3854f87b222c8f71cbf6eb99de2bcf9974 should have never been merged.