### PR TITLE
feat: adds creation of demo user and undercloud-dev nautobot access group.

### DIFF
--- a/components/dexidp/values-azure.yaml
+++ b/components/dexidp/values-azure.yaml
@@ -30,7 +30,7 @@ config:
         # Required, admin user credentials to connect to keystone.
         domain: default
         keystoneUsername: demo
-        keystonePassword: DEMO_PASS
+        keystonePassword: demo
     - type: oidc
       name: Azure
       id: azure

--- a/components/dexidp/values-generic.yaml
+++ b/components/dexidp/values-generic.yaml
@@ -30,7 +30,7 @@ config:
         # Required, admin user credentials to connect to keystone.
         domain: default
         keystoneUsername: demo
-        keystonePassword: DEMO_PASS
+        keystonePassword: demo
   logger:
     level: info
 

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -21,6 +21,12 @@ bootstrap:
           --user="${OS_USERNAME}" \
           --domain="${OS_DEFAULT_DOMAIN}" \
           "admin"
+    # create a demo user with demo password
+    openstack user create --domain="${OS_DEFAULT_DOMAIN}" --password demo demo
+    # create undercloud-dev group
+    openstack group create --or-show undercloud-dev
+    # add demo user to undercloud-dev group
+    openstack group add user undercloud-dev demo
 
 network:
   api:


### PR DESCRIPTION
The group `undercloud-dev` is used by nautobot and users in this group have elevated permissions. With dex integration, we can use the keystone group undercloud-dev to control access to nautobot. 