### PR TITLE
fix(ironic): use the correct dnsmasq image

### DIFF
--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -44,7 +44,7 @@ spec:
       hostNetwork: true
       containers:
         - name: dnsmasq
-          image: ghcr.io/rackerlabs/openstackhelm/dnsmasq:latest
+          image: ghcr.io/rackerlabs/understack/dnsmasq:latest
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
The dnsmasq image was moved into understack.