### PR TITLE
fix: argo-events: remove accidentally added configMapGenerator

### DIFF
--- a/components/12-argo-events/kustomization.yaml
+++ b/components/12-argo-events/kustomization.yaml
@@ -20,9 +20,3 @@ resources:
   - sensor-workflow-role.yaml
   - webhook-sensor.yaml
   - workflow-role.yaml
-
-configMapGenerator:
-  - name: workflow-controller-configmap
-    behavior: merge
-    files:
-      - sso


### PR DESCRIPTION
This configMapGenerator was accidentally added in d3e9d90f - it should have been added only to the argo-workflows/kustomization.yaml. Fixes:

```
❯ k -n argocd describe app argo-events
Name:         argo-events
Namespace:    argocd
<snip>
      Self Heal:  true
Status:
  Conditions:
    Last Transition Time:  2024-04-04T11:49:52Z
    Message:               Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = Manifest generation error (cached): `kustomize build <path to cached source>/components/12-argo-events --enable-helm` failed exit status 1: Error: loading KV pairs: file sources: [sso]: evalsymlink failure on '<path to cached source>/components/12-argo-events/sso' : lstat <path to cached source>/components/12-argo-events/sso: no such file or directory
    Type:                  ComparisonError
  Controller Namespace:    argocd
```