### PR TITLE
chore(openstack): Update OpenStack components to use the latest helm chart versions.

### DIFF
--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -17,19 +17,19 @@ spec:
           - list:
               elements:
                 - component: keystone
-                  chartVersion: 0.3.13
-                - component: ironic
-                  chartVersion: 0.2.15
-                - component: placement
                   chartVersion: 0.3.15
+                - component: ironic
+                  chartVersion: 0.2.18
+                - component: placement
+                  chartVersion: 0.3.16
                 - component: neutron
                   chartVersion: 0.3.47
                 - component: glance
-                  chartVersion: 0.4.26
+                  chartVersion: 0.5.0
                 - component: nova
-                  chartVersion: 0.3.42
+                  chartVersion: 0.3.44
                 - component: horizon
-                  chartVersion: 0.3.26
+                  chartVersion: 0.3.27
   template:
     metadata:
       name: '{{.name}}-{{.component}}'

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -25,6 +25,7 @@ bootstrap:
     openstack project create undercloud --or-show
     openstack user create --project undercloud --password demo argoworkflow --or-show
     openstack role add --user argoworkflow --project undercloud member
+    openstack role add --user argoworkflow --project undercloud admin
     # allow ironic user to see servers in undercloud project
     openstack role add --project undercloud --user ironic --user-domain service  member
     openstack role add --project service --user ironic --user-domain service service

--- a/components/nova/aio-values.yaml
+++ b/components/nova/aio-values.yaml
@@ -141,5 +141,8 @@ annotations:
       argocd.argoproj.io/hook: Sync
       argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     nova_cell_setup:
+      argocd.argoproj.io/hook: PostSync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    nova_bootstrap:
       argocd.argoproj.io/hook: Sync
       argocd.argoproj.io/hook-delete-policy: BeforeHookCreation

--- a/components/placement/aio-values.yaml
+++ b/components/placement/aio-values.yaml
@@ -32,3 +32,18 @@ manifests:
 # editing the annotation which deletes the item
 # and wipes our keys.
 helm3_hook: false
+
+annotations:
+  job:
+    placement_db_sync:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    placement_ks_service:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    placement_ks_user:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    placement_ks_endpoints:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation


### PR DESCRIPTION
Release notes: https://github.com/openstack/openstack-helm/tree/master/releasenotes/notes

Most of the changes are minor. The glance chart has deprecated a couple settings but we aren't using them.