### PR TITLE
feat: add documentation for networking, metallb, and dhcp related settings.

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,48 @@
+# Networking
+
+!!! warning Networking Configuration
+    Your networking configurations in UnderStack are highly dependent on
+    your own environment.
+
+## MetalLB Load Balancer for DHCP
+
+We are using [MetalLB](https://metallb.io/) to provide a TCP/UDP load balancer
+for dnsmasq's DHCP server.
+
+The MetalLB configuration you will use depends on the network and physical
+server interface in your environment.
+
+Here's an example MetalLB manifest where we use `192.168.200.2` as our DHCP
+load balancer IP address, and on our server running UnderStack services, we
+will use ethernet interface `eno2`.
+
+```yaml
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: lb-provisioning
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.200.2/32  # IMPORTANT: this is the load balancer IP we will use for DHCP
+  autoAssign: true
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: lb-provisioning-advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - lb-provisioning
+  interfaces:
+  - eno2  # IMPORTANT: this is the physical interface on your understack server
+```
+
+## DHCP Dnsmasq Configuration
+
+You will want to review and edit the dnsmasq DHCP configuration for your environment:
+<https://github.com/rackerlabs/understack/blob/main/components/ironic/dnsmasq-cm.yaml>
+
+The important settings to review are `DHCP_RANGE`, `DHCP_RANGE_ROUTER`, and `INGRESS_IP`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,3 +65,4 @@ nav:
     - gitops-install.md
     - install-understack-ubuntu-k3s.md
     - auth.md
+    - networking.md


### PR DESCRIPTION
Adds a new `Networking` section to the docs, with sub-sections for metallb and dhcp configuration settings.