### PR TITLE
fix: bump OSH Neutron for Ironic auth

### DIFF
--- a/apps/appsets/openstack/openstack.yaml
+++ b/apps/appsets/openstack/openstack.yaml
@@ -21,7 +21,7 @@ spec:
                 - component: placement
                   chartVersion: 0.3.15
                 - component: neutron
-                  chartVersion: 0.3.44
+                  chartVersion: 0.3.45
                 - component: nova
                   chartVersion: 0.3.42
                 - component: horizon


### PR DESCRIPTION
Bump to pull in https://review.opendev.org/c/openstack/openstack-helm/+/923325 to fix Neutron auth to Ironic