### PR TITLE
feat: workflow updates Nautobot Interface.status instead of device.custom_field.conected_to_network

### DIFF
--- a/argo-workflows/trigger-undersync/workflowtemplates/undersync-device.yaml
+++ b/argo-workflows/trigger-undersync/workflowtemplates/undersync-device.yaml
@@ -15,6 +15,8 @@ spec:
         command:
           - undersync-device
         args:
+          - --interface-id
+          - "{{workflow.parameters.interface_uuid}}"
           - --device-id
           - "{{workflow.parameters.device_uuid}}"
           - --network-name
@@ -32,6 +34,7 @@ spec:
             readOnly: true
       inputs:
         parameters:
+          - name: interface_uuid
           - name: device_uuid
           - name: network_name
           - name: force

--- a/argo-workflows/trigger-undersync/workflowtemplates/undersync-device.yaml
+++ b/argo-workflows/trigger-undersync/workflowtemplates/undersync-device.yaml
@@ -15,8 +15,8 @@ spec:
         command:
           - undersync-device
         args:
-          - --interface-id
-          - "{{workflow.parameters.interface_uuid}}"
+          - --interface-mac
+          - "{{workflow.parameters.interface_mac}}"
           - --device-id
           - "{{workflow.parameters.device_uuid}}"
           - --network-name
@@ -34,7 +34,7 @@ spec:
             readOnly: true
       inputs:
         parameters:
-          - name: interface_uuid
+          - name: interface_mac
           - name: device_uuid
           - name: network_name
           - name: force

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -263,14 +263,16 @@ class UnderstackDriver(MechanismDriver):
             return "tenant"
 
     def _move_to_network(self, context):
+        interface_uuid = context.current["id"]
         device_uuid = context.current["binding:host_id"]
         network_name = self.__network_name(context.current["network_id"])
-        LOG.debug(f"Selected {network_name=} for {device_uuid=}")
+        LOG.debug(f"Selected {network_name=} for {device_uuid=} {interface_id=}")
 
         result = argo_client.submit(
             template_name="undersync-device",
             entrypoint="trigger-undersync",
             parameters={
+                "interface_uuid": interface_uuid,
                 "device_uuid": device_uuid,
                 "network_name": network_name,
                 "dry_run": cfg.CONF.ml2_type_understack.argo_dry_run,

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -263,16 +263,16 @@ class UnderstackDriver(MechanismDriver):
             return "tenant"
 
     def _move_to_network(self, context):
-        interface_uuid = context.current["id"]
+        interface_mac = context.current["mac_address"]
         device_uuid = context.current["binding:host_id"]
         network_name = self.__network_name(context.current["network_id"])
-        LOG.debug(f"Selected {network_name=} for {device_uuid=} {interface_id=}")
+        LOG.debug(f"Selected {network_name=} for {device_uuid=} {interface_mac=}")
 
         result = argo_client.submit(
             template_name="undersync-device",
             entrypoint="trigger-undersync",
             parameters={
-                "interface_uuid": interface_uuid,
+                "interface_mac": interface_mac,
                 "device_uuid": device_uuid,
                 "network_name": network_name,
                 "dry_run": cfg.CONF.ml2_type_understack.argo_dry_run,

--- a/python/neutron-understack/neutron_understack/tests/fixtures/neutron_update_port_postcommit.json
+++ b/python/neutron-understack/neutron_understack/tests/fixtures/neutron_update_port_postcommit.json
@@ -1,0 +1,35 @@
+{
+  "admin_state_up": true,
+  "allowed_address_pairs": [],
+  "binding:host_id": "",
+  "binding:profile": {},
+  "binding:vif_details": {},
+  "binding:vif_type": "unbound",
+  "binding:vnic_type": "normal",
+  "created_at": "2024-07-24T13:42:24Z",
+  "description": "",
+  "device_id": "41d18c6a-5548-4ee9-926f-4e3ebf43153f",
+  "device_owner": "compute:nova",
+  "extra_dhcp_opts": [],
+  "fixed_ips": [
+    {
+      "ip_address": "192.168.17.17",
+      "subnet_id": "7f2f436c-fd65-44b0-9265-6b642cecbec5"
+    }
+  ],
+  "id": "e5d5cd73-ca9a-4b74-9d52-43188d0cdcaa",
+  "mac_address": "fa:16:3e:35:1c:3d",
+  "name": "",
+  "network_id": "c2702769-5592-4555-8ae6-e670db82c31e",
+  "port_security_enabled": true,
+  "project_id": "ebc5b22e420d4dfc9e385a63b4583623",
+  "revision_number": 2,
+  "security_groups": [
+    "684dcc25-f419-44a5-b4e7-fdcad4335ecd"
+  ],
+  "standard_attr_id": 56,
+  "status": "DOWN",
+  "tags": [],
+  "tenant_id": "ebc5b22e420d4dfc9e385a63b4583623",
+  "updated_at": "2024-07-24T13:42:25Z"
+}

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from unittest.mock import patch, MagicMock
+import pytest
+from neutron_understack.argo.workflows import ArgoClient
+
+from neutron_understack.neutron_understack_mech import UnderstackDriver
+
+# TODO: I am not sure how we run tests in this project.
+
+@dataclass
+class ContextDouble:
+  current: dict
+
+def mock_context_data(file):
+    ref = pathlib.Path(__file__).joinpath(filename)
+    with ref.open("r") as f:
+        return ContextDouble(json.load(f))
+
+@patch('neutron_understack.argo.workflows.ArgoClient')
+def test_update_port_postcommit(mock_argo_client):
+    context_data = mock_context_data(
+        "fixtures/neutron_update_port_postcommit.json"
+    )
+
+    UnderstackDriver.update_port_postcommit(context_data)
+
+    mock_argo_client.assert_called_once_with(
+        template_name="undersync-device",
+        entrypoint="trigger-undersync",
+        parameters={
+            "interface_uuid": "e5d5cd73-ca9a-4b74-9d52-43188d0cdcaa",
+            "device_uuid": "41d18c6a-5548-4ee9-926f-4e3ebf43153f",
+            "network_name": "provisioning",
+            "dry_run": false,
+            "force": false,
+        },
+    )

--- a/python/understack-workflows/understack_workflows/main/undersync_device.py
+++ b/python/understack-workflows/understack_workflows/main/undersync_device.py
@@ -51,6 +51,9 @@ def argument_parser():
         description="Trigger undersync run for a device",
     )
     parser.add_argument(
+        "--interface-id", type=UUID, required=True, help="Nautobot interface UUID"
+    )
+    parser.add_argument(
         "--device-id", type=UUID, required=True, help="Nautobot device UUID"
     )
     parser.add_argument("--network-name", required=True)

--- a/python/understack-workflows/understack_workflows/main/undersync_device.py
+++ b/python/understack-workflows/understack_workflows/main/undersync_device.py
@@ -19,7 +19,7 @@ network_name_status = {
 
 def update_nautobot(args) -> UUID:
     device_id = args.device_id
-    interface_id = args.interface_id
+    interface_mac = args.interface_mac
     network_name = args.network_name
 
     nb_url = args.nautobot_url
@@ -28,9 +28,9 @@ def update_nautobot(args) -> UUID:
     new_status = network_name_status[args.network_name]
 
     nautobot = Nautobot(nb_url, nb_token, logger=logger)
-    logger.info(f"Updating Nautobot {device_id=!s} {interface_id=!s} {network_name=}")
-    interface = nautobot.update_switch_interface_status(interface_id, new_status)
-    logger.info(f"Updated Nautobot {device_id=!s} {interface_id=!s} {network_name=}")
+    logger.info(f"Updating Nautobot {device_id=!s} {interface_mac=!s} {network_name=}")
+    interface = nautobot.update_switch_interface_status(device_id, interface_mac, new_status)
+    logger.info(f"Updated Nautobot {device_id=!s} {interface_mac=!s} {network_name=}")
 
     switch_id = interface.device.id
     logger.info(f"Interface connected to switch {switch_id!s}")
@@ -57,7 +57,7 @@ def argument_parser():
         description="Trigger undersync run for a device",
     )
     parser.add_argument(
-        "--interface-id", type=UUID, required=True, help="Nautobot interface UUID"
+        "--interface-mac", type=str, required=True, help="Interface MAC address"
     )
     parser.add_argument(
         "--device-id", type=UUID, required=False, help="Nautobot device UUID"


### PR DESCRIPTION
We used to flip a bit on the nautobot Device object for “connected_to_network”
when changing a device from/to “provisioning” and “tenant” settings.

We need this to be interface specific.  Because of Ironic's knowlege of the
interface that is being used for PXE boot, we are called with a server interface
UUID.

We update the nautobot status field of connected switch interface.

This tells undersync which mode the port should be in - provisioning or
tenant (normal).

This would be released in tandem with https://github.com/RSS-Engineering/undersync/pull/14 fixes PUC-425