### PR TITLE
fix: patching sso configmap in workflows to template in correct domain

### DIFF
--- a/apps/components/argo-workflows.yaml
+++ b/apps/components/argo-workflows.yaml
@@ -8,6 +8,44 @@ spec:
     - repoURL: https://github.com/rackerlabs/understack.git
       path: components/11-argo-workflows/
       targetRevision: ${UC_REPO_REF}
+      kustomize:
+        patches:
+          - target:
+              kind: ConfigMap
+              name: workflow-controller-configmap
+            patch: |-
+              - op: replace
+                path: /data/sso
+                value: |-
+                  # This is the root URL of the OIDC provider (required).
+                  issuer: https://dex.${DNS_ZONE}
+                  # This defines how long your login is valid for (in hours). (optional)
+                  # If omitted, defaults to 10h. Example below is 10 days.
+                  sessionExpiry: 240h
+                  # This is name of the secret and the key in it that contain OIDC client
+                  # ID issued to the application by the provider (required).
+                  clientId:
+                    name: argo-sso
+                    key: client-id
+                  # This is name of the secret and the key in it that contain OIDC client
+                  # secret issued to the application by the provider (required).
+                  clientSecret:
+                    name: argo-sso
+                    key: client-secret
+                  # This is the redirect URL supplied to the provider (optional). It must
+                  # be in the form <argo-server-root-url>/oauth2/callback. It must be
+                  # browser-accessible. If omitted, will be automatically generated.
+                  redirectUrl: https://workflows.${DNS_ZONE}/oauth2/callback
+                  # Additional scopes to request. Typically needed for SSO RBAC. >= v2.12
+                  scopes:
+                    - groups
+                    - email
+                    - profile
+                  # RBAC Config. >= v2.12
+                  rbac:
+                    enabled: false
+                  # Skip TLS verify, not recommended in production environments. Useful for testing purposes. >= v3.2.4
+                  insecureSkipVerify: true
     - repoURL: ${UC_DEPLOY_GIT_URL}
       path: secrets/${DEPLOY_NAME}/
       targetRevision: ${UC_DEPLOY_REF}


### PR DESCRIPTION
I'm not convinced this is the best approach here, but it works and is at least consistent with how we're handling the Nautobot ingress patches. 