### PR TITLE
fix: search for integrated interfaces and adjust mac addr extraction

### DIFF
--- a/argo-workflows/nautobot-interface-sync/code/helpers.py
+++ b/argo-workflows/nautobot-interface-sync/code/helpers.py
@@ -58,6 +58,6 @@ def oob_sushy_session(oob_ip, oob_username, oob_password):
 
 def is_off_board(interface):
     return (
-        "Embedded" not in interface.location
-        and "Integrated" not in interface.name
+        "Embedded ALOM" in interface.location
+        or "Embedded" not in interface.location
     )


### PR DESCRIPTION
fix: search for integrated interfaces and adjust mac addr extraction

So as it turns out, Dell redfish is reporting "Integrated" interfaces, but these are actually add-ons so we need to include those when creating interfaces for servers in Nautobot.

Same case is for HP, these are using "Embedded ALOM" as one of their expansion ports.

In both cases, the only true onboard interfaces are designated as "Embedded",  which we filter out now correctly.

Another small issue this PR fixes is mac addr extraction, Dell in redfish is providing a list of all NIC mac addresses when querying the port, which is incorrect, so instead we now search in system resources to get the mac addr.