### PR TITLE
feat: Enable openstack ironic redfish-https boot interface.

### DIFF
--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -19,7 +19,7 @@ conf:
       enabled_deploy_interfaces: direct,ramdisk
       default_deploy_interface: direct
       enabled_bios_interfaces: no-bios,redfish
-      enabled_boot_interfaces: http-ipxe,http,redfish-virtual-media,ipxe,pxe
+      enabled_boot_interfaces: http-ipxe,http,redfish-virtual-media,redfish-https,ipxe,pxe
       enabled_hardware_types: ipmi,redfish,manual-management
       enabled_inspect_interfaces: redfish,no-inspect
       enabled_management_interfaces: noop,ipmitool,redfish


### PR DESCRIPTION
https://docs.openstack.org/ironic/latest/admin/drivers/redfish.html#redfish-http-s-boot