### PR TITLE
feat: Rook / Ceph deployment for our storage needs

### DIFF
--- a/apps/appsets/argocd-operators-project.yaml
+++ b/apps/appsets/argocd-operators-project.yaml
@@ -18,6 +18,8 @@ spec:
     server: '*'
   - namespace: 'cnpg-system'
     server: '*'
+  - namespace: 'rook-ceph'
+    server: '*'
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'

--- a/operators/rook/kustomization.yaml
+++ b/operators/rook/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources: []
+
+helmGlobals:
+  chartHome: ../../charts/
+
+helmCharts:
+- name: rook-ceph
+  includeCRDs: true
+  namespace: rook-system
+  valuesFile: values-operator.yaml
+  releaseName: rook-ceph
+  version: v1.15.0
+  repo: https://charts.rook.io/release
+
+- name: rook-ceph-cluster
+  includeCRDs: true
+  namespace: rook-system
+  valuesFile: values-cluster.yaml
+  releaseName: rook-ceph-cluster
+  version: v1.15.0
+  repo: https://charts.rook.io/release

--- a/operators/rook/values-cluster.yaml
+++ b/operators/rook/values-cluster.yaml
@@ -1,0 +1,187 @@
+# Defaults:
+# https://github.com/rook/rook/blob/release-1.15/deploy/charts/rook-ceph-cluster/values.yaml
+
+# TODO: adjust or remove this section when we have 3rd node
+cephClusterSpec:
+  mon:
+    # Set the number of mons to be started. Generally recommended to be 3.
+    # For highest availability, an odd number of mons should be specified.
+    count: 2
+    # The mons should be on unique nodes. For production, at least 3 nodes are recommended for this reason.
+    # Mons should only be allowed on the same node for test environments where data loss is acceptable.
+    allowMultiplePerNode: false
+
+  mgr:
+    # When higher availability of the mgr is needed, increase the count to 2.
+    # In that case, one mgr will be active and one in standby. When Ceph updates which
+    # mgr is active, Rook will update the mgr services to match the active mgr.
+    count: 2
+    allowMultiplePerNode: false
+
+
+# We offer 4 different storage tiers:
+# 1. Block-Storage with replication to 3 places. For most important data.
+# 2. Block storage with 2+1 EC, for most things that don't have big performance requirements
+# 3. Filesystem type storage with 2+1 EC, for pods that need shared storage
+# 4. Object storage with 2+1 EC
+
+# -- A list of CephBlockPool configurations to deploy
+cephBlockPools:
+  - name: ceph-block-replicated
+    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md#spec for available configuration
+    spec:
+      failureDomain: host
+      replicated:
+        size: 3
+    storageClass:
+      enabled: true
+      name: ceph-block-replicated
+      isDefault: false
+      reclaimPolicy: Retain
+      allowVolumeExpansion: true
+      volumeBindingMode: "Immediate"
+      mountOptions: []
+      # see https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies
+      allowedTopologies: []
+      parameters:
+        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+        csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+        imageFeatures: layering
+
+  # This pool is needed to support EC based block pools
+  - name: replicated-metadata-pool
+    spec:
+      replicated:
+        size: 2
+    storageClass:
+      enabled: false
+  - name: ceph-blockpool-ecoded
+    # For caches and other unimportant data
+    spec:
+      failureDomain: host
+      erasureCoded:
+        codingChunks: 1
+        dataChunks: 2
+    storageClass:
+      enabled: true
+      name: ceph-block-ecoded
+      isDefault: false
+      reclaimPolicy: Retain
+      allowVolumeExpansion: true
+      volumeBindingMode: "Immediate"
+      mountOptions: []
+      allowedTopologies: []
+      parameters:
+        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+        csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+        dataPool: ceph-blockpool-ecoded
+        pool: replicated-metadata-pool
+        # needed because we are running kernel 4.x which does not support fast-diff
+        # see  https://docs.ceph.com/en/latest/rbd/rbd-config-ref/ for things supported
+        # in particular kernel version
+        imageFeatures: layering
+
+# -- A list of CephFileSystem configurations to deploy
+# @default -- See [below](#ceph-file-systems)
+cephFileSystems:
+  - name: ceph-fs-ec
+    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Shared-Filesystem/ceph-filesystem-crd.md#filesystem-settings for available configuration
+    spec:
+      metadataPool:
+        replicated:
+          size: 3
+      dataPools:
+        - replicated:
+            size: 3
+        - erasureCoded:
+            dataChunks: 2
+            codingChunks: 1
+          name: data1
+      metadataServer:
+        activeCount: 1
+        activeStandby: true
+        resources:
+          limits:
+            cpu: "2000m"
+            memory: "4Gi"
+          requests:
+            cpu: "1000m"
+            memory: "4Gi"
+
+    storageClass:
+      enabled: true
+      isDefault: false
+      name: ceph-fs-ec
+      # (Optional) specify a data pool to use, must be the name of one of the data pools above, 'data0' by default
+      pool: data1
+      reclaimPolicy: Retain
+      allowVolumeExpansion: true
+      volumeBindingMode: "Immediate"
+      parameters:
+        # The secrets contain Ceph admin credentials.
+        csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+        csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+        csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+        csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+        csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+        csi.storage.k8s.io/fstype: ext4
+
+# -- A list of CephObjectStore configurations to deploy
+cephObjectStores:
+  - name: ceph-objectstore
+    # see https://github.com/rook/rook/blob/master/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md#object-store-settings for available configuration
+    spec:
+      metadataPool:
+        failureDomain: host
+        replicated:
+          size: 3
+      dataPool:
+        failureDomain: host
+        erasureCoded:
+          dataChunks: 2
+          codingChunks: 1
+      preservePoolsOnDelete: true
+      gateway:
+        port: 80
+        resources:
+          limits:
+            memory: "2Gi"
+          requests:
+            cpu: "1000m"
+            memory: "1Gi"
+        # securePort: 443
+        # sslCertificateRef:
+        instances: 1
+        priorityClassName: system-cluster-critical
+    storageClass:
+      enabled: true
+      name: ceph-bucket
+      reclaimPolicy: Delete
+      volumeBindingMode: "Immediate"
+      annotations: {}
+      labels: {}
+      # see https://github.com/rook/rook/blob/master/Documentation/Storage-Configuration/Object-Storage-RGW/ceph-object-bucket-claim.md#storageclass for available configuration
+      parameters:
+        # note: objectStoreNamespace and objectStoreName are configured by the chart
+        region: iad
+    ingress:
+      # Enable an ingress for the ceph-objectstore
+      enabled: false
+      # annotations: {}
+      # host:
+      #   name: objectstore.example.com
+      #   path: /
+      # tls:
+      # - hosts:
+      #     - objectstore.example.com
+      #   secretName: ceph-objectstore-tls
+      # ingressClassName: nginx

--- a/operators/rook/values-operator.yaml
+++ b/operators/rook/values-operator.yaml
@@ -1,0 +1,2 @@
+# Defaults
+# https://github.com/rook/rook/blob/release-1.15/deploy/charts/rook-ceph/values.yaml


### PR DESCRIPTION
This PR adds basic deployment of Rook so that we can use PVCs in the development cluster.

It has been tested on the new uc-iad3-dev and has deployed successfully:

```
❯   kubectl --namespace rook-ceph get cephcluster
NAME        DATADIRHOSTPATH   MONCOUNT   AGE     PHASE   MESSAGE                        HEALTH        EXTERNAL   FSID
rook-ceph   /var/lib/rook     2          9m12s   Ready   Cluster created successfully   HEALTH_WARN              8ea3e27d-f56a-4477-88de-e499ab5f1795
```

The Health Warning is related to an insufficient number of OSDs deployed because we only have two nodes but a minimum of three are required.

Partially delivers PUC-495