### PR TITLE
feat: use External Secrets to configure SSO for apps

### DIFF
--- a/apps/appsets/argocd.yaml
+++ b/apps/appsets/argocd.yaml
@@ -23,6 +23,8 @@ spec:
         path: bootstrap/argocd/
         targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
         kustomize:
+          components:
+            - components/sso
           patches:
             - target:
                 kind: ConfigMap

--- a/bootstrap/argocd/components/sso/external-secret-argocd-sso.yaml
+++ b/bootstrap/argocd/components/sso/external-secret-argocd-sso.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argocd-sso
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: dex
+  target:
+    name: argocd-sso
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          app.kubernetes.io/part-of: argocd
+      data:
+        client-id: "{{ .client_id }}"
+        client-secret: "{{ .client_secret }}"
+        issuer: "{{ .issuer }}"
+  data:
+  - secretKey: client_id
+    remoteRef:
+      key: argocd-sso
+      property: client-id
+  - secretKey: client_secret
+    remoteRef:
+      key: argocd-sso
+      property: client-secret
+  - secretKey: issuer
+    remoteRef:
+      key: argocd-sso
+      property: issuer

--- a/bootstrap/argocd/components/sso/kustomization.yaml
+++ b/bootstrap/argocd/components/sso/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - external-secret-argocd-sso.yaml
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: argocd-cm
+    patch: |-
+      - op: replace
+        path: /data/oidc.config
+        value: |-
+          name: SSO
+          issuer: $argocd-sso:issuer
+          clientID: $argocd-sso:client-id
+          clientSecret: $argocd-sso:client-secret
+          requestedIDTokenClaims: {"groups": {"essential": true}}

--- a/bootstrap/argocd/values.yaml
+++ b/bootstrap/argocd/values.yaml
@@ -13,12 +13,6 @@ server:
 configs:
   cm:
     kustomize.buildOptions: --enable-helm
-    oidc.config: |
-      name: SSO
-      issuer: $argocd-sso:issuer
-      clientID: $argocd-sso:client-id
-      clientSecret: $argocd-sso:client-secret
-      requestedIDTokenClaims: {"groups": {"essential": true}}
   rbac:
     policy.csv: |
       g, ucadmin, role:admin

--- a/components/dex/secretstore-dex.yaml
+++ b/components/dex/secretstore-dex.yaml
@@ -24,6 +24,10 @@ rules:
   - get
   - list
   - watch
+  resourceNames:
+  - argo-sso
+  - argocd-sso
+  - nautobot-sso
 - apiGroups:
   - authorization.k8s.io
   resources:

--- a/components/nautobot/external-secret-nautobot-sso.yaml
+++ b/components/nautobot/external-secret-nautobot-sso.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: nautobot-sso
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: dex
+  target:
+    name: nautobot-sso
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      engineVersion: v2
+      data:
+        # need to re-generate secrets first
+        # client-id: "{{ .client_id }}"
+        client-secret: "{{ .client_secret }}"
+  data:
+  - secretKey: client_secret
+    remoteRef:
+      key: nautobot-sso
+      property: client-secret

--- a/components/nautobot/kustomization.yaml
+++ b/components/nautobot/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - postgres-nautobot.yaml
   - secretstore-nautobot.yaml
+  - external-secret-nautobot-sso.yaml
 
 helmCharts:
 - name: redis

--- a/docs/gitops-install.md
+++ b/docs/gitops-install.md
@@ -174,13 +174,7 @@ At this point we will use our configs to make the actual deployment.
 Make sure everything you've committed to your deployment repo is pushed
 to your git server so that ArgoCD can access it.
 
-Configure ArgoCD to be able to authenticate against Dex IdP.
-
-```bash
-kubectl -n argocd apply -f "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/argocd/secret-argocd-sso-argocd.yaml"
-```
-
-Then configure your ArgoCD to be aware of your cluster:
+Configure your ArgoCD to be aware of your cluster:
 
 ```bash
 kubectl -n argocd apply -f "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/argocd/secret-*-cluster.yaml"

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -123,16 +123,15 @@ kubectl --namespace nautobot \
     | secret-seal-stdin "${DEST_DIR}/secret-nautobot-redis.yaml"
 
 NAUTOBOT_SSO_SECRET=$(./scripts/pwgen.sh)
-for ns in nautobot dex; do
-  [ ! -f "${DEST_DIR}/secret-nautobot-sso-$ns.yaml" ] && \
-  kubectl --namespace $ns \
-    create secret generic nautobot-sso \
-    --dry-run=client \
-    -o yaml \
-    --type Opaque \
-    --from-literal=client-secret="$NAUTOBOT_SSO_SECRET" \
-    | secret-seal-stdin "${DEST_DIR}/secret-nautobot-sso-$ns.yaml"
-done
+[ ! -f "${DEST_DIR}/secret-nautobot-sso-dex.yaml" ] && \
+kubectl --namespace dex \
+  create secret generic nautobot-sso \
+  --dry-run=client \
+  -o yaml \
+  --type Opaque \
+  --from-literal=client-secret="$NAUTOBOT_SSO_SECRET" \
+  --from-literal=client-id=nautobot \
+  | secret-seal-stdin "${DEST_DIR}/secret-nautobot-sso-dex.yaml"
 unset NAUTOBOT_SSO_SECRET
 
 ARGO_SSO_SECRET=$(./scripts/pwgen.sh)

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -147,22 +147,18 @@ kubectl --namespace dex \
 unset ARGO_SSO_SECRET
 
 ARGOCD_SSO_SECRET=$(./scripts/pwgen.sh)
-for ns in argocd dex; do
-  [ ! -f "${DEST_DIR}/secret-argocd-sso-$ns.yaml" ] && \
-  kubectl --namespace $ns \
-    create secret generic argocd-sso \
-    --dry-run=client \
-    -o yaml \
-    --type Opaque \
-    --from-literal=issuer="https://dex.${DNS_ZONE}" \
-    --from-literal=client-secret="$ARGOCD_SSO_SECRET" \
-    --from-literal=client-id=argocd \
-    | yq '.metadata.labels |= {"app.kubernetes.io/part-of": "argocd"}' \
-    | secret-seal-stdin "${DEST_DIR}/secret-argocd-sso-$ns.yaml"
-done
+[ ! -f "${DEST_DIR}/secret-argocd-sso-dex.yaml" ] && \
+kubectl --namespace dex \
+  create secret generic argocd-sso \
+  --dry-run=client \
+  -o yaml \
+  --type Opaque \
+  --from-literal=issuer="https://dex.${DNS_ZONE}" \
+  --from-literal=client-secret="$ARGOCD_SSO_SECRET" \
+  --from-literal=client-id=argocd \
+  | secret-seal-stdin "${DEST_DIR}/secret-argocd-sso-dex.yaml"
 unset ARGOCD_SSO_SECRET
 mkdir -p "${DEST_DIR}/cluster/"
-mv -f "${DEST_DIR}/secret-argocd-sso-argocd.yaml" "${DEST_DIR}/cluster/"
 
 # create constant OpenStack memcache key to avoid cache invalidation on deploy
 export MEMCACHE_SECRET_KEY="$(./scripts/pwgen.sh 64)"


### PR DESCRIPTION
Instead of having to duplicate the SSO secrets between the dex namespace and the application specific namespaces, use the External Secrets Operator to copy it and keep it in sync for us. Broke up the ArgoCD SSO configuration into its own component to not have it broken on initial deploy and have to restart. This simplifies the docs as well.