### PR TITLE
fix: Switch to using nautobot-custom-env due to upstream nautobot helm chart overrides

### DIFF
--- a/components/nautobot/nautobot-values.yaml
+++ b/components/nautobot/nautobot-values.yaml
@@ -43,10 +43,14 @@ nautobot:
       readOnly: true
       subPath: client-secret
 
+  extraEnvVarsSecret:
+    - nautobot-custom-env
+
 celery:
   replicaCount: 1
   extraEnvVarsSecret:
     - nautobot-django
+    - nautobot-custom-env
 
 postgresql:
   enabled: false

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -427,13 +427,13 @@ kustomize create --autodetect
 popd
 
 # Placeholders don't need sealing
-if [ ! -f "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/secret-nautobot-env.yaml" ]; then
-    echo "Creating nautobot-env secret placeholder"
+if [ ! -f "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/secret-nautobot-custom-env.yaml" ]; then
+    echo "Creating nautobot-custom-env secret placeholder"
     kubectl --namespace nautobot \
-        create secret generic nautobot-env \
+        create secret generic nautobot-custom-env \
         --dry-run=client \
         -o yaml \
-        --type Opaque > "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/secret-nautobot-env.yaml"
+        --type Opaque > "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/secret-nautobot-custom-env.yaml"
 fi
 
 exit 0


### PR DESCRIPTION
Upstream nautobot helm uses and wants to control `nautobot-env` secret which we were also using. This changes ours to `nautobot-custom-env` instead.
