### PR TITLE
feat: Add DRAC enable network boot process to existing workflow

### DIFF
--- a/argo-workflows/obm-utils/workflowtemplates/obm-sync-creds.yaml
+++ b/argo-workflows/obm-utils/workflowtemplates/obm-sync-creds.yaml
@@ -43,6 +43,17 @@ spec:
                   value: "{{tasks.get-obm-ip.outputs.parameters.ip}}"
                 - name: target_creds_secret_name
                   value: "{{tasks.get-obm-creds.outputs.parameters.secret}}"
+          - name: idrac-enable-network-boot
+            dependencies: [get-obm-ip, get-obm-creds]
+            templateRef:
+              name: idrac-enable-network-boot
+              template: idrac-enable-network-boot
+            arguments:
+              parameters:
+                - name: host
+                  value: "{{tasks.get-obm-ip.outputs.parameters.ip}}"
+                - name: target_creds_secret_name
+                  value: "{{tasks.get-obm-creds.outputs.parameters.secret}}"
 
     - name: obm-sync-creds
       inputs:


### PR DESCRIPTION
This should update the DRAC settings via DRAC to get Dell servers to PXE boot from the correct NICs - by default the dell BIOS is configured to use the built-in NICs but we don't cable those up, so we make this update to the BIOS settings that will cause it to use te add-in card instead.