### PR TITLE
Add ENV for undersync secret values

### DIFF
--- a/components/undersync/deployment.yaml
+++ b/components/undersync/deployment.yaml
@@ -19,3 +19,9 @@ spec:
         image: ghcr.io/rss-engineering/undersync/undersync:latest
         ports:
         - containerPort: 8080
+        env:
+          - name: RACK_ENV
+            value: "production"
+        envFrom:
+          - secretRef:
+            name: settings


### PR DESCRIPTION
When starting an undersync pod this should, in theory, inject the various secret values defined in a k8s secret called "settings" as environment variables.