### PR TITLE
fix: add file missed from 47bbb1437e

### DIFF
--- a/components/keystone/values.tpl.yaml
+++ b/components/keystone/values.tpl.yaml
@@ -1,0 +1,8 @@
+# add your values.yaml overrides for the helm chart here
+
+network:
+  api:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        cert-manager.io/cluster-issuer: ${DEPLOY_NAME}-cluster-issuer


### PR DESCRIPTION
In 47bbb1437e we needed to add the template for generating the ingress TLS settings for keystone.