### PR TITLE
fix: bump external-secrets to get webhook fixes

### DIFF
--- a/operators/external-secrets/kustomization.yaml
+++ b/operators/external-secrets/kustomization.yaml
@@ -7,5 +7,5 @@ helmCharts:
   includeCRDs: true
   namespace: external-secrets
   releaseName: external-secrets
-  version: 0.9.19
+  version: 0.9.20
   repo: https://charts.external-secrets.io


### PR DESCRIPTION
There were some fixes with the webhook provider that were landed in 0.9.20 that we noticed in 0.9.19 so bump to the latest version to get those.