### PR TITLE
feat: Re-organize documentation nav and categories

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,9 @@ plugins:
 
 nav:
   - Home: index.md
-  - openstack-helm.md
-  - secrets.md
-  - install-understack-ubuntu-k3s.md
-  - gitops-install.md
+  - 'Getting Started':
+    - openstack-helm.md
+    - secrets.md
+  - 'Installation':
+    - gitops-install.md
+    - install-understack-ubuntu-k3s.md


### PR DESCRIPTION
Groups the current pages in to a couple categories, which cleans up the navigation bar a little.

Demo of my changes:
<img width="1466" alt="Screenshot 2024-04-19 at 3 52 09 PM" src="https://github.com/rackerlabs/understack/assets/1755790/ec56dfd9-7537-4baa-aa93-12e9a3e84859">
<img width="1489" alt="Screenshot 2024-04-19 at 3 53 06 PM" src="https://github.com/rackerlabs/understack/assets/1755790/101a668c-6f41-4342-877a-60429e04bd37">

Here's the current one for reference:
<img width="1488" alt="Screenshot 2024-04-19 at 4 02 57 PM" src="https://github.com/rackerlabs/understack/assets/1755790/f27f5ac7-8a4a-43d6-8766-2ead303f915b">
