### PR TITLE
fix: testing of the python code was wrong

### DIFF
--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -7,7 +7,7 @@ on:
     paths:
       - "python/**"
       - ".github/workflows/code-test.yaml"
-  pull_request_target:
+  pull_request:
     paths:
       - "python/**"
       - ".github/workflows/code-test.yaml"
@@ -45,7 +45,7 @@ jobs:
           cache: "poetry"
       - run: poetry install --sync --with test
       - run: poetry build
-      - run: "poetry run pytest --cov-report xml:coverage.xml"
+      - run: "poetry run pytest --cov --cov-report xml:coverage.xml"
       - uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
         with:
           coverageFile: python/${{ matrix.project }}/coverage.xml

--- a/python/neutron-understack/neutron_understack/tests/conftest.py
+++ b/python/neutron-understack/neutron_understack/tests/conftest.py
@@ -1,0 +1,26 @@
+import random
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def device_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def mac_address() -> str:
+    return (
+        f"{random.randint(0, 255):02x}:"
+        f"{random.randint(0, 255):02x}:"
+        f"{random.randint(0, 255):02x}:"
+        f"{random.randint(0, 255):02x}:"
+        f"{random.randint(0, 255):02x}:"
+        f"{random.randint(0, 255):02x}"
+    )
+
+
+@pytest.fixture
+def network_id() -> uuid.UUID:
+    return uuid.uuid4()

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from neutron_understack.neutron_understack_mech import UnderstackDriver
 from neutron_understack.argo.workflows import ArgoClient
+from neutron_understack.neutron_understack_mech import UnderstackDriver
 
 
 @pytest.fixture
@@ -11,13 +11,13 @@ def argo_client() -> ArgoClient:
     return MagicMock(spec_set=ArgoClient)
 
 
-def test_move_to_network__provisioning(argo_client):
+def test_move_to_network__provisioning(argo_client, device_id, network_id, mac_address):
     driver = UnderstackDriver()
     driver._move_to_network(
         vif_type="other",
-        mac_address="fa:16:3e:35:1c:3d",
-        device_uuid="41d18c6a-5548-4ee9-926f-4e3ebf43153f",
-        network_id="c2702769-5592-4555-8ae6-e670db82c31e",
+        mac_address=mac_address,
+        device_uuid=str(device_id),
+        network_id=str(network_id),
         argo_client=argo_client,
     )
 
@@ -25,8 +25,8 @@ def test_move_to_network__provisioning(argo_client):
         template_name="undersync-device",
         entrypoint="trigger-undersync",
         parameters={
-            "interface_mac": "fa:16:3e:35:1c:3d",
-            "device_uuid": "41d18c6a-5548-4ee9-926f-4e3ebf43153f",
+            "interface_mac": mac_address,
+            "device_uuid": str(device_id),
             "network_name": "tenant",
             "dry_run": True,
             "force": False,

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -28,6 +28,7 @@ def test_move_to_network__provisioning(argo_client, device_id, network_id, mac_a
             "interface_mac": mac_address,
             "device_uuid": str(device_id),
             "network_name": "tenant",
+            "network_id": str(network_id),
             "dry_run": True,
             "force": False,
         },


### PR DESCRIPTION
The test used `pull_request_target` which used code from the main branch instead of what the user submitted so that needs to be disabled. Fixed the test by adding the missing parameter. Made the tests more generic by using fixtures.