### PR TITLE
fix: update openstack-admin-client image to heat, which contains more openstack-client plugins

### DIFF
--- a/components/openstack-admin-client/openstack-admin-client.yaml
+++ b/components/openstack-admin-client/openstack-admin-client.yaml
@@ -7,7 +7,7 @@ spec:
   restartPolicy: Always
   containers:
     - name: "image-ks-service-registration"
-      image: docker.io/openstackhelm/openstack-client:2024.1
+      image: docker.io/openstackhelm/heat:2024.1-ubuntu_jammy
       imagePullPolicy: IfNotPresent
       command:
         - sleep


### PR DESCRIPTION
I discovered the image `docker.io/openstackhelm/openstack-client:2024.1` weirdly does not contain all the openstackclient plugins, but only around half of them compared to the heat image. The missing plugins in the openstack-client:2024.1 image include the ironic baremetal commands, which we need.

docker.io/openstackhelm/openstack-client:2024.1:
```bash
root@openstack-admin-client:/# openstack help | wc -l
1078
```

docker.io/openstackhelm/heat:2024.1-ubuntu_jammy
```bash
root@4b6cd4b82159:/# openstack help | wc -l
2099
```