### PR TITLE
fix: Ironic enable iDRAC virtual media and remove unnecessary interfaces

### DIFF
--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -22,7 +22,7 @@ conf:
       # systems need
       default_deploy_interface: direct
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo
-      enabled_boot_interfaces: http-ipxe,http,ipxe,pxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-pxe,ilo-ipxe
+      enabled_boot_interfaces: http-ipxe,ipxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-ipxe
       enabled_deploy_interfaces: direct,ramdisk
       enabled_firmware_interfaces: no-firmware,redfish
       enabled_hardware_types: redfish,ipmi,idrac,ilo5,ilo,manual-management

--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -24,14 +24,14 @@ conf:
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo
       enabled_boot_interfaces: http-ipxe,ipxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-ipxe
       enabled_deploy_interfaces: direct,ramdisk
-      enabled_firmware_interfaces: no-firmware,redfish
-      enabled_hardware_types: redfish,ipmi,idrac,ilo5,ilo,manual-management
-      enabled_inspect_interfaces: redfish,no-inspect,inspector,idrac-redfish,ilo
-      enabled_management_interfaces: noop,ipmitool,redfish,idrac-redfish,ilo,ilo5
+      enabled_firmware_interfaces: redfish
+      enabled_hardware_types: redfish,idrac,ilo5,ilo
+      enabled_inspect_interfaces: redfish,inspector,idrac-redfish,ilo
+      enabled_management_interfaces: ipmitool,redfish,idrac-redfish,ilo,ilo5
       enabled_network_interfaces: noop,neutron
-      enabled_power_interfaces: fake,redfish,ipmitool,idrac-redfish,ilo
-      enabled_raid_interfaces: no-raid,redfish,idrac-redfish,ilo5
-      enabled_vendor_interfaces: no-vendor,redfish,ipmitool,idrac-redfish,ilo
+      enabled_power_interfaces: redfish,ipmitool,idrac-redfish,ilo
+      enabled_raid_interfaces: redfish,idrac-redfish,ilo5
+      enabled_vendor_interfaces: redfish,ipmitool,idrac-redfish,ilo
     conductor:
       automated_clean: false
     dhcp:

--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -22,7 +22,7 @@ conf:
       # systems need
       default_deploy_interface: direct
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo
-      enabled_boot_interfaces: http-ipxe,http,ipxe,pxe,redfish-virtual-media,redfish-https,ilo-virtual-media,ilo-uefi-https,ilo-pxe,ilo-ipxe
+      enabled_boot_interfaces: http-ipxe,http,ipxe,pxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-pxe,ilo-ipxe
       enabled_deploy_interfaces: direct,ramdisk
       enabled_firmware_interfaces: no-firmware,redfish
       enabled_hardware_types: redfish,ipmi,idrac,ilo5,ilo,manual-management


### PR DESCRIPTION
When we use the iDRAC driver in Ironic and need to use the virtual media boot interface, we must use the idrac-redfish-virtual-media interface which wasn't enabled. So enable it. At the same time scrape the list to better target what we want to support and use going forward.