### PR TITLE
fix: stop using device name for interface sync

### DIFF
--- a/argo-workflows/shared-sensors/nb-oob-interface-update-sensor.yaml
+++ b/argo-workflows/shared-sensors/nb-oob-interface-update-sensor.yaml
@@ -63,8 +63,8 @@ spec:
                   parameters:
                     - name: interface_update_event
                       value: Some nautobot interface has changed
-                    - name: device_hostname
-                      value: hostname of the device that event is for
+                    - name: device_id
+                      value: device id that event is for
                     - name: hostname
                       value: to support other workflows that references hostname
                 entrypoint: start

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-nb-server-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-nb-server-to-ironic.yaml
@@ -8,7 +8,7 @@ spec:
     parameters:
       - name: interface_update_event
         value: Some nautobot interface has changed
-      - name: device_hostname
+      - name: hostname
         value: hostname of the device that event is for
   templates:
     - name: main

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-obm-creds.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-obm-creds.yaml
@@ -18,7 +18,7 @@ spec:
             arguments:
               parameters:
                 - name: hostname
-                  value: '{{workflow.parameters.device_hostname}}'
+                  value: '{{workflow.parameters.hostname}}'
         - - name: synchronize-obm-creds
             template: synchronize-obm-creds
             arguments:

--- a/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-interfaces-to-nautobot.yaml
+++ b/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-interfaces-to-nautobot.yaml
@@ -5,7 +5,7 @@ kind: WorkflowTemplate
 spec:
   arguments:
     parameters:
-      - name: hostname
+      - name: device_id
         value: "{}"
       - name: oob_secret
         value: "{}"
@@ -15,7 +15,7 @@ spec:
         image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
         command:
           - sync-nautobot-interfaces
-        args: ["--hostname", "{{workflow.parameters.device_hostname}}"]
+        args: ["--device-id", "{{workflow.parameters.device_id}}"]
         volumeMounts:
           - mountPath: /etc/nb-token/
             name: nb-token

--- a/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-srv-redfish-intfs-to-nb.yaml
+++ b/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-srv-redfish-intfs-to-nb.yaml
@@ -6,6 +6,8 @@ spec:
   entrypoint: main
   arguments:
     parameters:
+      - name: device_id
+        value: "{}"
       - name: hostname
         value: "{}"
   templates:
@@ -18,7 +20,7 @@ spec:
             arguments:
               parameters:
                 - name: hostname
-                  value: "{{workflow.parameters.device_hostname}}"
+                  value: "{{workflow.parameters.hostname}}"
         - - name: get-obm-creds-secret
             templateRef:
               name: get-obm-creds
@@ -26,14 +28,14 @@ spec:
             arguments:
               parameters:
                 - name: hostname
-                  value: "{{workflow.parameters.device_hostname}}"
+                  value: "{{workflow.parameters.hostname}}"
         - - name: synchronize-interfaces-to-nautobot
             templateRef:
               name: sync-interfaces-to-nautobot
               template: synchronize-interfaces
             arguments:
               parameters:
-                - name: hostname
-                  value: "{{workflow.parameters.device_hostname}}"
+                - name: device_id
+                  value: "{{workflow.parameters.device_id}}"
                 - name: oob_secret
                   value: "{{steps.get-obm-creds-secret.outputs.parameters.secret}}"

--- a/python/understack-workflows/tests/test_sync_nautobot_interfaces.py
+++ b/python/understack-workflows/tests/test_sync_nautobot_interfaces.py
@@ -1,0 +1,23 @@
+import uuid
+
+import pytest
+
+from understack_workflows.main.sync_nautobot_interfaces import argument_parser
+
+
+@pytest.fixture
+def device_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+def test_parse_device_name():
+    parser = argument_parser(__name__)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--device-id", "FOO"])
+
+
+def test_parse_device_id(device_id):
+    parser = argument_parser(__name__)
+    args = parser.parse_args(["--device-id", str(device_id)])
+
+    assert args.device_id == device_id

--- a/python/understack-workflows/understack_workflows/helpers.py
+++ b/python/understack-workflows/understack_workflows/helpers.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 import pathlib
 from functools import partial
 
@@ -22,18 +21,6 @@ def setup_logger(name: str | None = None, level: int = logging.DEBUG):
         level=logging.DEBUG,
     )
     return logging.getLogger(name)
-
-
-def arg_parser(name):
-    parser = argparse.ArgumentParser(
-        prog=os.path.basename(name), description="Nautobot Interface sync"
-    )
-    parser.add_argument("--hostname", required=True, help="Nautobot device name")
-    parser.add_argument("--oob_username", required=False, help="OOB username")
-    parser.add_argument("--oob_password", required=False, help="OOB password")
-    parser.add_argument("--nautobot_url", required=False)
-    parser.add_argument("--nautobot_token", required=False)
-    return parser
 
 
 def boolean_args(val):

--- a/python/understack-workflows/understack_workflows/main/sync_nautobot_interfaces.py
+++ b/python/understack-workflows/understack_workflows/main/sync_nautobot_interfaces.py
@@ -1,4 +1,7 @@
-from understack_workflows.helpers import arg_parser
+import argparse
+import os
+from uuid import UUID
+
 from understack_workflows.helpers import credential
 from understack_workflows.helpers import is_off_board
 from understack_workflows.helpers import oob_sushy_session
@@ -8,21 +11,32 @@ from understack_workflows.nautobot import Nautobot
 
 logger = setup_logger(__name__)
 
+DEFAULT_NB_URL = "http://nautobot-default.nautobot.svc.cluster.local"
 
-def main():
-    parser = arg_parser(__file__)
-    args = parser.parse_args()
 
-    default_nb_url = "http://nautobot-default.nautobot.svc.cluster.local"
-    device_name = args.hostname
-    nb_url = args.nautobot_url or default_nb_url
-    nb_token = args.nautobot_token or credential("nb-token", "token")
-    oob_username = args.oob_username or credential("oob-secrets", "username")
-    oob_password = args.oob_password or credential("oob-secrets", "password")
+def argument_parser(name):
+    parser = argparse.ArgumentParser(
+        prog=os.path.basename(name), description="Nautobot Interface sync"
+    )
+    parser.add_argument(
+        "--device-id", type=UUID, required=True, help="Nautobot device ID"
+    )
+    parser.add_argument("--oob_username", required=False, help="OOB username")
+    parser.add_argument("--oob_password", required=False, help="OOB password")
+    parser.add_argument(
+        "--nautobot_url",
+        required=False,
+        help="Nautobot API %(default)s",
+        default=DEFAULT_NB_URL,
+    )
+    parser.add_argument("--nautobot_token", required=False)
+    return parser
 
+
+def do_sync(device_id: UUID, nb_url: str, nb_token: str, bmc_user: str, bmc_pass: str):
     nautobot = Nautobot(nb_url, nb_token, logger=logger)
-    oob_ip = nautobot.device_oob_ip(device_name)
-    oob = oob_sushy_session(oob_ip, oob_username, oob_password)
+    oob_ip = nautobot.device_oob_ip(device_id)
+    oob = oob_sushy_session(oob_ip, bmc_user, bmc_pass)
 
     chassis = Chassis.from_redfish(oob)
 
@@ -30,7 +44,18 @@ def main():
         interface for interface in chassis.network_interfaces if is_off_board(interface)
     ]
 
-    nautobot.bulk_create_interfaces(device_name, interfaces)
+    nautobot.bulk_create_interfaces(device_id, interfaces)
+
+
+def main():
+    parser = argument_parser(__file__)
+    args = parser.parse_args()
+
+    nb_token = args.nautobot_token or credential("nb-token", "token")
+    bmc_user = args.oob_username or credential("oob-secrets", "username")
+    bmc_pass = args.oob_password or credential("oob-secrets", "password")
+
+    do_sync(args.device_id, args.nautobot_url, nb_token, bmc_user, bmc_pass)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use the device ID / UUID which is a better identifier for us to use to find the device to sync the interfaces for. This saves us a trip to the Nautobot DB as well. In Nautobot the device name does not have to be unique so this avoids possible issues there. Added tests of the parser to make sure we get the correct data. Added types so we can have better tests in the future. Cleaned up the duplicate hostname usage in the workflow as well.