### PR TITLE
fix: allow github  workflows to perform manual docs deployment

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -47,8 +47,8 @@ jobs:
     # depend on the docs being built
     needs: build
 
-    # ensure we only run on commits to the main branch
-    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    # ensure we only run on commits to the main branch or manual workflows executions
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I'm unable to manually start a github actions workflow to deploy documentation. The deploy step gets skipped due to workflow if statement.

<img width="703" alt="Screenshot 2024-04-22 at 11 02 17 AM" src="https://github.com/rackerlabs/understack/assets/1755790/ca8abb93-b480-4d5f-8a9e-3b500fc434bd">
