### PR TITLE
chore: Add ApplicationSet and Deployment for Undersync

### DIFF
--- a/apps/appsets/operators/service.yaml
+++ b/apps/appsets/operators/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: service/v1
+kind: Service
+metadata:
+  name: undersync-service
+  labels:
+    app: undersync
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: undersync

--- a/apps/appsets/operators/undersync.yaml
+++ b/apps/appsets/operators/undersync.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: undersync
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            argocd.argoproj.io/secret-type: cluster
+  template:
+    metadata:
+      name: '{{.name}}-undersync'
+    spec:
+      project: default
+      source:
+        repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
+        targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
+        path: 'components/undersync'
+      destination:
+        server: '{{.server}}'
+        namespace: 'undersync'
+      syncPolicy:
+        automated:
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/components/undersync/deployment.yaml
+++ b/components/undersync/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: undersync-deployment
+  labels:
+    app: undersync
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: undersync
+  template:
+    metadata:
+      labels:
+        app: undersync
+    spec:
+      containers:
+      - name: undersync
+        image: ghcr.io/rss-engineering/undersync/undersync:latest
+        ports:
+        - containerPort: 8080


### PR DESCRIPTION
Caveat:  I have no real idea what I'm doing with this stuff and I wasn't able to test this out.

https://rackspace.atlassian.net/browse/PUC-349

"Argo (understack) should reference undersync repo to get this deployed as one of the required apps. Doesn’t necessarily need to be through the app of apps, but needs to be deployed in the IAD Dev environment."