### PR TITLE
feat: update to latest helm chart version

### DIFF
--- a/apps/components/ironic.yaml
+++ b/apps/components/ironic.yaml
@@ -11,7 +11,7 @@ spec:
       ref: understack
     - repoURL: https://tarballs.opendev.org/openstack/openstack-helm/
       chart: ironic
-      targetRevision: 0.2.14
+      targetRevision: 0.2.15
       helm:
         releaseName: ironic
         valueFiles:


### PR DESCRIPTION
The helm chart has updates to allow us to disable the pxe and http container in the conductor. Since we're running dnsmasq ourselves for the pxe service so we need to be able to disable the one in the conductor.