### PR TITLE
Nova/Neutron integration

### DIFF
--- a/components/argo-events/kustomization.yaml
+++ b/components/argo-events/kustomization.yaml
@@ -27,3 +27,6 @@ resources:
   - workflow-role.yaml
 
   - configmaps.yaml
+
+  ## allow neutron's service account to submit workflows
+  - svc-neutron.yaml

--- a/components/argo-events/svc-neutron.yaml
+++ b/components/argo-events/svc-neutron.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: neutron-svc-user
+  namespace: argo-events
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - list
+  - get
+  - create
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtemplates
+  verbs:
+  - list
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: neutron-svc-user
+  namespace: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: neutron-svc-user
+subjects:
+- kind: ServiceAccount
+  name: neutron-server
+  namespace: openstack

--- a/components/argo-workflows/patch-server-deployment.yaml
+++ b/components/argo-workflows/patch-server-deployment.yaml
@@ -4,6 +4,7 @@
   value:
     - server
     - --auth-mode=sso
+    - --auth-mode=client
     - --namespaced
     - --managed-namespace
     - argo-events

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -25,11 +25,6 @@ bootstrap:
     openstack project create undercloud --or-show
     openstack user create --project undercloud --password demo argoworkflow --or-show
     openstack role add --user argoworkflow --project undercloud member
-    # ironic-neutron-agent user
-    # TODO: investigate if we can use 'ironic' user for this.
-    openstack user create --project service --domain service --password ironic-neutron-password ironic-neutron-agent --or-show
-    openstack role add --domain service --user ironic-neutron-agent --user-domain service  service
-    openstack role add --project service --project-domain service --user ironic-neutron-agent --user-domain service member
     # allow ironic user to see servers in undercloud project
     openstack role add --project undercloud --user ironic --user-domain service  member
     # add 'demo' user to have 'member' role, needed for horizon dashboard use

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -27,6 +27,7 @@ bootstrap:
     openstack role add --user argoworkflow --project undercloud member
     # allow ironic user to see servers in undercloud project
     openstack role add --project undercloud --user ironic --user-domain service  member
+    openstack role add --project service --user ironic --user-domain service service
     # add 'demo' user to have 'member' role, needed for horizon dashboard use
     openstack role add --user demo --project undercloud member
 

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -28,9 +28,8 @@ bootstrap:
     # ironic-neutron-agent user
     # TODO: investigate if we can use 'ironic' user for this.
     openstack user create --project service --domain service --password ironic-neutron-password ironic-neutron-agent --or-show
-    openstack role add --domain service --user ironic-neutron-agent service
+    openstack role add --domain service --user ironic-neutron-agent --user-domain service  service
     openstack role add --project service --project-domain service --user ironic-neutron-agent --user-domain service member
-
     # allow ironic user to see servers in undercloud project
     openstack role add --project undercloud --user ironic --user-domain service  member
     # add 'demo' user to have 'member' role, needed for horizon dashboard use

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -30,6 +30,9 @@ bootstrap:
     openstack user create --project service --domain service --password ironic-neutron-password ironic-neutron-agent --or-show
     openstack role add --domain service --user ironic-neutron-agent service
     openstack role add --project service --project-domain service --user ironic-neutron-agent --user-domain service member
+
+    # allow ironic user to see servers in undercloud project
+    openstack role add --project undercloud --user ironic --user-domain service  member
     # add 'demo' user to have 'member' role, needed for horizon dashboard use
     openstack role add --user demo --project undercloud member
 

--- a/python/neutron-understack/neutron_understack/argo/workflows.py
+++ b/python/neutron-understack/neutron_understack/argo/workflows.py
@@ -1,0 +1,81 @@
+import requests
+import time
+import urllib3
+
+urllib3.disable_warnings()
+
+
+class ArgoClient:
+    def __init__(
+        self,
+        token: str,
+        namespace="argo-events",
+        api_url="https://argo-server.argo.svc.cluster.local:2746",
+    ):
+        self.token = token
+        self.namespace = namespace
+        self.api_url = api_url
+        self.headers = {"Authorization": f"Bearer {self.token}"}
+
+    def submit(
+        self,
+        template_name: str,
+        entrypoint: str,
+        parameters: dict,
+        service_account="default",
+    ):
+        json_body = self.__request_body(
+            template_name, entrypoint, parameters, service_account
+        )
+
+        response = requests.post(
+            f"{self.api_url}/api/v1/workflows/{self.namespace}/submit",
+            headers=self.headers,
+            json=json_body,
+            verify=False,
+        )
+        response.raise_for_status()
+        print(response.json())
+        return response
+
+    def submit_wait(self, *args, **kwargs):
+        max_attempts = kwargs.pop("max_attempts", 20)
+        response = self.submit(*args, **kwargs)
+        workflow_name = response.json()["metadata"]["name"]
+        result = None
+        for i in range(1, max_attempts + 1):
+            print(f"Workflow: {workflow_name} retry {i}/{max_attempts}")
+            time.sleep(5)
+            result = self.check_status(workflow_name)
+            if result in ["Succeeded", "Failed", "Error"]:
+                break
+        return result
+
+    def check_status(self, name: str):
+        response = requests.get(
+            f"{self.api_url}/api/v1/workflows/{self.namespace}/{name}",
+            headers=self.headers,
+            json={"fields": "status.phase"},
+            verify=False,
+        )
+        response.raise_for_status()
+        return response.json()["status"]["phase"]
+
+    def __request_body(
+        self,
+        template_name: str,
+        entrypoint: str,
+        parameters: dict,
+        service_account: str,
+    ):
+        return {
+            "resourceKind": "WorkflowTemplate",
+            "namespace": self.namespace,
+            "resourceName": template_name,
+            "submitOptions": {
+                "labels": f"workflows.argoproj.io/workflow-template={template_name}",
+                "parameters": [f"{k}={v}" for k, v in parameters.items()],
+                "entryPoint": entrypoint,
+                "serviceAccount": service_account,
+            },
+        }

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -3,6 +3,7 @@ import logging
 import typing
 import uuid
 
+from pprint import pprint
 from neutron_lib.plugins.ml2.api import MechanismDriver, NetworkContext, PortContext, SubnetContext
 
 LOG = logging.getLogger(__name__)
@@ -76,7 +77,13 @@ def log_call(method: str, context: typing.Union[NetworkContext, SubnetContext, P
         )
         return
     LOG.info("%s method called with data: %s", method, jsondata)
-    LOG.debug("%s method executed with context: %s", method, context.current)
+    LOG.debug("%s method executed with context:", method)
+    # for chunk in chunked(str(context.current), 750):
+    pprint(context.current)
+
+
+def chunked(inputstr, length):
+    return (inputstr[0 + i : length + i] for i in range(0, len(inputstr), length))
 
 
 class UnderstackDriver(MechanismDriver):


### PR DESCRIPTION
This PR is related to PUC-414 and PUC-354. 

Summary:

- keystone changes to make sure that `nova-compute-ironic` agent works correctly and Nova can talk to the Ironic
- bunch of changes to our custom ML2 plugin:
   - better debug logging
   - ability to trigger Argo Workflows through Argo Server API

Depends on changes in `undercloud-deploy` `neutron-jul24` branch (PR coming shortly).