### PR TITLE
fix: ensure UC_REPO/UC_DEPLOY are set correctly

### DIFF
--- a/docs/gitops-install.md
+++ b/docs/gitops-install.md
@@ -48,7 +48,7 @@ To avoid defining many environment variables we'll simplify by creating an
 place it where we've cloned understack. A complete file would like like
 
 ```bash title="/path/to/uc-deploy/my-k3s.env"
-UC_DEPLOY="$(pwd)/$(dirname ${BASH_SOURCE[0]})"
+UC_DEPLOY="$(cd "$(dirname ${BASH_SOURCE[0]})" && git rev-parse --show-toplevel)"
 DEPLOY_NAME="my-k3s"
 UC_DEPLOY_GIT_URL=git@github.com:myorg/uc-deploy.git
 UC_DEPLOY_SSH_FILE="$HOME/devel/uc-deploy-key"

--- a/scripts/gitops-deploy.sh
+++ b/scripts/gitops-deploy.sh
@@ -17,14 +17,21 @@ if [ $# -ne 1 ]; then
     usage
 fi
 
+SCRIPTS_DIR=$(dirname "$0")
+
 if [ ! -f "$1" ]; then
     echo "Did not get a file with environment variables." >&2
     usage
 fi
 
+# set temp path so we can reset it after import
+UC_REPO_PATH="$(cd "${SCRIPTS_DIR}" && git rev-parse --show-toplevel)"
+export UC_REPO="${UC_REPO_PATH}"
+
 . "$1"
 
-export UC_REPO="$(git rev-parse --show-toplevel)"
+# set the value again after import
+export UC_REPO="${UC_REPO_PATH}"
 
 if [ ! -d "${UC_REPO}" ]; then
     echo "UC_REPO not set to a path." >&2

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -18,9 +18,14 @@ if [ ! -f "$1" ]; then
     usage
 fi
 
+# set temp path so we can reset it after import
+UC_REPO_PATH="$(cd "${SCRIPTS_DIR}" && git rev-parse --show-toplevel)"
+export UC_REPO="${UC_REPO_PATH}"
+
 . "$1"
 
-export UC_REPO="$(git rev-parse --show-toplevel)"
+# set the value again after import
+export UC_REPO="${UC_REPO_PATH}"
 
 if [ ! -d "${UC_DEPLOY}" ]; then
     echo "UC_DEPLOY not set to a path." >&2


### PR DESCRIPTION
Ensure that the UC_REPO variable is set to the top-level of the repo even if the environment variable file overwrites it. Suggest how the UC_DEPLOY variable can be set to the path to the git repo. fixes #80