### PR TITLE
feat: set interface/port names in ironic

### DIFF
--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -34,4 +34,3 @@ jobs:
         with:
           coverageFile: python/understack-workflows/coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          sourceDir: python/understack-workflows

--- a/python/understack-workflows/understack_workflows/main/synchronize_interfaces.py
+++ b/python/understack-workflows/understack_workflows/main/synchronize_interfaces.py
@@ -24,15 +24,13 @@ def get_nautobot_interfaces(device_id: UUID) -> list[PortConfiguration]:
     nautobot = pynautobot.api(nautobot_api, nautobot_token)
     interfaces = nautobot.dcim.interfaces.filter(device_id=device_id)
 
-    ports = []
-    for i in interfaces:
-        if i.mac_address:
-            ports.append(
-                PortConfiguration(
-                    node_uuid=str(device_id), address=i.mac_address, uuid=i.id
-                )
-            )
-    return ports
+    return [
+        PortConfiguration(
+            node_uuid=str(device_id), address=i.mac_address, uuid=i.id, name=i.name
+        )
+        for i in interfaces
+        if i.mac_address
+    ]
 
 
 def get_patch(nautobot_port: PortConfiguration, port: Port) -> list:

--- a/python/understack-workflows/understack_workflows/port_configuration.py
+++ b/python/understack-workflows/understack_workflows/port_configuration.py
@@ -10,3 +10,4 @@ class PortConfiguration(BaseModel):
     ]  # ironicclient's Port class lowercases this attribute
     uuid: str  # using a str here to due to ironicclient Port attribute
     node_uuid: str  # using a str here due to ironicclient Port attribute
+    name: str  # port name


### PR DESCRIPTION
Set the nautobot interface name on the corresponding ironic port on the node.