### PR TITLE
fix: cannot set the nautobot extra envars due to merge order

### DIFF
--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -91,10 +91,6 @@ spec:
                               cert-manager.io/cluster-issuer: '{{.name }}-cluster-issuer'
                               nginx.ingress.kubernetes.io/backend-protocol: HTTPS
                             hostname: 'nautobot.{{index .metadata.annotations "dns_zone" }}'
-                          nautobot:
-                            extraEnvVars:
-                              - name: SOCIAL_AUTH_OIDC_OIDC_ENDPOINT
-                                value: 'https://dex.{{index .metadata.annotations "dns_zone" }}'
                         valueFiles:
                           - $understack/components/nautobot/nautobot-values.yaml
                           - $secrets/helm-configs/{{.name}}/nautobot.yaml


### PR DESCRIPTION
Due to the merge order in ArgoCD
https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-value-precedence we cannot set this value here otherwise it will ignore our valueFiles which will likely want to provide additional values. This data is now read out of the SSO secret so it does not need to be passed in as an extra variable.