### PR TITLE
fix: Ironic support iDRAC and iLO Redfish OEM interfaces

### DIFF
--- a/containers/Dockerfile.ironic
+++ b/containers/Dockerfile.ironic
@@ -8,3 +8,4 @@ RUN apt-get update && \
         genisoimage \
         isolinux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN /var/lib/openstack/bin/python -m pip install --no-cache sushy-oem-idrac==5.0.0 proliantutils==2.16.2


### PR DESCRIPTION
The iLO and iDRAC specific backends require the OEM interface packages to be functional.