### PR TITLE
fix: add deps dir from generic argo wf

### DIFF
--- a/apps/appsets/workflows.yaml
+++ b/apps/appsets/workflows.yaml
@@ -23,7 +23,7 @@ spec:
           path: 'argo-workflows'
           directory:
             recurse: true
-            include: '{shared-sensors/*.yaml,*/sensors/*.yaml,*/workflowtemplates/*.yaml}'
+            include: '{generic/deps/*.yaml,shared-sensors/*.yaml,*/sensors/*.yaml,*/workflowtemplates/*.yaml}'
             exclude: '{example-feature/*,*/*/*example*}'
         - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
           targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'


### PR DESCRIPTION
We have removed the deps dir from appset workflow yaml as the files in them supposed to be overwritten from external repos and are left there as an example how the yamls should look like. The generic deps directory files however are needed.