### PR TITLE
feat: Enable argo client auth mode and add service account for argo api usage

### DIFF
--- a/components/argo-events/argo-api-user.yaml
+++ b/components/argo-events/argo-api-user.yaml
@@ -9,6 +9,14 @@ rules:
   - argoproj.io
   resources:
   - workflows
+  verbs:
+  - list
+  - update
+  - create
+  - patch
+- apiGroups:
+  - argoproj.io
+  resources:
   - workflowtemplates
   verbs:
   - list

--- a/components/argo-events/argo-api-user.yaml
+++ b/components/argo-events/argo-api-user.yaml
@@ -9,6 +9,7 @@ rules:
   - argoproj.io
   resources:
   - workflows
+  - workflowtemplates
   verbs:
   - list
   - update

--- a/components/argo-events/argo-api-user.yaml
+++ b/components/argo-events/argo-api-user.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argoapi
+  namespace: argo-events
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - list
+  - update
+  - create
+  - patch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argoapi
+  namespace: argo-events
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argoapi
+  namespace: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argoapi
+subjects:
+- kind: ServiceAccount
+  name: argoapi
+  namespace: argo-events
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argoapi.service-account-token
+  annotations:
+    kubernetes.io/service-account.name: argoapi
+type: kubernetes.io/service-account-token

--- a/components/argo-events/kustomization.yaml
+++ b/components/argo-events/kustomization.yaml
@@ -22,3 +22,6 @@ resources:
   - workflow-role.yaml
 
   - configmaps.yaml
+
+  # adds argoapi service account user
+  - argo-api-user.yaml

--- a/components/argo-workflows/patch-server-deployment.yaml
+++ b/components/argo-workflows/patch-server-deployment.yaml
@@ -4,6 +4,7 @@
   value:
     - server
     - --auth-mode=sso
+    - --auth-mode=client
     - --namespaced
     - --managed-namespace
     - argo-events


### PR DESCRIPTION
1.) Enable `--auth-mode=client` in argo server
2.) Adds a service account user `argoapi` with argo permissions to query and use the api

https://argo-workflows.readthedocs.io/en/stable/access-token/
https://argo-workflows.readthedocs.io/en/release-3.5/faq/#token-not-valid-any-bearer-token-is-able-to-login-in-the-ui-or-use-the-api
https://github.com/argoproj/argo-workflows/issues/4991
https://github.com/argoproj/argo-workflows/issues/7490
