### PR TITLE
fix: improve argo-events and the openstack event source

### DIFF
--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -167,6 +167,13 @@ spec:
                       name: workflow
                       jsonPointers:
                         - /imagePullSecrets
+                - component: understack-workflows
+                  componentNamespace: argo-events
+                  source:
+                    repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
+                    targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
+                    path: 'apps/understack-workflows'
+
 
   template:
     metadata:

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -103,7 +103,7 @@ spec:
                             # path: $understack/components/nautobot/nautobot_config.py
                             path: 'https://raw.githubusercontent.com/rackerlabs/understack/{{index .metadata.annotations "uc_repo_ref" }}/components/nautobot/nautobot_config.py'
                 - component: argo
-                  source: &uc_component
+                  source:
                     repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
                     targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
                     path: 'components/argo'
@@ -158,7 +158,8 @@ spec:
                               value: '{{.name }}-cluster-issuer'
                 - component: argo-events
                   source:
-                    <<: *uc_component
+                    repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
+                    targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
                     path: 'components/argo-events'
                   ignoreDifferences:
                     - group: ''

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -175,7 +175,7 @@ spec:
       project: default
       destination:
         server: '{{.server}}'
-        namespace: '{{.component}}'
+        namespace: '{{coalesce (get . "componentNamespace") .component}}'
       syncPolicy:
         automated:
           selfHeal: true

--- a/apps/appsets/infra.yaml
+++ b/apps/appsets/infra.yaml
@@ -98,7 +98,7 @@ spec:
       project: default
       destination:
         server: '{{.server}}'
-        namespace: '{{.component}}'
+        namespace: '{{coalesce (get . "componentNamespace") .component}}'
       syncPolicy:
         automated:
           prune: true

--- a/apps/understack-workflows/eventsource-openstack/argo-rabbitmq.yaml
+++ b/apps/understack-workflows/eventsource-openstack/argo-rabbitmq.yaml
@@ -3,30 +3,23 @@ apiVersion: rabbitmq.com/v1beta1
 kind: User
 metadata:
   name: argo
-  namespace: openstack
 spec:
-  tags:
-  - management  # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
-  - policymaker
   rabbitmqClusterReference:
     name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
-  importCredentialsSecret:
-    name: argo-rabbitmq-password
 ---
 apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: argo-to-ironic-permission
-  namespace: openstack
 spec:
   vhost: "ironic"
   userReference:
     name: "argo"  # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
   permissions:
-    write: ".*"
-    configure: ".*"
-    read: ".*"
+    write: "^$"
+    configure: "^$"
+    read: "^ironic_versioned_notifications.info$"
   rabbitmqClusterReference:
     name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack

--- a/apps/understack-workflows/eventsource-openstack/eventbus-default.yaml
+++ b/apps/understack-workflows/eventsource-openstack/eventbus-default.yaml
@@ -1,0 +1,27 @@
+# default NATS EventBus sourced from:
+# https://raw.githubusercontent.com/argoproj/argo-events/stable/examples/eventbus/native.yaml
+
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+spec:
+  nats:
+    native:
+      # Optional, defaults to 3. If it is < 3, set it to 3, that is the minimal requirement.
+      replicas: 3
+      # Optional, authen strategy, "none" or "token", defaults to "none"
+      auth: token
+#      containerTemplate:
+#        resources:
+#          requests:
+#            cpu: "10m"
+#      metricsContainerTemplate:
+#        resources:
+#          requests:
+#            cpu: "10m"
+#      antiAffinity: false
+#      persistence:
+#        storageClassName: standard
+#        accessMode: ReadWriteOnce
+#        volumeSize: 10Gi

--- a/apps/understack-workflows/eventsource-openstack/eventbus-default.yaml
+++ b/apps/understack-workflows/eventsource-openstack/eventbus-default.yaml
@@ -25,3 +25,14 @@ spec:
 #        storageClassName: standard
 #        accessMode: ReadWriteOnce
 #        volumeSize: 10Gi
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: eventbus-default-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      controller: eventbus-controller
+      eventbus-name: default

--- a/apps/understack-workflows/eventsource-openstack/kustomization.yaml
+++ b/apps/understack-workflows/eventsource-openstack/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openstack
+
+resources:
+  - argo-rabbitmq.yaml
+  - eventbus-default.yaml
+  - openstack-event-source.yaml

--- a/apps/understack-workflows/eventsource-openstack/openstack-event-source.yaml
+++ b/apps/understack-workflows/eventsource-openstack/openstack-event-source.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: EventSource
 metadata:
-  name: openstack-amqp
+  name: openstack-ironic
 spec:
   amqp:
     openstack:
@@ -27,8 +27,8 @@ spec:
       # use secret selectors
       auth:
         username:
-          name: argo-rabbitmq-password
+          name: argo-user-credentials
           key: username
         password:
-          name: argo-rabbitmq-password
+          name: argo-user-credentials
           key: password

--- a/apps/understack-workflows/kustomization.yaml
+++ b/apps/understack-workflows/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - eventsource-openstack

--- a/components/argo-events/kustomization.yaml
+++ b/components/argo-events/kustomization.yaml
@@ -12,14 +12,10 @@ resources:
   - argo-server-role.yaml
   - argo-role.yaml
 
-  ## create a RabbitMQ user to access openstack notifications
-  - argo-rabbitmq.yaml
-
 
   ## deploy argo-event components
   - native-eventbus.yaml
   - webhook-event-source.yaml
-  - openstack-event-source.yaml
 
   ## configure webhook Sensor and associated role
   - sensor-workflow-role.yaml

--- a/components/argo-events/kustomization.yaml
+++ b/components/argo-events/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
-  - https://github.com/argoproj/argo-events/releases/download/v1.9.1/namespace-install.yaml
+  - https://github.com/argoproj/argo-events/releases/download/v1.9.1/install.yaml
   - https://github.com/argoproj/argo-events/releases/download/v1.9.1/install-validating-webhook.yaml
 
   ## configure rbac to integrate with argo-workflow

--- a/components/argo-events/native-eventbus.yaml
+++ b/components/argo-events/native-eventbus.yaml
@@ -25,3 +25,14 @@ spec:
 #        storageClassName: standard
 #        accessMode: ReadWriteOnce
 #        volumeSize: 10Gi
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: eventbus-default-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      controller: eventbus-controller
+      eventbus-name: default

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -353,22 +353,9 @@ yq '(.. | select(tag == "!!str")) |= envsubst' \
     "./components/openstack-secrets.tpl.yaml" \
     > "${DEST_DIR}/secret-openstack.yaml"
 
-echo "Checking argo-events"
-# Argo Events access to RabbitMQ - credentials
-for ns in argo-events openstack; do
-  [ ! -f "${DEST_DIR}/secret-argo-rabbitmq-password-$ns.yaml" ] && \
-  kubectl --namespace $ns \
-      create secret generic argo-rabbitmq-password \
-      --type Opaque \
-      --from-literal=username="argo" \
-      --from-literal=password="${ARGO_RABBITMQ_PASSWORD}" \
-      --dry-run=client -o yaml | secret-seal-stdin "${DEST_DIR}/secret-argo-rabbitmq-password-$ns.yaml"
-done
-
 echo "Checking undersync"
 # create a placeholder directory for undersync configs
 mkdir -p "${DEST_DIR}/undersync"
-
 
 find "${DEST_DIR}" -maxdepth 1 -mindepth 1 -type d | while read -r component; do
     if [ ! -f "${component}/kustomization.yaml" ]; then


### PR DESCRIPTION
Switched argo-events to run cluster wide since each namespace has its own resources. This makes it easier for us to not have to copy secrets around so removed that case. Updated the openstack event source to be narrower in access scope and use the generated credentials by the rabbitmq operator removing the need for a generated secret at all. Added a Pod Disruption Budget to the event bus so we do not lose events.