### PR TITLE
docs: fix fmt and update secret wording for auth

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -71,7 +71,8 @@ kubectl --namespace dex \
     -o yaml > ${UC_DEPLOY}/secrets/${DEPLOY_NAME}/secret-oidc-sso-dex.yaml
 ```
 
-You must remember to commit this file to your `${UC_DEPLOY}` repo.
+You must remember to add this secret to your secret storage (e.g. for
+Kube Seal you must commit the sealed file to your `${UC_DEPLOY}` repo).
 
 ### Static Users
 
@@ -93,7 +94,7 @@ to different parts of the system. The default groups through the system are:
 To customize the administrator group set the following in your
 `helm-configs/${DEPLOY_NAME}/nautobot.yaml`
 
-```yaml title=helm-configs/${DEPLOY_NAME}/nautobot.yaml
+```yaml title="helm-configs/${DEPLOY_NAME}/nautobot.yaml"
 nautobot:
   extraEnvVars:
     # ignoring existing values here, don't remove


### PR DESCRIPTION
On the auth page the formatting at the end was busted. Update the wording around the secret storage to be clear about storing this data.