### PR TITLE
feat: enable new ironic inspector and enable LLDP data from it

### DIFF
--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -41,6 +41,9 @@ conf:
     pxe:
       images_path: /var/lib/understack/master_iso_images
       instance_master_path: /var/lib/understack/master_iso_images
+    inspector:
+      extra_kernel_params: ipa-collect-lldp=1
+      hooks: "$default_hooks,parse-lldp,local-link-connection,physical-network"
 
 endpoints:
   oslo_messaging:

--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -26,7 +26,7 @@ conf:
       enabled_deploy_interfaces: direct,ramdisk
       enabled_firmware_interfaces: redfish,no-firmware
       enabled_hardware_types: redfish,idrac,ilo5,ilo
-      enabled_inspect_interfaces: redfish,inspector,idrac-redfish,ilo
+      enabled_inspect_interfaces: redfish,agent,idrac-redfish,ilo
       enabled_management_interfaces: ipmitool,redfish,idrac-redfish,ilo,ilo5
       enabled_network_interfaces: noop,neutron
       enabled_power_interfaces: redfish,ipmitool,idrac-redfish,ilo


### PR DESCRIPTION
Enable the new ironic inspector that is in tree and enable the hooks necessary to run LLDP and populate data about our devices from that LLDP data.

see the following for more info:
https://docs.openstack.org/ironic/latest/admin/inspection.html
https://docs.openstack.org/ironic/latest/admin/inspection/managed.html
https://docs.openstack.org/ironic/latest/admin/inspection/hooks.html