### PR TITLE
feat: uc-iad3-dev - redeployment for bravo iteration

### DIFF
--- a/apps/aio-app-of-apps.yaml
+++ b/apps/aio-app-of-apps.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: app-of-apps
+  namespace: argocd
 spec:
   syncPolicy:
     preserveResourcesOnDeletion: true

--- a/apps/app-of-apps.yaml
+++ b/apps/app-of-apps.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: app-of-apps
+  namespace: argocd
 spec:
   syncPolicy:
     preserveResourcesOnDeletion: true

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -163,16 +163,14 @@ spec:
                               value: '{{.name }}-cluster-issuer'
                 - component: argo-events
                   skipComponent: '{{has "argo-events" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
-                  source:
-                    repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
-                    targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
-                    path: 'components/argo-events'
-                  ignoreDifferences:
-                    - group: ''
-                      kind: ServiceAccount
-                      name: workflow
-                      jsonPointers:
-                        - /imagePullSecrets
+                  sources:
+                    - repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
+                      targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
+                      path: 'components/argo-events'
+                    - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
+                      targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
+                      ref: secrets
+                      path: 'secrets/{{.name}}/argo-events'
                 - component: understack-workflows
                   componentNamespace: argo-events
                   skipComponent: '{{has "understack-workflows" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'

--- a/apps/appsets/infra.yaml
+++ b/apps/appsets/infra.yaml
@@ -81,6 +81,14 @@ spec:
                         valueFiles:
                           - $secrets/helm-configs/{{.name}}/provisioning-ingress-nginx.yaml
                         ignoreMissingValueFiles: true
+                - component: cilium
+                  skipComponent: '{{has "cilium" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
+                  sources:
+                    # Cilium itself is deployed before ArgoCD so we only include project
+                    # and environment specific stuff here
+                    - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
+                      targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
+                      path: 'secrets/{{.name}}/cilium'
             selector:
               # by setting the key in the elements 'skipComponent' to 'true' it will skip installing it
               # ArgoCD's templating operates with strings so it's the string "true"

--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -18,6 +18,11 @@ conductor:
     # at this time we are running our own dnsmasq container and statefulset
     enabled: false
 
+labels:
+  conductor:
+    node_selector_key: ironic_role
+    node_selector_value: conductor
+
 conf:
   ironic:
     DEFAULT:

--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -145,7 +145,7 @@ pod:
             mountPath: /etc/dnsmasq.d/
           - name: dnsmasq-dhcp
             mountPath: /var/lib/dnsmasq/
-          - name: host-var-lib-understack
+          - name: understack-data
             mountPath: /var/lib/understack
         volumes:
           - name: dnsmasq-ironic
@@ -154,9 +154,9 @@ pod:
           - name: dnsmasq-dhcp
             persistentVolumeClaim:
               claimName: dnsmasq-dhcp
-          - name: host-var-lib-understack
-            hostPath:
-              path: /var/lib/understack
+          - name: understack-data
+            persistentVolumeClaim:
+              claimName: understack-data
   lifecycle:
     disruption_budget:
       api:

--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -76,7 +76,7 @@ spec:
               mountPath: /etc/dnsmasq.d
             - name: pod-dhcp
               mountPath: /var/lib/misc
-            - name: understack-images
+            - name: understack-data
               mountPath: /var/lib/understack/master_iso_images
               readOnly: true
       volumes:
@@ -88,6 +88,6 @@ spec:
         - name: pod-dhcp
           persistentVolumeClaim:
             claimName: dnsmasq-dhcp
-        - name: understack-images
-          hostPath:
-            path: /var/lib/understack/master_iso_images
+        - name: understack-data
+          persistentVolumeClaim:
+            claimName: understack-data

--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -33,6 +33,9 @@ spec:
       labels:
         application: ironic-dnsmasq
     spec:
+      nodeSelector:
+        ironic_role: conductor
+
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/components/ironic/kustomization.yaml
+++ b/components/ironic/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - dnsmasq-pvc.yaml
   - dnsmasq-cm.yaml
   - dnsmasq-ss.yaml
+  - understack-data-pvc.yaml

--- a/components/ironic/understack-data-pvc.yaml
+++ b/components/ironic/understack-data-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: understack-data
+  namespace: openstack
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/components/openstack/mariadb-instance.yaml
+++ b/components/openstack/mariadb-instance.yaml
@@ -15,7 +15,7 @@ spec:
   volumeClaimTemplate:
     resources:
       requests:
-        storage: 1Gi
+        storage: 10Gi
     accessModes:
       - ReadWriteOnce
 

--- a/docs/deploy-guide/gitops-install.md
+++ b/docs/deploy-guide/gitops-install.md
@@ -48,7 +48,11 @@ To avoid defining many environment variables we'll simplify by creating an
 place it where we've cloned understack. A complete file would like like
 
 ```bash title="/path/to/uc-deploy/my-k3s.env"
-UC_DEPLOY="$(cd "$(dirname ${BASH_SOURCE[0]})" && git rev-parse --show-toplevel)"
+if [ -n "$BASH_SOURCE" ]; then # bash
+    UC_DEPLOY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)"
+elif [ -n "$ZSH_VERSION" ]; then # zsh
+    UC_DEPLOY="$(cd "$(dirname "${(%):-%x}")" && git rev-parse --show-toplevel)"
+fi
 DEPLOY_NAME="my-k3s"
 UC_DEPLOY_GIT_URL=git@github.com:myorg/uc-deploy.git
 UC_DEPLOY_SSH_FILE="$HOME/devel/uc-deploy-key"

--- a/docs/deploy-guide/gitops-install.md
+++ b/docs/deploy-guide/gitops-install.md
@@ -180,6 +180,12 @@ Now configure your ArgoCD to have the credential access to your deploy repo:
 kubectl -n argocd apply -f "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/argocd/secret-deploy-repo.yaml"
 ```
 
+Label the node(s) to allow OpenStack control plane installation:
+
+```bash
+kubectl label node $(kubectl get nodes -o 'jsonpath={.items[*].metadata.name}') openstack-control-plane=enabled
+```
+
 Finally run the following to have ArgoCD deploy the system:
 
 ```bash

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -266,7 +266,7 @@ load_or_gen_os_secret() {
     local data_var=$1
     local secret_var=$2
 
-    if kubectl -n openstack get secret "${secret_var}" > /dev/null; then
+    if kubectl -n openstack get secret "${secret_var}" &>/dev/null; then
         data="$(kubectl -n openstack get secret "${secret_var}" -o jsonpath='{.data.password}' | base64 -d)"
         # good ol' bash 3 compat for macOS
         eval "${data_var}=\"${data}\""


### PR DESCRIPTION
This PR includes various changes required to move us to a multi-node, full K8s cluster that replaced K3s.

Related: https://github.com/RSS-Engineering/undercloud-deploy/pull/148

Closes PUC-518