### PR TITLE
feat: AzureAAD groups support

### DIFF
--- a/components/09-nautobot/base/nautobot/templates/configmap.yaml
+++ b/components/09-nautobot/base/nautobot/templates/configmap.yaml
@@ -29,6 +29,8 @@ data:
   NAUTOBOT_REDIS_SSL: "False"
   NAUTOBOT_SUPERUSER_EMAIL: "admin@example.com"
   NAUTOBOT_SUPERUSER_NAME: "admin"
+  RAX_SUPERUSER_GROUPS: undercloud-dev
+  RAX_STAFF_GROUPS: undercloud-dev
 ---
 # Source: nautobot/templates/configmap.yaml
 apiVersion: v1

--- a/components/13-dexidp/values.yaml
+++ b/components/13-dexidp/values.yaml
@@ -31,7 +31,7 @@ config:
         keystoneUsername: demo
         keystonePassword: DEMO_PASS
     - type: oidc
-      name: azure
+      name: Azure
       id: azure
       config:
         issuer: $AZURE_ISSUER
@@ -41,6 +41,7 @@ config:
         scopes:
           - openid
           - email
+          - offline_access
         insecureSkipEmailVerified: true
         insecureEnableGroups: true
         getUserInfo: true

--- a/components/13-dexidp/values.yaml
+++ b/components/13-dexidp/values.yaml
@@ -42,13 +42,10 @@ config:
           - openid
           - email
         insecureSkipEmailVerified: true
-        # enabling insecureEnableGroups adds the list of group UUIDs to the
-        # access token, which in turn results in a HTTP headers for requests to
-        # https://dexidp.local/userinfo being way too large for Ingress
-        # controller and python requests library. Even after adjusting ingress
-        # controlloer, the Nautobot still cannot handle token that large.
-        insecureEnableGroups: false
+        insecureEnableGroups: true
         getUserInfo: true
+        claimMapping:
+          groups: "roles"
   logger:
     level: info
 

--- a/components/13-dexidp/values.yaml
+++ b/components/13-dexidp/values.yaml
@@ -14,8 +14,9 @@ config:
     config:
       inCluster: true
 
-  # Enable at least one connector
-  # See https://dexidp.io/docs/connectors/ for more options
+  oauth2:
+    skipApprovalScreen: true
+
   enablePasswordDB: false
   connectors:
     - type: keystone


### PR DESCRIPTION
Following the changes in the Enterprise Application config for Nautobot, this PR adds support for recognising the groups sent as `roles` claim when authenticating through Dex.

The identity token should contain `roles` claim with `undercloud-dev` for a particular set of privileged users (usually mapped to one or more AD groups) and can be empty for everyone else.

![image](https://github.com/rackerlabs/understack/assets/183976/16191afa-aaf0-45de-ae8f-89d7b9a49878)
