### PR TITLE
chore: horizon: upgrade chart to 0.3.28

### DIFF
--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -29,7 +29,7 @@ spec:
                 - component: nova
                   chartVersion: 0.3.44
                 - component: horizon
-                  chartVersion: 0.3.27
+                  chartVersion: 0.3.28
   template:
     metadata:
       name: '{{.name}}-{{.component}}'


### PR DESCRIPTION
This is to allow setting websso_keystone_url
ref: https://review.opendev.org/c/openstack/openstack-helm/+/928957