### PR TITLE
fix: remove proliant OEM driver for Ironic

### DIFF
--- a/containers/Dockerfile.ironic
+++ b/containers/Dockerfile.ironic
@@ -8,4 +8,4 @@ RUN apt-get update && \
         genisoimage \
         isolinux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN /var/lib/openstack/bin/python -m pip install --no-cache sushy-oem-idrac==5.0.0 proliantutils==2.16.2
+RUN /var/lib/openstack/bin/python -m pip install --no-cache sushy-oem-idrac==5.0.0


### PR DESCRIPTION
The container is crashing with no output when it attempts to load hardware types so remove the proliant bits as a guess.