### PR TITLE
fix: Enable agent raid interface for Ironic

### DIFF
--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -30,7 +30,7 @@ conf:
       enabled_management_interfaces: ipmitool,redfish,idrac-redfish,ilo,ilo5
       enabled_network_interfaces: noop,neutron
       enabled_power_interfaces: redfish,ipmitool,idrac-redfish,ilo
-      enabled_raid_interfaces: redfish,idrac-redfish,ilo5
+      enabled_raid_interfaces: redfish,idrac-redfish,ilo5,agent
       enabled_vendor_interfaces: redfish,ipmitool,idrac-redfish,ilo
     conductor:
       automated_clean: false


### PR DESCRIPTION
ilo hw type requires agent or no-raid raid interface