### PR TITLE
fix: Use default storageclass

### DIFF
--- a/components/ironic/dnsmasq-pvc.yaml
+++ b/components/ironic/dnsmasq-pvc.yaml
@@ -11,7 +11,6 @@ spec:
   resources:
     requests:
       storage: 16Mi
-  storageClassName: standard
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -26,4 +25,3 @@ spec:
   resources:
     requests:
       storage: 16Mi
-  storageClassName: standard


### PR DESCRIPTION
The dnsmasq pod failed to start for me:
```
Events:
  Type     Reason            Age                  From               Message
  ----     ------            ----                 ----               -------
  Warning  FailedScheduling  17m                  default-scheduler  0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
  Warning  FailedScheduling  7m48s (x2 over 12m)  default-scheduler  0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
```
The pvc stuck:
```
root@915966-utility01-ospcv2-iad:~# kubectl get pvc
NAME                            STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
persistence-rabbitmq-server-0   Bound     pvc-6356953e-2c06-4aa9-858e-24e7ff41a479   10Gi       RWO            local-path     48d
storage-mariadb-0               Bound     pvc-b0ab04db-4ec5-4af4-8b78-6f4ba2bff394   1Gi        RWO            local-path     48d
dnsmasq-ironic                  Pending                                                                        standard       18m
dnsmasq-dhcp                    Pending                                                                        standard       18m

```
I missed capturing it in argo ui, but the error was that my my cluster didn't have a storageclass named 'standard'. But, I do have a default storageclass:
```
root@915966-utility01-ospcv2-iad:~# kubectl get storageclass
NAME                   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  48d
root@915966-utility01-ospcv2-iad:~#
```
This change uses the default storageclass for the pvc. Alternatively, I think we'd need to add something that ensures we have a storageclass named 'standard' when we bootstrap a new kubernetes cluster.