### PR TITLE
fix: adjust workflow sensors filtering

### DIFF
--- a/argo-workflows/ironic-nautobot-sync/sensors/nautobot-interface-update-sensor.yaml
+++ b/argo-workflows/ironic-nautobot-sync/sensors/nautobot-interface-update-sensor.yaml
@@ -26,7 +26,7 @@ spec:
             value:
               - iLO
               - iDRAC
-          - path: body.data.ip_addresses.0
+          - path: body.data.ip_addresses.0.address
             type: string
             value:
               - .*

--- a/argo-workflows/nautobot-interface-sync/sensors/nautobot-interface-update-sensor-int-sync.yaml
+++ b/argo-workflows/nautobot-interface-sync/sensors/nautobot-interface-update-sensor-int-sync.yaml
@@ -28,7 +28,7 @@ spec:
           value:
             - iLO
             - iDRAC
-        - path: body.data.ip_addresses.0
+        - path: body.data.ip_addresses.0.address
           type: string
           value:
             - .*


### PR DESCRIPTION
These fields are actually objects and not strings. The intention was probably to ensure that there is an IP address assigned to this interface so this updates to check the 'address' key inside of the object for a value.