### PR TITLE
feat: package up dnsmasq as a DNS and DHCP server

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -1,0 +1,36 @@
+name: container builds
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "containers/**"
+      - ".github/workflows/containers.yml"
+  pull_request:
+    paths:
+      - "containers/**"
+      - ".github/workflows/containers.yml"
+  workflow_dispatch:
+
+jobs:
+  ghcr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: login to ghcr.io
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: build and deploy container to registry
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:containers"
+          file: containers/Dockerfile.ironic
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/rackerlabs/openstackhelm/ironic:2023.1-ubuntu_jammy

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -1,4 +1,4 @@
-name: container builds
+name: ironic container builds
 
 on:
   push:
@@ -6,11 +6,11 @@ on:
       - main
     paths:
       - "containers/**"
-      - ".github/workflows/containers.yml"
+      - ".github/workflows/containers.yaml"
   pull_request:
     paths:
       - "containers/**"
-      - ".github/workflows/containers.yml"
+      - ".github/workflows/containers.yaml"
   workflow_dispatch:
 
 jobs:
@@ -27,10 +27,45 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: build and deploy container to registry
+
+      - name: Ironic image metadata
+        id: ironic-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/rackerlabs/openstackhelm/ironic
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,enable={{is_default_branch}}
+            type=raw,value=2023.1-ubuntu_jammy
+          labels: |
+            org.opencontainers.image.title=ironic with ISO utils
+            org.opencontainers.image.base.name=docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy
+      - name: build and deploy Ironic container image to registry
         uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:containers"
-          file: containers/Dockerfile.ironic
+          file: Dockerfile.ironic
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/rackerlabs/openstackhelm/ironic:2023.1-ubuntu_jammy
+          tags: ${{ steps.ironic-meta.outputs.tags }}
+          labels: ${{ steps.ironic-meta.outputs.labels }}
+
+      - name: dnsmasq image metadata
+        id: dnsmasq-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/rackerlabs/openstackhelm/dnsmasq
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,enable={{is_default_branch}}
+            type=raw,value=2023.1-ubuntu_jammy
+          labels: |
+            org.opencontainers.image.title=dnsmasq for Ironic deployed as openstack-helm
+            org.opencontainers.image.base.name=docker.io/alpine:3.19.1
+      - name: build and deploy dnsmasq container to registry
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:containers"
+          file: Dockerfile.dnsmasq
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.dnsmasq-meta.outputs.tags }}
+          labels: ${{ steps.dnsmasq-meta.outputs.labels }}

--- a/components/13-ironic/aio-values.yaml
+++ b/components/13-ironic/aio-values.yaml
@@ -1,5 +1,4 @@
 ---
-
 # we don't want to enable OpenStack Helm's
 # helm.sh/hooks because they set them as
 # post-install,post-upgrade which in ArgoCD
@@ -103,3 +102,20 @@ manifests:
   secret_db: false
   secret_rabbitmq: false
   secret_registry: false
+
+pod:
+  mounts:
+    ironic_conductor:
+      ironic_conductor:
+        volumeMounts:
+          - name: dnsmasq-ironic
+            mountPath: /etc/dnsmasq.d/
+          - name: dnsmasq-dhcp
+            mountPath: /var/lib/dnsmasq/
+        volumes:
+          - name: dnsmasq-ironic
+            persistentVolumeClaim:
+              claimName: dnsmasq-ironic
+          - name: dnsmasq-dhcp
+            persistentVolumeClaim:
+              claimName: dnsmasq-dhcp

--- a/components/13-ironic/aio-values.yaml
+++ b/components/13-ironic/aio-values.yaml
@@ -28,7 +28,7 @@ conf:
     conductor:
       automated_clean: false
     dhcp:
-      dhcp_provider: none
+      dhcp_provider: dnsmasq
     oslo_messaging_rabbit:
       rabbit_ha_queues: true
 

--- a/components/13-ironic/dnsmasq-cm.yaml
+++ b/components/13-ironic/dnsmasq-cm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic-dnsmasq
+data:
+  DNS_PORT: '53'
+  # When defining the IP address range, make sure to include subnet
+  # information, especially for the pools serving relayed requests
+  DHCP_RANGE: 192.168.200.4,192.168.200.12,255.255.255.0,192.168.200.255,30m
+  LOG_DNS_QUERIES: 'true'
+  LOG_DHCP_QUERIES: 'true'

--- a/components/13-ironic/dnsmasq-cm.yaml
+++ b/components/13-ironic/dnsmasq-cm.yaml
@@ -3,13 +3,13 @@ kind: ConfigMap
 metadata:
   name: ironic-dnsmasq
 data:
-  DNS_PORT: '53'
   # When defining the IP address range, make sure to include subnet
   # information, especially for the pools serving relayed requests
   DHCP_RANGE: 192.168.200.4,192.168.200.12,255.255.255.0,192.168.200.255,30m
   # external IP address of Ingress. Used to populate DNS A records for the
   # Understack components
   INGRESS_IP: 192.168.1.177
+  DNS_PORT: '1053'
   LOG_DNS_QUERIES: 'true'
   LOG_DHCP_QUERIES: 'true'
   # If you want to print rendered dnsmasq.conf in the logs

--- a/components/13-ironic/dnsmasq-cm.yaml
+++ b/components/13-ironic/dnsmasq-cm.yaml
@@ -9,3 +9,5 @@ data:
   DHCP_RANGE: 192.168.200.4,192.168.200.12,255.255.255.0,192.168.200.255,30m
   LOG_DNS_QUERIES: 'true'
   LOG_DHCP_QUERIES: 'true'
+  # If you want to print rendered dnsmasq.conf in the logs
+  # DEBUG_DNSMASQ_CONF: "yes"

--- a/components/13-ironic/dnsmasq-cm.yaml
+++ b/components/13-ironic/dnsmasq-cm.yaml
@@ -6,6 +6,7 @@ data:
   # When defining the IP address range, make sure to include subnet
   # information, especially for the pools serving relayed requests
   DHCP_RANGE: 192.168.200.4,192.168.200.12,255.255.255.0,192.168.200.255,30m
+  DHCP_RANGE_ROUTER: 192.168.200.1
   # external IP address of Ingress. Used to populate DNS A records for the
   # Understack components
   INGRESS_IP: 192.168.1.177

--- a/components/13-ironic/dnsmasq-cm.yaml
+++ b/components/13-ironic/dnsmasq-cm.yaml
@@ -7,6 +7,9 @@ data:
   # When defining the IP address range, make sure to include subnet
   # information, especially for the pools serving relayed requests
   DHCP_RANGE: 192.168.200.4,192.168.200.12,255.255.255.0,192.168.200.255,30m
+  # external IP address of Ingress. Used to populate DNS A records for the
+  # Understack components
+  INGRESS_IP: 192.168.1.177
   LOG_DNS_QUERIES: 'true'
   LOG_DHCP_QUERIES: 'true'
   # If you want to print rendered dnsmasq.conf in the logs

--- a/components/13-ironic/dnsmasq-pvc.yaml
+++ b/components/13-ironic/dnsmasq-pvc.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    undercloud.local/purpose: dnsmasq-etc
+  name: dnsmasq-ironic
+  namespace: openstack
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 16Mi
+  storageClassName: standard
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    undercloud.local/purpose: dnsmasq-dhcp
+  name: dnsmasq-dhcp
+  namespace: openstack
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 16Mi
+  storageClassName: standard

--- a/components/13-ironic/dnsmasq-ss.yaml
+++ b/components/13-ironic/dnsmasq-ss.yaml
@@ -13,6 +13,14 @@ spec:
       labels:
         application: ironic-dnsmasq
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  application: ironic
+                  component: conductor
       containers:
         - name: dnsmasq
           image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:2023.1-ubuntu_jammy

--- a/components/13-ironic/dnsmasq-ss.yaml
+++ b/components/13-ironic/dnsmasq-ss.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: dnsmasq
-          image: docker.io/cardoe/dnsmasq:latest
+          image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:2023.1-ubuntu_jammy
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/components/13-ironic/dnsmasq-ss.yaml
+++ b/components/13-ironic/dnsmasq-ss.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ironic-dnsmasq
+  namespace: openstack
 spec:
   replicas: 1
   selector:
@@ -44,6 +45,8 @@ spec:
         - name: pod-tmp
           emptyDir: {}
         - name: pod-dnsmasq-d
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: dnsmasq-ironic
         - name: pod-dhcp
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: dnsmasq-dhcp

--- a/components/13-ironic/dnsmasq-ss.yaml
+++ b/components/13-ironic/dnsmasq-ss.yaml
@@ -37,8 +37,9 @@ spec:
             - configMapRef:
                 name: ironic-dnsmasq
           ports:
-            - containerPort: 53
+            - containerPort: 1053
               protocol: UDP
+              hostPort: 53
             - containerPort: 1067
               protocol: UDP
               hostPort: 67

--- a/components/13-ironic/dnsmasq-ss.yaml
+++ b/components/13-ironic/dnsmasq-ss.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: dnsmasq
           image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:2023.1-ubuntu_jammy
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/components/13-ironic/dnsmasq-ss.yaml
+++ b/components/13-ironic/dnsmasq-ss.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ironic-dnsmasq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: ironic-dnsmasq
+  template:
+    metadata:
+      labels:
+        application: ironic-dnsmasq
+    spec:
+      containers:
+        - name: dnsmasq
+          image: docker.io/cardoe/dnsmasq:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              add: ["NET_ADMIN"]
+          args:
+            - /usr/sbin/dnsmasq
+            - '--no-daemon'
+          envFrom:
+            - configMapRef:
+                name: ironic-dnsmasq
+          ports:
+            - containerPort: 53
+              protocol: UDP
+            - containerPort: 1067
+              protocol: UDP
+              hostPort: 67
+          volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
+            - name: pod-dnsmasq-d
+              mountPath: /etc/dnsmasq.d
+            - name: pod-dhcp
+              mountPath: /var/lib/misc
+      volumes:
+        - name: pod-tmp
+          emptyDir: {}
+        - name: pod-dnsmasq-d
+          emptyDir: {}
+        - name: pod-dhcp
+          emptyDir: {}

--- a/components/13-ironic/kustomization.yaml
+++ b/components/13-ironic/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 resources:
   - ironic-mariadb-db.yaml
   - ironic-rabbitmq-queue.yaml
+  - dnsmasq-pvc.yaml
+  - dnsmasq-cm.yaml
+  - dnsmasq-ss.yaml
 
 helmGlobals:
   chartHome: ../../charts/

--- a/components/openstack-2023.1-jammy.yaml
+++ b/components/openstack-2023.1-jammy.yaml
@@ -21,7 +21,7 @@ images:
 
     # ironic
     ironic_api: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
-    ironic_conductor: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
+    ironic_conductor: "ghcr.io/rackerlabs/openstackhelm/ironic:2023.1-ubuntu_jammy"
     ironic_pxe: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
     ironic_pxe_init: "docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy"
     ironic_pxe_http: "docker.io/nginx:1.13.3"

--- a/containers/Dockerfile.dnsmasq
+++ b/containers/Dockerfile.dnsmasq
@@ -1,14 +1,11 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:jammy
+FROM alpine:3.19.1
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        dnsmasq \
-        python3 \
-        python3-pip \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+LABEL org.opencontainers.image.title="dnsmasq for ironic deployed as openstack-helm"
+LABEL org.opencontainers.image.base.name="ghcr.io/rackerlabs/understack/dnsmasq-alpine3.19.1"
+LABEL org.opencontainers.image.source=https://github.com/rackerlabs/understack
 
-RUN pip3 install --no-cache-dir 'jinja2>3,<4'
+RUN apk add --update --no-cache dnsmasq=2.90-r2 python3=3.11.8-r0 py3-pip=23.3.1-r0 py3-jinja2=3.1.2-r3
 
 COPY common/helpers.sh /helpers.sh
 COPY dnsmasq/entry-point.sh /entry-point.sh

--- a/containers/Dockerfile.dnsmasq
+++ b/containers/Dockerfile.dnsmasq
@@ -1,10 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM alpine:3.19.1
 
-LABEL org.opencontainers.image.title="dnsmasq for ironic deployed as openstack-helm"
-LABEL org.opencontainers.image.base.name="ghcr.io/rackerlabs/understack/dnsmasq-alpine3.19.1"
-LABEL org.opencontainers.image.source=https://github.com/rackerlabs/understack
-
 RUN apk add --update --no-cache dnsmasq=2.90-r2 python3=3.11.8-r0 py3-pip=23.3.1-r0 py3-jinja2=3.1.2-r3
 
 COPY common/helpers.sh /helpers.sh

--- a/containers/Dockerfile.dnsmasq
+++ b/containers/Dockerfile.dnsmasq
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:jammy
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        dnsmasq \
+        python3 \
+        python3-pip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir 'jinja2>3,<4'
+
+COPY common/helpers.sh /helpers.sh
+COPY dnsmasq/entry-point.sh /entry-point.sh
+RUN chmod +x /entry-point.sh
+COPY dnsmasq/dnsmasq.conf.j2 /etc/dnsmasq.conf.j2
+# let our entry point write out the script
+RUN ln -sf /etc/dnsmasq.d/dnsmasq.conf /etc/dnsmasq.conf
+
+EXPOSE 1053/udp
+EXPOSE 1067/udp
+
+ENTRYPOINT ["/entry-point.sh"]
+CMD ["/usr/sbin/dnsmasq", "-d"]

--- a/containers/Dockerfile.ironic
+++ b/containers/Dockerfile.ironic
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+FROM docker.io/openstackhelm/ironic:2023.1-ubuntu_jammy
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        genisoimage \
+        isolinux \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/containers/common/helpers.sh
+++ b/containers/common/helpers.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+render_j2_file() {
+    # use Python's jinja2 library to transform stdin to stdout replacing variables
+    python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' \
+    < "$1" > "$2"
+
+}

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -1,7 +1,7 @@
 #
 # UnderStack dnsmasq configuration for OpenStack Ironic
 #
-# This script should be processed with envsubst
+# This config should be processed with jinja
 #
 
 # log to stderr
@@ -55,9 +55,6 @@ dhcp-match=set:efi6,option6:61,0016
 
 # provide PXE services to HTTPClient machines as well
 dhcp-pxe-vendor=PXEClient,HTTPClient
-
-# disable DHCP for unknown hosts (disabling inventory)
-#dhcp-ignore=tag:!known
 
 # conductor will write configs here
 dhcp-hostsdir=/etc/dnsmasq.d/hostsdir.d

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -1,0 +1,66 @@
+#
+# UnderStack dnsmasq configuration for OpenStack Ironic
+#
+# This script should be processed with envsubst
+#
+
+# log to stderr
+log-facility=-
+
+# configs
+conf-dir=/etc/dnsmasq.d
+
+# bind to all interfaces
+#interface={{ env.INTERFACE }}
+except-interface=lo
+bind-interfaces
+
+# DNS port to listen on, set to 0 to disable
+port={{ env.DNS_PORT | default(53) }}
+dhcp-alternate-port=1067,68
+
+{% if env.LOG_DNS_QUERIES | default(False, True) %}
+# enable DNS logging
+log-queries=extra
+{% endif %}
+
+# for now, do not set any resolv settings which results in us
+# forwarding requests to kubedns within the cluster
+
+# don't advertise /etc/hosts entries
+no-hosts
+
+# DHCP range to hand out
+{% if env.DHCP_RANGE is defined %}
+dhcp-range={{ env.DHCP_RANGE }}
+{% endif %}
+
+# don't set to enable logging
+{% if env.LOG_DHCP_QUERIES | default(False, True) %}
+# enable DNS logging
+log-dhcp
+{% endif %}
+
+# check if client is already running iPXE
+dhcp-match=ipxe,175
+
+# Detect PXE architecture
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+dhcp-match=set:efi,option:client-arch,11
+dhcp-match=set:efi,option:client-arch,16
+# dhcpv6.option: Client System Architecture Type (61)
+dhcp-match=set:efi6,option6:61,0007
+dhcp-match=set:efi6,option6:61,0009
+dhcp-match=set:efi6,option6:61,0011
+dhcp-match=set:efi6,option6:61,0016
+
+# provide PXE services to HTTPClient machines as well
+dhcp-pxe-vendor=PXEClient,HTTPClient
+
+# disable DHCP for unknown hosts (disabling inventory)
+#dhcp-ignore=tag:!known
+
+# conductor will write configs here
+dhcp-hostsdir=/etc/dnsmasq.d/ironic.dhcp-hosts.d
+dhcp-optsdir=/etc/dnsmasq.d/ironic.dhcp-opts.d

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -59,3 +59,9 @@ dhcp-pxe-vendor=PXEClient,HTTPClient
 # conductor will write configs here
 dhcp-hostsdir=/etc/dnsmasq.d/hostsdir.d
 dhcp-optsdir=/etc/dnsmasq.d/optsdir.d
+
+# static DNS entries to reach UnderStack components
+{% set components = env.get('COMPONENTS', ['argocd', 'dex', 'ironic', 'keystone', 'nautobot', 'workflows', ]) -%}
+{% for component in components -%}
+address=/{{ component }}.{{ env.DNS_ZONE }}/{{ env.INGRESS_IP }}
+{% endfor %}

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -31,7 +31,8 @@ no-hosts
 # DHCP range to hand out
 {% if env.DHCP_RANGE is defined %}
 dhcp-range={{ env.DHCP_RANGE }}
-shared-network=eth0,{{ env.DHCP_RANGE.split(',')[0] }}
+shared-network=eth0,{{ env.DHCP_RANGE_ROUTER }}
+dhcp-option=option:router,{{ env.DHCP_RANGE_ROUTER }}
 {% endif %}
 
 # don't set to enable logging
@@ -66,3 +67,5 @@ dhcp-optsdir=/etc/dnsmasq.d/optsdir.d
 {% for component in components -%}
 address=/{{ component }}.{{ env.DNS_ZONE }}/{{ env.INGRESS_IP }}
 {% endfor %}
+
+dhcp-option=option:dns-server,{{ env.get('DNS_IP', env['INGRESS_IP']) }}

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -10,8 +10,6 @@ log-facility=-
 # configs
 conf-dir=/etc/dnsmasq.d
 
-# bind to all interfaces
-#interface={{ env.INTERFACE }}
 except-interface=lo
 bind-interfaces
 

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -60,5 +60,5 @@ dhcp-pxe-vendor=PXEClient,HTTPClient
 #dhcp-ignore=tag:!known
 
 # conductor will write configs here
-dhcp-hostsdir=/etc/dnsmasq.d/ironic.dhcp-hosts.d
-dhcp-optsdir=/etc/dnsmasq.d/ironic.dhcp-opts.d
+dhcp-hostsdir=/etc/dnsmasq.d/hostsdir.d
+dhcp-optsdir=/etc/dnsmasq.d/optsdir.d

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -31,6 +31,7 @@ no-hosts
 # DHCP range to hand out
 {% if env.DHCP_RANGE is defined %}
 dhcp-range={{ env.DHCP_RANGE }}
+shared-network=eth0,{{ env.DHCP_RANGE.split(',')[0] }}
 {% endif %}
 
 # don't set to enable logging

--- a/containers/dnsmasq/entry-point.sh
+++ b/containers/dnsmasq/entry-point.sh
@@ -10,6 +10,10 @@ mkdir -p /etc/dnsmasq.d/optsdir.d
 
 render_j2_file /etc/dnsmasq.conf.j2 /etc/dnsmasq.conf
 
+if [ -n "${DEBUG_DNSMASQ_CONF+x}" ]; then
+  cat /etc/dnsmasq.conf
+fi
+
 /usr/sbin/dnsmasq --test
 
 case "$1" in

--- a/containers/dnsmasq/entry-point.sh
+++ b/containers/dnsmasq/entry-point.sh
@@ -5,8 +5,8 @@ set -eux
 . /helpers.sh
 
 mkdir -p /etc/dnsmasq.d/
-mkdir -p /etc/dnsmasq.d/ironic.dhcp-hosts.d
-mkdir -p /etc/dnsmasq.d/ironic.dhcp-opts.d
+mkdir -p /etc/dnsmasq.d/hostsdir.d
+mkdir -p /etc/dnsmasq.d/optsdir.d
 
 render_j2_file /etc/dnsmasq.conf.j2 /etc/dnsmasq.conf
 

--- a/containers/dnsmasq/entry-point.sh
+++ b/containers/dnsmasq/entry-point.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eux
+
+. /helpers.sh
+
+mkdir -p /etc/dnsmasq.d/
+mkdir -p /etc/dnsmasq.d/ironic.dhcp-hosts.d
+mkdir -p /etc/dnsmasq.d/ironic.dhcp-opts.d
+
+render_j2_file /etc/dnsmasq.conf.j2 /etc/dnsmasq.conf
+
+/usr/sbin/dnsmasq --test
+
+case "$1" in
+    *sh|*dnsmasq) exec "$@" ;;
+    *) exec /usr/sbin/dnsmasq "$@" ;;
+esac


### PR DESCRIPTION
This PR adds dnsmasq installation to the `openstack` namespace. It will:
- hand out IP addresses to hosts that are provisioned with Ironic
- cooperate with Ironic for setting per-host options
- enable a DNS server that can resolve records for endpoint URLs returned by the OpenStack Identity service catalogue

In its current form, it supports only a single DHCP range/pool. Support for multiple pools will be added as a separate story as it requires more input parameters (MACs of the relays, range names, and potentially different DNS server IPs).

Closes PUC-225