### PR TITLE
chore: bump mariadb operator to 0.26.0

### DIFF
--- a/components/glance/glance-mariadb-db.yaml
+++ b/components/glance/glance-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: glance
@@ -14,7 +14,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: glance
@@ -33,7 +33,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: glance-grant

--- a/components/horizon/horizon-mariadb-db.yaml
+++ b/components/horizon/horizon-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: horizon
@@ -14,7 +14,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: horizon
@@ -33,7 +33,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: horizon-grant

--- a/components/ironic/ironic-mariadb-db.yaml
+++ b/components/ironic/ironic-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: ironic
@@ -14,7 +14,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: ironic
@@ -33,7 +33,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: ironic-grant

--- a/components/keystone/keystone-mariadb-db.yaml
+++ b/components/keystone/keystone-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: keystone
@@ -14,7 +14,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: keystone
@@ -33,7 +33,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: keystone-grant

--- a/components/neutron/neutron-mariadb-db.yaml
+++ b/components/neutron/neutron-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: neutron
@@ -14,7 +14,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: neutron
@@ -33,7 +33,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: neutron-grant

--- a/components/nova/nova-api-mariadb-db.yaml
+++ b/components/nova/nova-api-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: nova-api
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: nova-api-grant

--- a/components/nova/nova-cell0-mariadb-db.yaml
+++ b/components/nova/nova-cell0-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: nova-cell0
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: nova-cell0-grant

--- a/components/nova/nova-mariadb-db.yaml
+++ b/components/nova/nova-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: nova
@@ -14,7 +14,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: nova
@@ -33,7 +33,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: nova-grant

--- a/components/openstack/mariadb-instance.yaml
+++ b/components/openstack/mariadb-instance.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: MariaDB
 metadata:
   name: mariadb  # this name is referenced by other resource kinds
@@ -8,16 +8,15 @@ spec:
     name: mariadb
     key: root-password
 
+  # renovate: image:mariadb
   image: mariadb:11.0.3
   imagePullPolicy: IfNotPresent
 
   port: 3306
-  volumeClaimTemplate:
-    resources:
-      requests:
-        storage: 10Gi
-    accessModes:
-      - ReadWriteOnce
+  storage:
+    size: 10Gi
+    resizeInUseVolumes: true
+    waitForVolumeResize: true
 
   service:
     type: ClusterIP
@@ -29,6 +28,19 @@ spec:
     binlog_format=row
     innodb_autoinc_lock_mode=2
     max_allowed_packet=256M
+  # ArgoCD diff for server side apply
+  myCnfConfigMapKeyRef:
+    key: my.cnf
+    name: mariadb-config
 
   metrics:
     enabled: true
+    # ArgoCD diff due to server side apply
+    exporter:
+      image: prom/mysqld-exporter:v0.15.1
+      port: 9104
+    passwordSecretKeyRef:
+      key: password
+      name: mariadb-metrics-password
+    serviceMonitor: {}
+    username: mariadb-metrics

--- a/components/placement/placement-mariadb-db.yaml
+++ b/components/placement/placement-mariadb-db.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: placement
@@ -14,7 +14,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: placement
@@ -33,7 +33,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: placement-grant

--- a/docs/openstack-helm.md
+++ b/docs/openstack-helm.md
@@ -12,13 +12,13 @@ to run the [db-init][db-init] and [db-drop][db-drop] jobs by utilizing the
 correct operator resources.
 
 ```yaml
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 ```
 

--- a/operators/mariadb-operator/kustomization.yaml
+++ b/operators/mariadb-operator/kustomization.yaml
@@ -14,5 +14,5 @@ helmCharts:
   namespace: mariadb-operator
   valuesFile: values.yaml
   releaseName: mariadb-operator
-  version: 0.26.0
+  version: 0.27.0
   repo: https://mariadb-operator.github.io/mariadb-operator

--- a/operators/mariadb-operator/kustomization.yaml
+++ b/operators/mariadb-operator/kustomization.yaml
@@ -14,5 +14,5 @@ helmCharts:
   namespace: mariadb-operator
   valuesFile: values.yaml
   releaseName: mariadb-operator
-  version: 0.24.0
+  version: 0.26.0
   repo: https://mariadb-operator.github.io/mariadb-operator


### PR DESCRIPTION
The mariadb-operator had a breaking API change. This upgrades to the 0.26.0 CRDs so that we can move to the newer version. This has to be done in increments to handle all the upgrades.