### PR TITLE
feat(argocd): upgrade to ArgoCD 2.12.2

### DIFF
--- a/bootstrap/argocd/kustomization.yaml
+++ b/bootstrap/argocd/kustomization.yaml
@@ -14,5 +14,5 @@ helmCharts:
   namespace: argocd
   valuesFile: values.yaml
   releaseName: argo-cd
-  version: 7.4.0
+  version: 7.4.5
   repo: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
Upgraded the helm chart from 7.4.0 to 7.4.5 which upgrades the ArgoCD version.