### PR TITLE
fix: Updates k3s install option to automatically set the openstack node label

### DIFF
--- a/docs/install-understack-ubuntu-k3s.md
+++ b/docs/install-understack-ubuntu-k3s.md
@@ -27,7 +27,7 @@ apt-get -y update
 ## Install K3s
 
 ```bash
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable=traefik" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable=traefik --node-label=openstack-control-plane=enabled" sh -
 ```
 
 References:


### PR DESCRIPTION
We were manually setting the node labels required by openstack-helm, but we can set them when we install k3s.
```bash
root@nick-understack-test-20240429:/var/log# kubectl describe node/nick-understack-test-20240429
Name:               nick-understack-test-20240429
Roles:              control-plane,master
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=k3s
                    beta.kubernetes.io/os=linux
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=nick-understack-test-20240429
                    kubernetes.io/os=linux
                    node-role.kubernetes.io/control-plane=true
                    node-role.kubernetes.io/master=true
                    node.kubernetes.io/instance-type=k3s
                    openstack-control-plane=enabled  # <--------------------
```