### PR TITLE
fix: the workflow rename didn't remove these entries

### DIFF
--- a/components/argo-events/kustomization.yaml
+++ b/components/argo-events/kustomization.yaml
@@ -15,11 +15,9 @@ resources:
 
   ## deploy argo-event components
   - native-eventbus.yaml
-  - webhook-event-source.yaml
 
   ## configure webhook Sensor and associated role
   - sensor-workflow-role.yaml
-  - webhook-sensor.yaml
   - workflow-role.yaml
 
   - configmaps.yaml


### PR DESCRIPTION
These entries moved with the workflow rename because this is technically part of the workflows and not part of the argo-events application but didn't remove these entries.