### PR TITLE
chore: workflows: add annotations for easier locating

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -34,3 +34,15 @@ jobs:
             kubectl kustomize --enable-helm "${item}" | \
               kubeconform -skip=Secret -strict -ignore-missing-schemas
           done
+
+  workflows-description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: thiagodnf/yaml-schema-checker@v0.0.12
+        with:
+          jsonSchemaFile: argo-workflows/.workflow_with_description.schema.json
+          yamlFiles: |
+            argo-workflows/**/workflowtemplates/*.y*ml
+            argo-workflows/**/sensors/*.y*ml
+            argo-workflows/**/workflows/*.y*ml

--- a/argo-workflows/.workflow_with_description.schema.json
+++ b/argo-workflows/.workflow_with_description.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "properties": {
+            "workflows.argoproj.io/description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workflows.argoproj.io/description"
+          ]
+        }
+      },
+      "required": [
+        "annotations"
+      ]
+    }
+  },
+  "required": [
+    "metadata"
+  ]
+}

--- a/argo-workflows/generic/workflowtemplates/get-device-nautobot.yaml
+++ b/argo-workflows/generic/workflowtemplates/get-device-nautobot.yaml
@@ -5,7 +5,8 @@ metadata:
   name: get-device-nautobot
   namespace: argo-events
   annotations:
-    workflows.argoproj.io/description: Return Device Information from Nautobot
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/generic/workflowtemplates/get-device-nautobot.yaml`. Return Device Information from Nautobot
 spec:
   serviceAccountName: workflow
   entrypoint: main

--- a/argo-workflows/generic/workflowtemplates/get-obm-creds.yaml
+++ b/argo-workflows/generic/workflowtemplates/get-obm-creds.yaml
@@ -4,7 +4,9 @@ metadata:
   name: get-obm-creds
   namespace: argo-events
   annotations:
-    workflows.argoproj.io/description: An example template to return the name of a Kubernetes Secret which containing device's OBM credentials.
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/generic/workflowtemplates/get-obm-creds.yaml`.
+      An example template to return the name of a Kubernetes Secret which containing device's OBM credentials.
 spec:
   # garbage collection on the secret is tied to this pod. we remove this pod only after workflow completion to
   # allow access to this secret from subsequent workflow/steps.

--- a/argo-workflows/generic/workflowtemplates/get-obm-ip.yaml
+++ b/argo-workflows/generic/workflowtemplates/get-obm-ip.yaml
@@ -4,7 +4,9 @@ metadata:
   name: get-obm-ip
   namespace: argo-events
   annotations:
-    workflows.argoproj.io/description: Get OBM IP address for target Device
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/generic/workflowtemplates/get-obm-creds.yaml`.
+      Get OBM IP address for target Device
 spec:
   serviceAccountName: workflow
   entrypoint: main

--- a/argo-workflows/generic/workflowtemplates/nautobot-api.yaml
+++ b/argo-workflows/generic/workflowtemplates/nautobot-api.yaml
@@ -5,7 +5,9 @@ metadata:
   name: nautobot-api
   namespace: argo-events
   annotations:
-    workflows.argoproj.io/description: HTTP Template Workflow to query the Nautobot API
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/generic/workflowtemplates/nautobot-api.yaml`.
+      HTTP Template Workflow to query the Nautobot API
 spec:
   serviceAccountName: workflow
   entrypoint: main

--- a/argo-workflows/ironic-to-nautobot-sync/sensors/ironic-to-nautobot-sensor.yaml
+++ b/argo-workflows/ironic-to-nautobot-sync/sensors/ironic-to-nautobot-sensor.yaml
@@ -8,6 +8,9 @@ metadata:
     argocd.argoproj.io/instance: argo-events
   name: ironic-node-update
   namespace: argo-events
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/ironic-to-nautobot-sensor/sensors/sync.yaml`
 spec:
   dependencies:
   - eventName: openstack

--- a/argo-workflows/ironic-to-nautobot-sync/workflowtemplates/sync.yaml
+++ b/argo-workflows/ironic-to-nautobot-sync/workflowtemplates/sync.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: synchronize-provision-state-to-nautobot
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/ironic-to-nautobot-sensor/workflowtemplates/sync.yaml`
 kind: WorkflowTemplate
 spec:
   serviceAccountName: workflow

--- a/argo-workflows/obm-utils/workflowtemplates/idrac-enable-network-boot.yaml
+++ b/argo-workflows/obm-utils/workflowtemplates/idrac-enable-network-boot.yaml
@@ -5,7 +5,9 @@ metadata:
   name: idrac-enable-network-boot
   namespace: argo-events
   annotations:
-    workflows.argoproj.io/description: Enable network boot in Dell iDrac BIOS
+    workflows.argoproj.io/title: Enable network boot in Dell iDrac BIOS
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/obm-utils/workflowtemplates/idrac-enable-network-boot.yaml`
 spec:
   arguments:
     parameters:

--- a/argo-workflows/obm-utils/workflowtemplates/obm-firmware-update.yaml
+++ b/argo-workflows/obm-utils/workflowtemplates/obm-firmware-update.yaml
@@ -4,7 +4,9 @@ metadata:
   name: obm-firmware-update
   namespace: argo-events
   annotations:
-    workflows.argoproj.io/description: Update OBM firmware on target Device
+    workflows.argoproj.io/title: Update OBM firmware on target Device
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/obm-utils/workflowtemplates/obm-firmware-update.yaml`
 spec:
   serviceAccountName: workflow
   entrypoint: main

--- a/argo-workflows/obm-utils/workflowtemplates/obm-sync-creds.yaml
+++ b/argo-workflows/obm-utils/workflowtemplates/obm-sync-creds.yaml
@@ -5,7 +5,9 @@ metadata:
   name: obm-sync-creds
   namespace: argo-events
   annotations:
-    workflows.argoproj.io/description: Sync's a devices OBM password with what we have on record
+    workflows.argoproj.io/title: Sync's a devices OBM password with what we have on record
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/obm-utils/workflowtemplates/obm-sync-creds.yaml`
 spec:
   arguments:
     parameters:

--- a/argo-workflows/shared-sensors/nb-oob-interface-update-sensor.yaml
+++ b/argo-workflows/shared-sensors/nb-oob-interface-update-sensor.yaml
@@ -7,6 +7,9 @@ metadata:
     argocd.argoproj.io/instance: argo-workflows-templates
   name: nb-oob-interface-update
   namespace: argo-events
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/shared-sensors/nb-oob-interface-update-sensor.yaml`
 spec:
   dependencies:
     - eventName: nautobot

--- a/argo-workflows/sync-nb-server-to-ironic/sensors/debug-sensor.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/sensors/debug-sensor.yaml
@@ -3,6 +3,9 @@ kind: Sensor
 metadata:
   name: debug-sensor
   namespace: argo-events
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-nb-server-to-ironic/sensors/debug-sensor.yaml`
 spec:
   dependencies:
   - eventName: interface-update

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/node-events.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/node-events.yaml
@@ -2,6 +2,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: node-events
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-nb-server-to-ironic/node-events.yaml`
 spec:
   volumes:
     - name: argo-secrets

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-nb-server-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-nb-server-to-ironic.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: sync-nb-server-to-ironic
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-nb-server-to-ironic/sync-nb-server-to-ironic.yaml`
 kind: WorkflowTemplate
 spec:
   entrypoint: main

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-interfaces-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-interfaces-to-ironic.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: synchronize-interfaces-to-ironic
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-nb-server-to-ironic/synchronize-interfaces-to-ironic.yaml`
 kind: WorkflowTemplate
 spec:
   arguments:

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-obm-creds.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-obm-creds.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: synchronize-obm-creds
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-nb-server-to-ironic/synchronize-obm-creds.yaml`
 kind: WorkflowTemplate
 spec:
   entrypoint: main

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-server-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/synchronize-server-to-ironic.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: synchronize-server-to-ironic
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-nb-server-to-ironic/synchronize-server-to-ironic.yaml`
 kind: WorkflowTemplate
 spec:
   arguments:

--- a/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-interfaces-to-nautobot.yaml
+++ b/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-interfaces-to-nautobot.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: sync-interfaces-to-nautobot
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-srv-redfish-intfs-to-nb/sync-interfaces-to-nautobot.yaml`
 kind: WorkflowTemplate
 spec:
   arguments:

--- a/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-srv-redfish-intfs-to-nb.yaml
+++ b/argo-workflows/sync-srv-redfish-intfs-to-nb/workflowtemplates/sync-srv-redfish-intfs-to-nb.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: sync-srv-redfish-intfs-to-nb
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/sync-srv-redfish-intfs-to-nb/sync-srv-redfish-intfs-to-nb.yaml`
 kind: WorkflowTemplate
 spec:
   entrypoint: main

--- a/argo-workflows/trigger-undersync/workflowtemplates/undersync-device.yaml
+++ b/argo-workflows/trigger-undersync/workflowtemplates/undersync-device.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: undersync-device
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/trigger-undersync/undersync-device.yaml`
 kind: WorkflowTemplate
 spec:
   entrypoint: trigger-undersync

--- a/argo-workflows/trigger-undersync/workflowtemplates/undersync-switch.yaml
+++ b/argo-workflows/trigger-undersync/workflowtemplates/undersync-switch.yaml
@@ -1,6 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 metadata:
   name: undersync-switch
+  annotations:
+    workflows.argoproj.io/description: |
+      Defined in `argo-workflows/trigger-undersync/undersync-switch.yaml`
 kind: WorkflowTemplate
 spec:
   entrypoint: undersync-switch


### PR DESCRIPTION
- All Sensors and Workflows require some description now, ideally containing a reference to the file where they were defined.
- Adds descriptions
 
example CI failure: https://github.com/rackerlabs/understack/actions/runs/10407977498/job/28824377015