### PR TITLE
fix: revert Ironic support iDRAC and iLO Redfish OEM interfaces

### DIFF
--- a/containers/Dockerfile.ironic
+++ b/containers/Dockerfile.ironic
@@ -8,5 +8,3 @@ RUN apt-get update && \
         genisoimage \
         isolinux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache sushy-oem-idrac==5.0.0 proliantutils==2.16.2


### PR DESCRIPTION
Reverts rackerlabs/understack#170. Causing the pod to crash.