### PR TITLE
feat: update sync server workflow to return node state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ venv/
 /python/*/dist/
 __pycache__
 .coverage
+.idea
 
 # auto-generated argo-workflows docs
 # see .github/workflows/mkdocs.yaaml

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
@@ -12,27 +12,26 @@ spec:
         value: "{}"
   templates:
     - name: main
-      input:
-        parameters:
-          - name: interface_update_event
-      output:
-        parameters:
-          - name: server_state
-            valueFrom:
-              expression: "{{ steps.sync-server.outputs.parameters.result }}"
       steps:
         - - name: sync-server
+            input:
+              parameters:
+                - name: interface_update_event
+            output:
+              parameters:
+                - name: server_state
+                  value: "{{ steps.sync-server.outputs.parameters.result.server_state }}"
             container:
-            image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
-            command:
-              - sync-server
-            args:
-              - "{{input.parameters.interface_update_event}}"
-            volumeMounts:
-              - mountPath: /etc/ironic-secrets/
-                name: ironic-secrets
-                readOnly: true
+              image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
+              command:
+                - sync-server
+              args:
+                - "{{input.parameters.interface_update_event}}"
+              volumeMounts:
+                - mountPath: /etc/ironic-secrets/
+                  name: ironic-secrets
+                  readOnly: true
             volumes:
               - name: ironic-secrets
                 secret:
-                secretName: production-ironic-for-argo-creds
+                  secretName: production-ironic-for-argo-creds

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
@@ -11,18 +11,28 @@ spec:
       - name: interface_update_event
         value: "{}"
   templates:
-    - name: sync-server
-      container:
-        image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
-        command:
-          - sync-server
-        args:
-          - "{{workflow.parameters.interface_update_event}}"
-        volumeMounts:
-          - mountPath: /etc/ironic-secrets/
-            name: ironic-secrets
-            readOnly: true
-      volumes:
-        - name: ironic-secrets
-          secret:
-            secretName: production-ironic-for-argo-creds
+    - name: main
+      input:
+        parameters:
+          - name: interface_update_event
+      output:
+        parameters:
+          - name: server_state
+            valueFrom:
+              expression: "{{ steps.sync-server.outputs.parameters.result }}"
+      steps:
+        - - name: sync-server
+            container:
+            image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
+            command:
+              - sync-server
+            args:
+              - "{{input.parameters.interface_update_event}}"
+            volumeMounts:
+              - mountPath: /etc/ironic-secrets/
+                name: ironic-secrets
+                readOnly: true
+            volumes:
+              - name: ironic-secrets
+                secret:
+                secretName: production-ironic-for-argo-creds

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
@@ -11,7 +11,7 @@ spec:
       - name: interface_update_event
         value: "{}"
   templates:
-    - name: main
+    - name: sync-server
       outputs:
         parameters:
           - name: server_state

--- a/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
+++ b/argo-workflows/sync-nb-server-to-ironic/workflowtemplates/sync-server-to-ironic.yaml
@@ -12,26 +12,22 @@ spec:
         value: "{}"
   templates:
     - name: main
-      steps:
-        - - name: sync-server
-            input:
-              parameters:
-                - name: interface_update_event
-            output:
-              parameters:
-                - name: server_state
-                  value: "{{ steps.sync-server.outputs.parameters.result.server_state }}"
-            container:
-              image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
-              command:
-                - sync-server
-              args:
-                - "{{input.parameters.interface_update_event}}"
-              volumeMounts:
-                - mountPath: /etc/ironic-secrets/
-                  name: ironic-secrets
-                  readOnly: true
-            volumes:
-              - name: ironic-secrets
-                secret:
-                  secretName: production-ironic-for-argo-creds
+      outputs:
+        parameters:
+          - name: server_state
+            valueFrom:
+              path: "/tmp/ironic_state.txt"
+      container:
+        image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
+        command:
+          - sync-server
+        args:
+          - "{{workflow.parameters.interface_update_event}}"
+        volumeMounts:
+          - mountPath: /etc/ironic-secrets/
+            name: ironic-secrets
+            readOnly: true
+      volumes:
+        - name: ironic-secrets
+          secret:
+            secretName: production-ironic-for-argo-creds

--- a/python/understack-workflows/understack_workflows/main/sync_server.py
+++ b/python/understack-workflows/understack_workflows/main/sync_server.py
@@ -12,6 +12,11 @@ from understack_workflows.node_configuration import IronicNodeConfiguration
 logger = setup_logger(__name__)
 
 
+def write_ironic_state_to_file(state):
+    with open("/tmp/ironic_state.txt", "w") as f:
+        f.write(state)
+
+
 def main():
     if len(sys.argv) < 1:
         raise ValueError(
@@ -77,8 +82,4 @@ def main():
     response = client.update_node(node.uuid, patches)
     logger.info(f"Patching: {patches}")
     logger.info(f"Updated: {response}")
-    return ironic_node.provision_state
-
-
-if __name__ == "__main__":
-    sys.stdout.write(main())
+    write_ironic_state_to_file(ironic_node.provision_state)

--- a/python/understack-workflows/understack_workflows/main/sync_server.py
+++ b/python/understack-workflows/understack_workflows/main/sync_server.py
@@ -48,7 +48,7 @@ def main():
             f"Device {node.uuid} is in a {ironic_node.provision_state} "
             f"provision_state, so the updates are not allowed."
         )
-        return ironic_node.provision_state
+        sys.exit(0)
 
     drac_ip = update_data["ip_addresses"][0]["host"]
     expected_address = f"https://{drac_ip}"
@@ -81,4 +81,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.stdout.write(main())

--- a/python/understack-workflows/understack_workflows/main/sync_server.py
+++ b/python/understack-workflows/understack_workflows/main/sync_server.py
@@ -48,7 +48,7 @@ def main():
             f"Device {node.uuid} is in a {ironic_node.provision_state} "
             f"provision_state, so the updates are not allowed."
         )
-        sys.exit(0)
+        return ironic_node.provision_state
 
     drac_ip = update_data["ip_addresses"][0]["host"]
     expected_address = f"https://{drac_ip}"
@@ -77,3 +77,8 @@ def main():
     response = client.update_node(node.uuid, patches)
     logger.info(f"Patching: {patches}")
     logger.info(f"Updated: {response}")
+    return ironic_node.provision_state
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Changes in this PR are:
1. Python code update to sync_server.py to return state of the ironic node
2. Argo workflow update to sync_server_to_ironic.yaml file to return output results for next steps to utilize.

fixes PUC-494