### PR TITLE
fix: avoid out of sync on ExternalSecrets

### DIFF
--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -201,7 +201,6 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
-          - ServerSideApply=true
           - RespectIgnoreDifferences=true
   templatePatch: |
     spec:


### PR DESCRIPTION
Due to the way ArgoCD handles server side apply when the API adds these fields, ArgoCD sees the change and thinks everything is out of sync. Removing server side apply until this can be resolved. ref: https://github.com/argoproj/argo-cd/issues/13004