### PR TITLE
fix: avoid double apply of workflows

### DIFF
--- a/apps/appsets/workflows.yaml
+++ b/apps/appsets/workflows.yaml
@@ -18,12 +18,6 @@ spec:
     spec:
       project: default
       sources:
-        - repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
-          targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
-          path: 'workflows/argo-events'
-          directory:
-            recurse: true
-            include: '{roles/*.yaml,rolebindings/*.yaml,secrets/*.yaml,sensors/*yaml,eventsources/*.yaml,workflowtemplates/*.yaml}'
         - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
           targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
           path: 'argo-workflows'


### PR DESCRIPTION
These are applied via kustomize from the workflows directory via the components AppSet under the understack-workflows Application. This was a legacy glob apply which needs to ultimately go away.