### PR TITLE
feat: Neutron ML2 workflow calls nautobot job to set tenant networks

### DIFF
--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -291,6 +291,7 @@ class UnderstackDriver(MechanismDriver):
                 "interface_mac": mac_address,
                 "device_uuid": device_uuid,
                 "network_name": network_name,
+                "network_id": network_id,
                 "dry_run": cfg.CONF.ml2_type_understack.argo_dry_run,
                 "force": cfg.CONF.ml2_type_understack.argo_force,
             },

--- a/python/understack-workflows/understack_workflows/main/undersync_device.py
+++ b/python/understack-workflows/understack_workflows/main/undersync_device.py
@@ -65,6 +65,9 @@ def argument_parser():
         "--device-id", type=UUID, required=False, help="Nautobot device UUID"
     )
     parser.add_argument("--network-name", required=True)
+    parser.add_argument(
+        "--network-id", type=UUID, required=True, help="Nautobot network UUID"
+    )
     parser = parser_nautobot_args(parser)
     parser.add_argument(
         "--force",

--- a/python/understack-workflows/understack_workflows/main/undersync_device.py
+++ b/python/understack-workflows/understack_workflows/main/undersync_device.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 from uuid import UUID
+import requests
 
 from understack_workflows.helpers import boolean_args
 from understack_workflows.helpers import credential
@@ -12,8 +13,6 @@ from understack_workflows.undersync.client import Undersync
 
 logger = setup_logger(__name__)
 
-network_name_status = {"tenant": "Active", "provisioning": "Provisioning Interface"}
-
 
 def update_nautobot(args) -> UUID:
     device_id = args.device_id
@@ -23,18 +22,71 @@ def update_nautobot(args) -> UUID:
     nb_url = args.nautobot_url
     nb_token = args.nautobot_token or credential("nb-token", "token")
 
-    new_status = network_name_status[args.network_name]
-
-    nautobot = Nautobot(nb_url, nb_token, logger=logger)
     logger.info(f"Updating Nautobot {device_id=!s} {interface_mac=!s} {network_name=}")
+
+    if network_name == "tenant":
+        switch_id = update_nautobot_for_tenant(
+            nb_url, nb_token, interface_mac, args.network_id
+        )
+    elif network_name == "provisioning":
+        switch_id = update_nautobot_for_provisioning(
+            nb_url, nb_token, device_id, interface_mac
+        )
+    else:
+        raise ValueError(f"need provisioning or tenant, not {network_name=}")
+
+    logger.info(f"Updated Nautobot {device_id=!s} {interface_mac=!s} {network_name=}")
+
+    logger.info(f"Interface connected to switch {switch_id!s}")
+    return switch_id
+
+
+def update_nautobot_for_provisioning(
+    nb_url, nb_token, device_id: UUID, interface_mac: str
+):
+    new_status = "Provisioning Interface"
+    nautobot = Nautobot(nb_url, nb_token, logger=logger)
+
     interface = nautobot.update_switch_interface_status(
         device_id, interface_mac, new_status
     )
-    logger.info(f"Updated Nautobot {device_id=!s} {interface_mac=!s} {network_name=}")
-
     switch_id = interface.device.id
-    logger.info(f"Interface connected to switch {switch_id!s}")
     return switch_id
+
+
+def update_nautobot_for_tenant(
+    nb_url, nb_token, server_interface_mac: str, ucvni_id: UUID
+) -> UUID:
+    """Runs a Nautobot Job to update a switch interface for tenant mode
+
+    The nautobot job will assign vlans as required and set the interface
+    into the correct mode for "normal" tenant operation.
+
+    The switch ID is returned.
+    """
+
+    # Making this http request directly because it was not clear how to get
+    # the pynautobot api client to call an arbitrary endpoint:
+
+    uri = f"{nb_url}api/plugins/undercloud-vni/ucvni_jobs/prep_switch_interface"
+    payload = {
+        "ucvni_id": str(ucvni_id),
+        "server_interface_mac": str(server_interface_mac),
+    }
+    headers = {
+        "Authorization": f"Token {nb_token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    logger.debug(f"Running Nautobot prep_switch_interface job {uri=} {payload=}")
+
+    response = requests.request("POST", uri, headers=headers, json=payload)
+    response.raise_for_status()
+    response = response.json()
+    logger.debug(f"Nautobot prep_switch_interface job {response=}")
+
+    return response["switch_id"]
 
 
 def call_undersync(args, switch_id: UUID):

--- a/python/understack-workflows/understack_workflows/main/undersync_device.py
+++ b/python/understack-workflows/understack_workflows/main/undersync_device.py
@@ -68,7 +68,7 @@ def update_nautobot_for_tenant(
     # Making this http request directly because it was not clear how to get
     # the pynautobot api client to call an arbitrary endpoint:
 
-    uri = f"{nb_url}api/plugins/undercloud-vni/ucvni_jobs/prep_switch_interface"
+    uri = f"{nb_url}/api/plugins/undercloud-vni/ucvni_jobs/prep_switch_interface"
     payload = {
         "ucvni_id": str(ucvni_id),
         "server_interface_mac": str(server_interface_mac),

--- a/workflows/argo-events/workflowtemplates/undersync-device.yaml
+++ b/workflows/argo-events/workflowtemplates/undersync-device.yaml
@@ -22,6 +22,8 @@ spec:
           - "{{workflow.parameters.device_uuid}}"
           - --network-name
           - "{{workflow.parameters.network_name}}"
+          - --network-id
+          - "{{workflow.parameters.network_id}}"
           - --dry-run
           - "{{workflow.parameters.dry_run}}"
           - --force


### PR DESCRIPTION
We now have two separate operations:

1) to set to provisioning mode, the regular nautobot API is used to set the port status
2) to set to tenant mode, a special API call runs Milan's Nautobot job.  This will set the port status as well as creating the relevant VLAN(s).