### PR TITLE
fix: Set OpenStack container image pull policy to Always

### DIFF
--- a/components/openstack-2024.1-jammy.yaml
+++ b/components/openstack-2024.1-jammy.yaml
@@ -1,5 +1,8 @@
 ---
 images:
+  # imagePullPolicy
+  pull_policy: "Always"
+
   tags:
     # these are common across all these OpenStack Helm installations
     bootstrap: "docker.io/openstackhelm/heat:2024.1-ubuntu_jammy"


### PR DESCRIPTION
When openstack updates the image in docker, such as for image docker.io/openstackhelm/neutron:2024.1-ubuntu_jammy, the default image pull policy of IfNotPresent prevents us from getting upstream improvements and bug fixes if the image is already cached in kubernetes. This change forces pulling images to ensure we're getting the latest upstream patches.