### PR TITLE
fix: use the correct repo reference for operators

### DIFF
--- a/apps/operators/mariadb-operator.yaml
+++ b/apps/operators/mariadb-operator.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     repoURL: https://github.com/rackerlabs/understack.git
     path: operators/mariadb-operator/
-    targetRevision: ${UC_DEPLOY_REF}
+    targetRevision: ${UC_REPO_REF}
   destination:
     server: "https://kubernetes.default.svc"
     namespace: mariadb-operator

--- a/apps/operators/messaging-topology-operator.yaml
+++ b/apps/operators/messaging-topology-operator.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     repoURL: https://github.com/rackerlabs/understack.git
     path: operators/messaging-topology-operator/
-    targetRevision: ${UC_DEPLOY_REF}
+    targetRevision: ${UC_REPO_REF}
   destination:
     server: "https://kubernetes.default.svc"
     namespace: rabbitmq-system

--- a/apps/operators/postgres-operator.yaml
+++ b/apps/operators/postgres-operator.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     repoURL: https://github.com/rackerlabs/understack.git
     path: operators/postgres-operator/
-    targetRevision: ${UC_DEPLOY_REF}
+    targetRevision: ${UC_REPO_REF}
   destination:
     server: "https://kubernetes.default.svc"
     namespace: postgres-operator

--- a/apps/operators/rabbitmq-operator.yaml
+++ b/apps/operators/rabbitmq-operator.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     repoURL: https://github.com/rackerlabs/understack.git
     path: operators/rabbitmq-operator/
-    targetRevision: ${UC_DEPLOY_REF}
+    targetRevision: ${UC_REF_REF}
   destination:
     server: "https://kubernetes.default.svc"
     namespace: rabbitmq-system


### PR DESCRIPTION
The operators templates used the wrong repo reference so the wrong branch was referenced when the templates were generated.