### PR TITLE
fix: makes nautobot oidc auth endpoint configurable

### DIFF
--- a/components/09-nautobot/base/nautobot/templates/configmap.yaml
+++ b/components/09-nautobot/base/nautobot/templates/configmap.yaml
@@ -580,7 +580,7 @@ data:
     SOCIAL_AUTH_OIDC_SSL_PROTOCOL = None
     # TODO: until we figure out how to add local CA to python trusted CAs
     SOCIAL_AUTH_OIDC_VERIFY_SSL = False
-    SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = "http://dexidp.local"
+    SOCIAL_AUTH_OIDC_OIDC_ENDPOINT = os.getenv("SOCIAL_AUTH_OIDC_OIDC_ENDPOINT", "http://dexidp.local")
     SOCIAL_AUTH_OIDC_USERNAME_KEY = 'name'
     SOCIAL_AUTH_OIDC_KEY = 'nautobot'
     with open("/opt/nautobot/dex_client_secret") as oidc_secret:


### PR DESCRIPTION
I need to be able to set django's `SOCIAL_AUTH_OIDC_OIDC_ENDPOINT` to a different url, but let's keep the existing default in place.