### PR TITLE
fix: ironic_understack: fix inspection hook loading

### DIFF
--- a/python/ironic-understack/ironic_understack/resource_class.py
+++ b/python/ironic-understack/ironic_understack/resource_class.py
@@ -1,6 +1,7 @@
 # from ironic.drivers.modules.inspector.hooks import base
 from ironic.common import exception
 from ironic.drivers.modules.inspector.hooks import base
+from ironic_understack.conf import CONF
 from ironic_understack.flavor_spec import FlavorSpec
 from ironic_understack.machine import Machine
 from ironic_understack.matcher import Matcher


### PR DESCRIPTION
Without this, there is a race condition when the ironic_understack specific oslo_config parser is loaded. In some cases, the  redfish inspect interface is loaded first and the `CONF` constant is avaialable, whereas if `resource_class` is loaded first, it throws following exception:

```
1327172-hp1:/var/lib/openstack $ python
Python 3.10.12 (main, Jul 29 2024, 16:56:48) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from ironic_understack.resource_class import UndercloudResourceClassHook
Traceback (most recent call last):
  File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2230, in __getattr__
    return self._get(name)
  File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2664, in _get
    value, loc = self._do_get(name, group, namespace)
  File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2682, in _do_get
    info = self._get_opt_info(name, group)
  File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2887, in _get_opt_info
    raise NoSuchOptError(opt_name, group)
oslo_config.cfg.NoSuchOptError: no such option ironic_understack in group [DEFAULT]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/lib/openstack/lib/python3.10/site-packages/ironic_understack/resource_class.py", line 13, in <module>
    FLAVORS = FlavorSpec.from_directory(CONF.ironic_understack.flavors_dir)
  File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2234, in __getattr__
    raise NoSuchOptError(name)
oslo_config.cfg.NoSuchOptError: no such option ironic_understack in group [DEFAULT]
```

Unfortunately Ironic completely swallows that exception and simply exits without any explanation.