### PR TITLE
feat: generate memcache token secret to be constant

### DIFF
--- a/components/openstack-secrets.tpl.yaml
+++ b/components/openstack-secrets.tpl.yaml
@@ -17,6 +17,12 @@ endpoints:
       ironic:
         password: "${IRONIC_KEYSTONE_PASSWORD}"
 
+  # 'oslo_cache' is the memcache layer
+  oslo_cache:
+    auth:
+      # this is used for encrypting / protecting the memcache tokens
+      memcache_secret_key: "${MEMCACHE_SECRET_KEY}"
+
   # 'oslo_db' is for MariaDB
   oslo_db:
     auth:

--- a/scripts/gen-os-secrets.sh
+++ b/scripts/gen-os-secrets.sh
@@ -28,6 +28,9 @@ SCRIPTS_DIR="$(dirname "$0")"
 echo "This script will attempt to look up the existing values this repo used"
 echo "or will generate new values. The output below will be related to that."
 
+# memcache secret key
+export MEMCACHE_SECRET_KEY=$("${SCRIPTS_DIR}/pwgen.sh" 64)
+
 # keystone admin
 export KEYSTONE_ADMIN_PASSWORD=$(kubectl -n openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d || "${SCRIPTS_DIR}/pwgen.sh")
 # keystone mariadb


### PR DESCRIPTION
OpenStack Helm will always randomly generate this value if we don't use a constant memcache token secret in our config. This causes the secrets to always change and their annotations to change which restarts all containers from OpenStack Helm every time. This should allow us to maintain the container configs as idempotent.