### PR TITLE
feat: allow interface binding and drop specific version

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -73,7 +73,6 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,enable={{is_default_branch}}
-            type=raw,value=0.0.1
           labels: |
             org.opencontainers.image.title=dnsmasq for Ironic deployed as openstack-helm
       - name: build and deploy dnsmasq container to registry

--- a/components/ironic/dnsmasq-cm.yaml
+++ b/components/ironic/dnsmasq-cm.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: ironic-dnsmasq
 data:
+  # interface to listen on the host
+  PROVISIONER_INTERFACE: "eth0"
   # common separated list of DHCP tagged configs
   DHCP_TAGS: tag1
   # When defining the IP address range, make sure to include subnet

--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -41,6 +41,7 @@ spec:
                 matchLabels:
                   application: ironic
                   component: conductor
+      hostNetwork: true
       containers:
         - name: dnsmasq
           image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:latest

--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -62,6 +62,9 @@ spec:
             - name: dhcp
               containerPort: 67
               protocol: UDP
+            - name: tftp
+              containerPort: 69
+              protocol: UDP
           volumeMounts:
             - name: pod-tmp
               mountPath: /tmp

--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -43,8 +43,7 @@ spec:
                   component: conductor
       containers:
         - name: dnsmasq
-          image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:0.0.1
-          imagePullPolicy: IfNotPresent
+          image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:latest
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/containers/Dockerfile.dnsmasq
+++ b/containers/Dockerfile.dnsmasq
@@ -47,9 +47,5 @@ COPY dnsmasq/dnsmasq.conf.j2 /etc/dnsmasq.conf.j2
 # let our entry point write out the script
 RUN ln -sf /etc/dnsmasq.d/dnsmasq.conf /etc/dnsmasq.conf
 
-
-EXPOSE 1053/udp
-EXPOSE 1067/udp
-
 ENTRYPOINT ["/entry-point.sh"]
 CMD ["/usr/sbin/dnsmasq", "-d"]

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -10,8 +10,13 @@ log-facility=-
 # configs
 conf-dir=/etc/dnsmasq.d
 
+{% if env.PROVISIONER_INTERFACE is defined -%}
+interface={{ PROVISIONER_INTERFACE }}
+bind-dynamic
+{%- else -%}
 except-interface=lo
 bind-interfaces
+{%- endif %}
 
 # DNS port to listen on, set to 0 to disable
 port={{ env.DNS_PORT | default(53) }}
@@ -48,9 +53,9 @@ dhcp-circuitid=set:{{ tag }}{{ env[dhcp_circuitid] }}
 {% set tag = "" -%}
 {%- endif %}
 dhcp-range={{ tag }}{{ env[dhcp_range] }}
-shared-network=eth0,{{ env[dhcp_range].split(',')[0] }}
+shared-network={{ env.PROVISIONER_INTERFACE | default("eth0") }},{{ env[dhcp_range].split(',')[0] }}
 {% if env[dhcp_proxy] is defined -%}
-shared-network=eth0,{{ env[dhcp_proxy] }}
+shared-network={{ env.PROVISIONER_INTERFACE | default("eth0") }},{{ env[dhcp_proxy] }}
 {{ dhcp_proxy_list.append(env[dhcp_proxy]) or '' }}
 {%- endif %}
 {% for key, value in env.items() if key.startswith(dhcp_option) -%}


### PR DESCRIPTION
Allow dnsmasq to bind to a specific interface. Stop using the 0.0.1 version for the main branch and let the image pull policy default.