### PR TITLE
fix: keystone is missing rxt plugin

### DIFF
--- a/components/10-keystone/aio-values.yaml
+++ b/components/10-keystone/aio-values.yaml
@@ -505,8 +505,6 @@ conf:
       lockout_duration: 1800
     auth:
       methods: password,token,application_credential,totp
-      password: rxt
-      totp: rxt
 
   # NOTE(lamt) We can leverage multiple domains with different
   # configurations as outlined in


### PR DESCRIPTION
The `rxt` auth plugins are not available after we switched to generic upstream docker images for Keystone in #17.

Fixes:
```
2024-03-13 17:54:22.798 14 CRITICAL keystone [-] Unhandled error: stevedore.exception.NoMatches: No 'keystone.auth.password' driver found, looking for 'rxt'
2024-03-13 17:54:22.798 14 ERROR keystone Traceback (most recent call last):
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/bin/keystone-manage", line 8, in <module>
2024-03-13 17:54:22.798 14 ERROR keystone     sys.exit(main())
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/cmd/manage.py", line 41, in main
2024-03-13 17:54:22.798 14 ERROR keystone     cli.main(argv=sys.argv, developer_config_file=developer_config)
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/cmd/cli.py", line 1366, in main
2024-03-13 17:54:22.798 14 ERROR keystone     CONF.command.cmd_class.main()
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/cmd/cli.py", line 193, in main
2024-03-13 17:54:22.798 14 ERROR keystone     klass = cls()
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/cmd/cli.py", line 64, in __init__
2024-03-13 17:54:22.798 14 ERROR keystone     self.bootstrapper = bootstrap.Bootstrapper()
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/cmd/bootstrap.py", line 31, in __init__
2024-03-13 17:54:22.798 14 ERROR keystone     backends.load_backends()
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/server/backends.py", line 75, in load_backends
2024-03-13 17:54:22.798 14 ERROR keystone     auth.core.load_auth_methods()
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/auth/core.py", line 57, in load_auth_methods
2024-03-13 17:54:22.798 14 ERROR keystone     AUTH_METHODS[plugin] = load_auth_method(plugin)
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/auth/core.py", line 43, in load_auth_method
2024-03-13 17:54:22.798 14 ERROR keystone     driver_manager = _get_auth_driver_manager(namespace, plugin_name)
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/keystone/auth/core.py", line 37, in _get_auth_driver_manager
2024-03-13 17:54:22.798 14 ERROR keystone     return stevedore.DriverManager(namespace, plugin_name, invoke_on_load=True)
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/stevedore/driver.py", line 54, in __init__
2024-03-13 17:54:22.798 14 ERROR keystone     super(DriverManager, self).__init__(
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/stevedore/named.py", line 89, in __init__
2024-03-13 17:54:22.798 14 ERROR keystone     self._init_plugins(extensions)
2024-03-13 17:54:22.798 14 ERROR keystone   File "/var/lib/openstack/lib/python3.10/site-packages/stevedore/driver.py", line 113, in _init_plugins
2024-03-13 17:54:22.798 14 ERROR keystone     raise NoMatches('No %r driver found, looking for %r' %
2024-03-13 17:54:22.798 14 ERROR keystone stevedore.exception.NoMatches: No 'keystone.auth.password' driver found, looking for 'rxt'
2024-03-13 17:54:22.798 14 ERROR keystone
```