### PR TITLE
fix(cloudnative-pg): Switch to cloudnative-pg helm chart for better control of settings

### DIFF
--- a/components/nautobot/nautobot-values.yaml
+++ b/components/nautobot/nautobot-values.yaml
@@ -6,18 +6,18 @@ nautobot:
     engine: "django.db.backends.postgresql"
 
     # Using Crunchy postgres operator:
-    host: "nautobot-primary.nautobot.svc"
-    name: "nautobot"
-    user: "nautobot"
-    existingSecret: "nautobot-pguser-nautobot"
-    existingSecretPasswordKey: "password"
+    # host: "nautobot-primary.nautobot.svc"
+    # name: "nautobot"
+    # user: "nautobot"
+    # existingSecret: "nautobot-pguser-nautobot"
+    # existingSecretPasswordKey: "password"
 
     # Using CloudNative postgres operator:
-    # host: "nautobot-cluster-rw.nautobot.svc"
-    # name: "app"
-    # user: "app"
-    # existingSecret: "nautobot-cluster-app"
-    # existingSecretPasswordKey: "password"
+    host: "nautobot-cluster-rw.nautobot.svc"
+    name: "app"
+    user: "app"
+    existingSecret: "nautobot-cluster-app"
+    existingSecretPasswordKey: "password"
 
   django:
     existingSecret: nautobot-django

--- a/operators/cnpg-system/kustomization.yaml
+++ b/operators/cnpg-system/kustomization.yaml
@@ -1,5 +1,18 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/releases/cnpg-1.24.0.yaml
+  - namespace.yaml
+
+helmGlobals:
+  chartHome: ../../charts/
+
+helmCharts:
+- name: cloudnative-pg
+  includeCRDs: true
+  namespace: cnpg-system
+  valuesFile: values.yaml
+  releaseName: cloudnative-pg
+  version: 0.22.0
+  repo: https://cloudnative-pg.github.io/charts

--- a/operators/cnpg-system/namespace.yaml
+++ b/operators/cnpg-system/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnpg-system


### PR DESCRIPTION
While troubleshooting some issues with the cloudnative-pg kustomize install, I figured it would be easier moving forward if we used the helm install instead, so we can configure it easier.