### PR TITLE
fix: fix typo and add a note about ref variables

### DIFF
--- a/apps/operators/rabbitmq-operator.yaml
+++ b/apps/operators/rabbitmq-operator.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     repoURL: https://github.com/rackerlabs/understack.git
     path: operators/rabbitmq-operator/
-    targetRevision: ${UC_REF_REF}
+    targetRevision: ${UC_REPO_REF}
   destination:
     server: "https://kubernetes.default.svc"
     namespace: rabbitmq-system

--- a/docs/gitops-install.md
+++ b/docs/gitops-install.md
@@ -64,6 +64,14 @@ these two repos have been cloned.
 
 Optional variables of `UC_REPO_REF` and `UC_DEPLOY_REF` can be defined which
 can be set to any valid git reference in their respective repos (e.g. branch or tag or commit).
+A working default for these values, appended to your `my-k3s.env` file can be:
+
+```bash
+UC_REPO_REF=$(cd ${UC_REPO} && git rev-parse --abbrev-ref HEAD)
+UC_DEPLOY_REF=$(cd ${UC_DEPLOY} && git rev-parse --abbrev-ref HEAD)
+```
+
+This would set the value to your current branch each time.
 
 #### Deployment Name
 


### PR DESCRIPTION
Fixed a typo in the rabbitmq-operator template and added a note about ref variables