### PR TITLE
fix: remove providing nautobot-env explicitly

### DIFF
--- a/components/nautobot/values.yaml
+++ b/components/nautobot/values.yaml
@@ -1,8 +1,6 @@
 ---
 
 nautobot:
-  extraEnvVarsSecret:
-    - nautobot-env
 
   db:
     engine: "django.db.backends.postgresql"
@@ -49,7 +47,6 @@ celery:
   replicaCount: 1
   extraEnvVarsSecret:
     - nautobot-django
-    - nautobot-env
 
 postgresql:
   enabled: false


### PR DESCRIPTION
The helm chart already includes this secret into the containers so we don't need to provide it as an extra secret because it is being double included.