### PR TITLE
fix: dnsmasq: do not set default bootfile

### DIFF
--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -118,5 +118,4 @@ address=/{{ component }}.{{ env.DNS_ZONE }}/{{ env.INGRESS_IP }}
 {% endfor %}
 
 dhcp-option=option:dns-server,{{ env.get('DNS_IP', env['INGRESS_IP']) }}
-dhcp-boot=nonexistent.file
 # end of template


### PR DESCRIPTION
Now that we have the Ironic integration, the option 67 is set twice - once to 'nonexistent.file' and second time through the options file delivered by Ironic. In other words, the default is not overwritten but the second instance of the same option gets appended to the response.