### PR TITLE
fix: dnsmasq: mount /var/lib/understack/master_iso_images

### DIFF
--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -73,6 +73,9 @@ spec:
               mountPath: /etc/dnsmasq.d
             - name: pod-dhcp
               mountPath: /var/lib/misc
+            - name: understack-images
+              mountPath: /var/lib/understack/master_iso_images
+              readOnly: true
       volumes:
         - name: pod-tmp
           emptyDir: {}
@@ -82,3 +85,6 @@ spec:
         - name: pod-dhcp
           persistentVolumeClaim:
             claimName: dnsmasq-dhcp
+        - name: understack-images
+          hostPath:
+            path: /var/lib/understack/master_iso_images

--- a/containers/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq.conf.j2
@@ -87,6 +87,7 @@ dhcp-proxy={{ dhcp_proxy_list|join(',') }}
 dhcp-allowed-srvids={{ dhcp_allowed_srvids_list|join(',') }}
 enable-tftp
 tftp-no-fail
+tftp-root={{ env['TFTP_DIR'] | default('/var/lib/understack/master_iso_images') }}
 
 # don't set to enable logging
 {% if env.LOG_DHCP_QUERIES | default(False, True) %}


### PR DESCRIPTION
Now that we are serving the TFTP from the dnsmasq container, this PR adds an option to configure a directory that is not part of the read-only root filesystem of the container, but uses a host mapped volume instead.