### PR TITLE
fix: add fields that external secrets changes

### DIFF
--- a/bootstrap/argocd/components/sso/external-secret-argocd-sso.yaml
+++ b/bootstrap/argocd/components/sso/external-secret-argocd-sso.yaml
@@ -26,11 +26,23 @@ spec:
     remoteRef:
       key: argocd-sso
       property: client-id
+      # necessary to avoid argoproj/argo-cd#13004
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
   - secretKey: client_secret
     remoteRef:
       key: argocd-sso
       property: client-secret
+      # necessary to avoid argoproj/argo-cd#13004
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
   - secretKey: issuer
     remoteRef:
       key: argocd-sso
       property: issuer
+      # necessary to avoid argoproj/argo-cd#13004
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None

--- a/components/argo/external-secret-argo-sso.yaml
+++ b/components/argo/external-secret-argo-sso.yaml
@@ -12,17 +12,10 @@ spec:
     name: argo-sso
     creationPolicy: Owner
     deletionPolicy: Delete
-    template:
-      engineVersion: v2
-      data:
-        client-id: "{{ .client_id }}"
-        client-secret: "{{ .client_secret }}"
-  data:
-  - secretKey: client_id
-    remoteRef:
-      key: argo-sso
-      property: client-id
-  - secretKey: client_secret
-    remoteRef:
-      key: argo-sso
-      property: client-secret
+  dataFrom:
+    - extract:
+        key: argo-sso
+        # necessary to avoid argoproj/argo-cd#13004
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/components/keystone/external-secret-keystone-sso.yaml
+++ b/components/keystone/external-secret-keystone-sso.yaml
@@ -15,3 +15,7 @@ spec:
   dataFrom:
     - extract:
         key: keystone-sso
+        # necessary to avoid argoproj/argo-cd#13004
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/components/nautobot/external-secret-nautobot-sso.yaml
+++ b/components/nautobot/external-secret-nautobot-sso.yaml
@@ -15,3 +15,7 @@ spec:
   dataFrom:
     - extract:
         key: nautobot-sso
+        # necessary to avoid argoproj/argo-cd#13004
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
These fields are set by external secrets when we apply these resources. When using ArgoCD and server side apply it causes ArgoCD to see these resources as always out of sync due to argoproj/argo-cd#13004