### PR TITLE
fix(keystone): fix annoying warning message about inconsistent indentation

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -214,7 +214,7 @@ conf:
         type: multistring
         values:
           - http://localhost:9990/auth/websso/
-        # - https://yourinstance.of.horizon.example.com/auth/websso/
+          # - https://yourinstance.of.horizon.example.com/auth/websso/
     DEFAULT:
       max_token_size: 512
   wsgi_keystone: |


### PR DESCRIPTION
<img width="604" alt="Screenshot 2024-09-12 at 4 42 30 PM" src="https://github.com/user-attachments/assets/14a58c0e-1b42-4c84-be21-7679f059de1b">
