### PR TITLE
fix: adjust hooks on keystone jobs

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -1093,11 +1093,11 @@ helm3_hook: false
 annotations:
   job:
     keystone_fernet_setup:
-      "helm.sh/hook": pre-install,pre-upgrade
-      "helm.sh/hook-weight": "1"
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     keystone_db_sync:
-      "helm.sh/hook": pre-install,pre-upgrade
-      "helm.sh/hook-weight": "2"
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     keystone_credential_setup:
-      "helm.sh/hook": pre-install,pre-upgrade
-      "helm.sh/hook-weight": "1"
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation


### PR DESCRIPTION
The jobs cannot be run as pre steps because ArgoCD tries to run them before their dependent resources have been created.