### PR TITLE
fix: b9040cef4 ingress-nginxs argocd project

### DIFF
--- a/apps/operators/ingress-nginx.yaml
+++ b/apps/operators/ingress-nginx.yaml
@@ -3,7 +3,7 @@ kind: Application
 metadata:
   name: ingress-nginx
 spec:
-  project: understack
+  project: operators
   sources:
     - chart: ingress-nginx
       repoURL: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
The wrong project was used when it was moved into the operators bucket in b9040cef4.