### PR TITLE
fix: dnsmasq: pin versions, switch to debian

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -57,10 +57,9 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,enable={{is_default_branch}}
-            type=raw,value=2023.1-ubuntu_jammy
+            type=raw,value=0.0.1
           labels: |
             org.opencontainers.image.title=dnsmasq for Ironic deployed as openstack-helm
-            org.opencontainers.image.base.name=docker.io/alpine:3.19.1
       - name: build and deploy dnsmasq container to registry
         uses: docker/build-push-action@v5
         with:

--- a/argo-workflows/generic/containers/Dockerfile.python312_alpine
+++ b/argo-workflows/generic/containers/Dockerfile.python312_alpine
@@ -1,3 +1,4 @@
+
 FROM python:3.12.2-alpine3.19 as builder
 
 LABEL org.opencontainers.image.title="Python 3.12 image base image"

--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -23,7 +23,7 @@ spec:
                   component: conductor
       containers:
         - name: dnsmasq
-          image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:2023.1-ubuntu_jammy
+          image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:0.0.1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/containers/Dockerfile.dnsmasq
+++ b/containers/Dockerfile.dnsmasq
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM alpine:3.19.1
+FROM debian:bookworm-20240408-slim
 
-RUN apk add --update --no-cache dnsmasq=2.90-r2 python3=3.11.8-r0 py3-pip=23.3.1-r0 py3-jinja2=3.1.2-r3
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends dnsmasq=2.89-1 python3-jinja2=3.1.2-1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY common/helpers.sh /helpers.sh
 COPY dnsmasq/entry-point.sh /entry-point.sh


### PR DESCRIPTION
Turns out the Alpine project does not follow semver and changes the versioned upstream images after the fact, so we have to pin them to a specific sha256 to keep stable builds.

Closes PUC-241. Fixes [build failures like this one](https://github.com/rackerlabs/understack/actions/runs/8789533012/job/24119504196)