### PR TITLE
feat: use a common container list for OSH

### DIFF
--- a/components/10-keystone/README.md
+++ b/components/10-keystone/README.md
@@ -51,6 +51,7 @@ Secrets Reference:
 helm --namespace openstack template \
     keystone \
     ./openstack-helm/keystone/ \
+    -f components/openstack-2023.1-jammy.yaml \
     -f components/10-keystone/aio-values.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.keystone.password="$(kubectl --namespace openstack get secret keystone-db-password -o jsonpath='{.data.password}' | base64 -d)" \

--- a/components/10-keystone/aio-values.yaml
+++ b/components/10-keystone/aio-values.yaml
@@ -16,32 +16,6 @@ release_group: null
 # Set to false to upgrade using helm2
 helm3_hook: true
 
-images:
-  tags:
-    bootstrap: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    db_init: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    db_drop: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    keystone_api: "ghcr.io/rackerlabs/genestack/keystone-rxt:2023.1-ubuntu_jammy"
-    keystone_bootstrap: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    keystone_credential_rotate: "ghcr.io/rackerlabs/genestack/keystone-rxt:2023.1-ubuntu_jammy"
-    keystone_credential_setup: "ghcr.io/rackerlabs/genestack/keystone-rxt:2023.1-ubuntu_jammy"
-    keystone_db_sync: "ghcr.io/rackerlabs/genestack/keystone-rxt:2023.1-ubuntu_jammy"
-    keystone_domain_manage: "ghcr.io/rackerlabs/genestack/keystone-rxt:2023.1-ubuntu_jammy"
-    keystone_fernet_rotate: "ghcr.io/rackerlabs/genestack/keystone-rxt:2023.1-ubuntu_jammy"
-    keystone_fernet_setup: "ghcr.io/rackerlabs/genestack/keystone-rxt:2023.1-ubuntu_jammy"
-    ks_user: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    test: docker.io/xrally/xrally-openstack:2.0.0
-    rabbit_init: docker.io/rabbitmq:3.7-management
-    keystone_credential_cleanup: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
-    image_repo_sync: docker.io/docker:17.07.0
-  pull_policy: "IfNotPresent"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
-
 bootstrap:
   enabled: true
   ks_user: admin

--- a/components/13-ironic/README.md
+++ b/components/13-ironic/README.md
@@ -48,6 +48,7 @@ Secrets Reference:
 helm --namespace openstack template \
     ironic \
     ./openstack-helm/ironic/ \
+    -f components/openstack-2023.1-jammy.yaml \
     -f components/13-ironic/aio-values.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.ironic.password="$(kubectl --namespace openstack get secret ironic-db-password -o jsonpath='{.data.password}' | base64 -d)" \

--- a/components/13-ironic/aio-values.yaml
+++ b/components/13-ironic/aio-values.yaml
@@ -1,32 +1,5 @@
 ---
 
-images:
-  tags:
-    ironic_manage_cleaning_network: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    ironic_retrive_cleaning_network: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    ironic_retrive_swift_config: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    bootstrap: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    db_init: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    db_drop: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    ironic_db_sync: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
-    ironic_api: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
-    ironic_conductor: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
-    ironic_pxe: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
-    ironic_pxe_init: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
-    ironic_pxe_http: docker.io/nginx:1.13.3
-    ks_user: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    ks_service: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    ks_endpoints: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
-    rabbit_init: docker.io/rabbitmq:3.7-management
-    dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
-    image_repo_sync: docker.io/docker:17.07.0
-  pull_policy: "IfNotPresent"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
-
 bootstrap:
   image:
     enabled: false

--- a/components/openstack-2023.1-jammy.yaml
+++ b/components/openstack-2023.1-jammy.yaml
@@ -1,0 +1,34 @@
+---
+images:
+  tags:
+    # these are common across all these OpenStack Helm installations
+    bootstrap: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    db_init: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    db_drop: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ks_user: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ks_service: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ks_endpoints: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+
+    # keystone
+    keystone_api: "docker.io/openstackhelm/keystone:2023.1-ubuntu_jammy"
+    keystone_bootstrap: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    keystone_credential_rotate: "docker.io/openstackhelm/keystone:2023.1-ubuntu_jammy"
+    keystone_credential_setup: "docker.io/openstackhelm/keystone:2023.1-ubuntu_jammy"
+    keystone_db_sync: "docker.io/openstackhelm/keystone:2023.1-ubuntu_jammy"
+    keystone_domain_manage: "docker.io/openstackhelm/keystone:2023.1-ubuntu_jammy"
+    keystone_fernet_rotate: "docker.io/openstackhelm/keystone:2023.1-ubuntu_jammy"
+    keystone_fernet_setup: "docker.io/openstackhelm/keystone:2023.1-ubuntu_jammy"
+
+    # ironic
+    ironic_api: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_conductor: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_pxe: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_pxe_init: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_pxe_http: "docker.io/nginx:1.13.3"
+    ironic_db_sync: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    # these want curl which apparently is in the heat image
+    ironic_manage_cleaning_network: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ironic_retrive_cleaning_network: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+    ironic_retrive_swift_config: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
+
+...


### PR DESCRIPTION
Rather than having to maintain and keep up with different override files for OpenStack Helm's containers, centralize it into one file that can be shared between all the components.