### PR TITLE
docs: enable markdown extensions for the docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,13 @@ markdown_extensions:
   - admonition
   - attr_list
   - def_list
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
 
 plugins:
   - search


### PR DESCRIPTION
The docs are attempting to take advantage of these markdown extensions so we need to enable them.