### PR TITLE
fix: dnsmasq debug dump to stderr

### DIFF
--- a/containers/dnsmasq/entry-point.sh
+++ b/containers/dnsmasq/entry-point.sh
@@ -11,7 +11,7 @@ mkdir -p /etc/dnsmasq.d/optsdir.d
 render_j2_file /etc/dnsmasq.conf.j2 /etc/dnsmasq.conf
 
 if [ -n "${DEBUG_DNSMASQ_CONF+x}" ]; then
-  cat /etc/dnsmasq.conf
+  cat /etc/dnsmasq.conf >&2
 fi
 
 /usr/sbin/dnsmasq --test


### PR DESCRIPTION
Instead of having a race between stdout/stderr in the entry-point, just output everything to stderr.