### PR TITLE
feat: argo-workflows and argo-events deployments (JIRA:PUC-193)

### DIFF
--- a/components/11-argo-workflows/argo-server-cluster-role.yaml
+++ b/components/11-argo-workflows/argo-server-cluster-role.yaml
@@ -1,0 +1,26 @@
+## configure clusterrole for argo-server to provide permissions when argo-worfklows is running namespaced
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argo-server
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - clusterworkflowtemplates
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-server
+subjects:
+- kind: ServiceAccount
+  name: argo-server
+  namespace: argo

--- a/components/11-argo-workflows/ingress.yaml
+++ b/components/11-argo-workflows/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+  name: argo-workflows
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: workflows.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: argo-server
+            port:
+              number: 2746
+  tls:
+  - hosts:
+    - workflows.local
+    secretName: argo-workflows-ingress-tls

--- a/components/11-argo-workflows/kustomization.yaml
+++ b/components/11-argo-workflows/kustomization.yaml
@@ -4,3 +4,21 @@ kind: Kustomization
 
 resources:
   - https://github.com/argoproj/argo-workflows/releases/download/v3.5.4/namespace-install.yaml
+  - ingress.yaml
+
+  ## configure argo-workflow rbac
+  - argo-server-cluster-role.yaml
+
+patches:
+- target:  # configure argo-server namespaced and to set to server mode to disable auth until auth can be worked out
+    group: apps
+    version: v1
+    kind: Deployment
+    name: argo-server
+  path: patch-server-deployment.yaml
+- target:  # configure the workflow controller to monitor the argo-events namespace
+    group: apps
+    version: v1
+    kind: Deployment
+    name: workflow-controller
+  path: patch-workflow-deployment.yaml

--- a/components/11-argo-workflows/patch-server-deployment.yaml
+++ b/components/11-argo-workflows/patch-server-deployment.yaml
@@ -1,0 +1,10 @@
+## configure argo-server namespaced and to set to server mode to disable auth until auth can be worked out
+- op: replace
+  path: /spec/template/spec/containers/0/args
+  value:
+    - server
+    - --auth-mode=server
+    # - --auth-mode=client
+    - --namespaced
+    - --managed-namespace
+    - argo-events

--- a/components/11-argo-workflows/patch-workflow-deployment.yaml
+++ b/components/11-argo-workflows/patch-workflow-deployment.yaml
@@ -1,0 +1,7 @@
+## configure the workflow controller to monitor the argo-events namespace
+- op: replace
+  path: /spec/template/spec/containers/0/args
+  value:
+    - --namespaced
+    - --managed-namespace
+    - argo-events

--- a/components/12-argo-events/argo-role.yaml
+++ b/components/12-argo-events/argo-role.yaml
@@ -1,0 +1,140 @@
+# This role was sourced from the argo-workflows installation manifest, and is included to provide the neccessary RBAC
+# configuration for a namespaced argo-workflows/events install. Typically this role would be created within the
+# argo-workflows namespace, however since this installation is configured to use the argo-events namespace, this role
+# will need to be created here.
+#
+# https://github.com/argoproj/argo-workflows/blob/main/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+  name: argo-role
+  namespace: argo-events
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumeclaims/finalizers
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  - workflowtasksets
+  - workflowtasksets/finalizers
+  - workflowartifactgctasks
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - create
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtaskresults
+  verbs:
+  - list
+  - watch
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - cronworkflows
+  - cronworkflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-role-binding
+  namespace: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-role
+subjects:
+- kind: ServiceAccount
+  name: argo
+  namespace: argo

--- a/components/12-argo-events/argo-server-role.yaml
+++ b/components/12-argo-events/argo-server-role.yaml
@@ -1,0 +1,88 @@
+# This role was sourced from the argo-workflows installation manifest, and is included to provide the neccessary RBAC
+# configuration for a namespaced argo-workflows/events install. Typically this role would be created within the
+# argo-workflows namespace, however since this installation is configured to use the argo-events namespace, this role
+# will need to be created here.
+#
+# https://github.com/argoproj/argo-workflows/blob/main/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+  name: argo-server-role
+  namespace: argo-events
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - watch
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - eventsources
+  - sensors
+  - workflows
+  - workfloweventbindings
+  - workflowtemplates
+  - cronworkflows
+  - cronworkflows/finalizers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-server-role-binding
+  namespace: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-server-role
+subjects:
+- kind: ServiceAccount
+  name: argo-server
+  namespace: argo

--- a/components/12-argo-events/default-role.yaml
+++ b/components/12-argo-events/default-role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: default-role
+  namespace: argo-events
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-binding
+  namespace: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: default-role
+subjects:
+- kind: ServiceAccount
+  name: default

--- a/components/12-argo-events/kustomization.yaml
+++ b/components/12-argo-events/kustomization.yaml
@@ -6,3 +6,17 @@ resources:
   - namespace.yaml
   - https://github.com/argoproj/argo-events/releases/download/v1.9.1/namespace-install.yaml
   - https://github.com/argoproj/argo-events/releases/download/v1.9.1/install-validating-webhook.yaml
+
+  ## configure rbac to integrate with argo-workflow
+  # - default-role.yaml
+  - argo-server-role.yaml
+  - argo-role.yaml
+
+  ## deploy argo-event components
+  - native-eventbus.yaml
+  - webhook-event-source.yaml
+
+  ## configure webhook Sensor and associated role
+  - sensor-workflow-role.yaml
+  - webhook-sensor.yaml
+  - workflow-role.yaml

--- a/components/12-argo-events/native-eventbus.yaml
+++ b/components/12-argo-events/native-eventbus.yaml
@@ -1,0 +1,27 @@
+# Default and deprecated NATS EventBus sourced from:
+# https://github.com/argoproj/argo-events/blob/master/examples/eventbus/native.yaml
+
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+spec:
+  nats:
+    native:
+      # Optional, defaults to 3. If it is < 3, set it to 3, that is the minimal requirement.
+      replicas: 3
+      # Optional, authen strategy, "none" or "token", defaults to "none"
+      auth: token
+#      containerTemplate:
+#        resources:
+#          requests:
+#            cpu: "10m"
+#      metricsContainerTemplate:
+#        resources:
+#          requests:
+#            cpu: "10m"
+#      antiAffinity: false
+#      persistence:
+#        storageClassName: standard
+#        accessMode: ReadWriteOnce
+#        volumeSize: 10Gi

--- a/components/12-argo-events/sensor-workflow-role.yaml
+++ b/components/12-argo-events/sensor-workflow-role.yaml
@@ -1,0 +1,37 @@
+# This ServiceAccount and Role are used by the EventSensor to trigger Workflows. This Role is distinct and
+# separate from the Role Workflows use to make calls to the kubernetes API.
+#
+# https://github.com/argoproj/argo-events/blob/master/examples/rbac/sensor-rbac.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: operate-workflow-sa
+---
+# Similarly you can use a ClusterRole and ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operate-workflow-role
+rules:
+  - apiGroups:
+      - argoproj.io
+    verbs:
+      - "*"
+    resources:
+      - workflows
+      - workflowtemplates
+      - cronworkflows
+      - clusterworkflowtemplates
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operate-workflow-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operate-workflow-role
+subjects:
+  - kind: ServiceAccount
+    name: operate-workflow-sa

--- a/components/12-argo-events/webhook-event-source.yaml
+++ b/components/12-argo-events/webhook-event-source.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: nautobot-webhook
+spec:
+  service:
+    ports:
+    - name: insecure
+      port: 12000
+      targetPort: 12000
+  webhook:
+    nautobot:
+      endpoint: /nautobot
+      method: POST
+      port: "12000"

--- a/components/12-argo-events/webhook-sensor.yaml
+++ b/components/12-argo-events/webhook-sensor.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: nautobot-webhook
+spec:
+  template:
+    serviceAccountName: operate-workflow-sa
+  dependencies:
+    - name: nautobot-dep
+      eventSourceName: nautobot-webhook       # must match EventSource name
+      eventName: nautobot                     # must match event name defined in EventSource
+  triggers:
+    - template:
+        name: nautobot-workflow-trigger
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: nautobot-webhook-
+              spec:
+                serviceAccountName: workflow
+                entrypoint: whalesay
+                arguments:
+                  parameters:
+                  - name: message
+                    # the value will get overridden by event payload from test-dep
+                    value: hello world
+                templates:
+                - name: whalesay
+                  inputs:
+                    parameters:
+                    - name: message
+                  container:
+                    image: docker/whalesay:latest
+                    command: [cowsay]
+                    args: ["{{inputs.parameters.message}}"]
+          parameters:
+            - src:
+                dependencyName: nautobot-dep
+                dataKey: body
+              dest: spec.arguments.parameters.0.value

--- a/components/12-argo-events/workflow-role.yaml
+++ b/components/12-argo-events/workflow-role.yaml
@@ -1,0 +1,40 @@
+# This Role is included in the argo-workflows quick-start installation manfiest and can be found at:
+# https://github.com/argoproj/argo-workflows/blob/main/manifests/quick-start/base/executor/emissary/executor-role.yaml
+#
+# This Role enables a Workflow Pod (running Emissary executor) to be able to create and patch WorkflowTaskResults,
+# which get shared with the Workflow Controller. The Controller uses the results to update Workflow status.
+#
+# More information can be found at: https://github.com/argoproj/argo-workflows/blob/main/docs/workflow-rbac.md
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflow
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    workflows.argoproj.io/description: |
+      Recomended minimum permissions for the `emissary` executor.
+  name: executor
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtaskresults
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workflow-executor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: executor
+subjects:
+- kind: ServiceAccount
+  name: workflow


### PR DESCRIPTION
This creates basic argo-workflow and argo-events deployments

- deploys argo-workflows in namespaced mode
- argo-workflows controller monitors argo-events namespace
- does not configure auth for argo-workflows
- creates a single EventSource for a webhook event on POSTs to /nautobot
- creates a single Sensor with dependency on the event described above which defines a single hello-world Workflow trigger
