### PR TITLE
fix: Updates README to point to the GitOps based install guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The requirements are a Kubernetes cluster, which
 this repo will contain information about building different
 clusters and then a pile of bare metal systems that can
 be ingested into the stack to be available to be consumed
-via Openstack Ironic.
+via OpenStack Ironic.
 
 ## Basic Deploy
 
@@ -29,55 +29,7 @@ development environment including those tools by launching `nix-shell` in the
 project directory. If you don't have `nix-shell` on your machine, it can be
 [downloaded here](https://nixos.org/download.html).
 
-### Bootstrapping and Operators
+### Install
 
-There's a handful of base required components to get a cluster ready to accept
-traffic and utilize ArgoCD to deploy the rest of the stack. We'll call that
-"bootstrap". Below is the easy one liner but you can look at
-[./bootstrap/README.md](./bootstrap/README.md) for detailed info.
-
-```bash
-./bootstrap/bootstrap.sh
-```
-
-### (Optional) Install MetalLB
-
-[Install MetalLB](./components/20-metallb/README.md)
-
-
-At this point ArgoCD can start doing the heavy lifting.
-
-```bash
-kubectl -n argocd apply -k apps/operators/
-```
-
-### Secrets
-
-To make it possible to utilize GitOps, we need to have our secrets pre-created
-and not randomly generated. A better solution for secrets will ultimately be
-needed but for now we can generate them easily for a dev environment and
-deploy them. Visit [/components/01-secrets/README.md](./components/01-secrets/README.md)
-for specific steps.  Otherwise just follow the steps below.
-
-```bash
-# generate secrets
-./scripts/easy-secrets-gen.sh
-# make the namespaces where the secrets will live
-kubectl apply -k components/00-namespaces/
-# load the secrets
-kubectl apply -k components/01-secrets/
-```
-
-### Deploy the UnderStack components
-
-```bash
-kubectl -n argocd apply -k apps/components/
-```
-
-ArgoCD should successfully get Nautobot deployed. Now come the OpenStack
-components which aren't working with GitOps methods at this time.
-
-[Install Keystone](./components/keystone/README.md)
-
-[Configure environment for Keystone/Dex auth](./components/dexidp/README.md).
-
+Follow the [GitOps Install Guide](https://rackerlabs.github.io/understack/gitops-install/)
+which walks through creating a configuration and bootstrapping UnderStack.

--- a/docs/gitops-install.md
+++ b/docs/gitops-install.md
@@ -176,3 +176,11 @@ At this point ArgoCD will work to deploy Understack.
 [app-of-apps]: <https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/>
 [argocd]: <https://argo-cd.readthedocs.io/en/stable/>
 [gh-deploy-keys]: <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#set-up-deploy-keys>
+
+## Advanced Configurations
+
+### Argo CD
+
+The UnderStack deploy makes a hardcoded Argo CD config that works with github.com and a SSH key.
+If you use something, such as a privately hosted Git service, you can refer to the Argo CD
+documentation for configuration details: <https://argo-cd.readthedocs.io/en/stable/user-guide/private-repositories/#unknown-ssh-hosts>


### PR DESCRIPTION
Some of the things in the old README were outdated and no longer worked. This updates the install guide to use the gitops based install: https://rackerlabs.github.io/understack/gitops-install/
