### PR TITLE
fix: Adds volume mount for the /var/lib/ironic hostpath.

### DIFF
--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -103,6 +103,8 @@ pod:
             mountPath: /etc/dnsmasq.d/
           - name: dnsmasq-dhcp
             mountPath: /var/lib/dnsmasq/
+          - name: host-var-lib-ironic
+            mountPath: /var/lib/ironic
         volumes:
           - name: dnsmasq-ironic
             persistentVolumeClaim:


### PR DESCRIPTION
The upstream openstack-helm is already creating a hostPath volume for /var/lib/ironic: https://github.com/openstack/openstack-helm/blob/master/ironic/templates/statefulset-conductor.yaml#L257-L259 - but it's not creating the volume mount in all of the containers. Currently we're putting images in to the host's /var/lib/ironic directory in order to make them available for the ironic-conductor-http containers to serve.