### PR TITLE
fix: undersync interface status was incorrect

### DIFF
--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -77,7 +77,7 @@ spec:
             - name: pod-dhcp
               mountPath: /var/lib/misc
             - name: understack-data
-              mountPath: /var/lib/understack/master_iso_images
+              mountPath: /var/lib/understack/
               readOnly: true
       volumes:
         - name: pod-tmp

--- a/python/understack-workflows/understack_workflows/main/undersync_device.py
+++ b/python/understack-workflows/understack_workflows/main/undersync_device.py
@@ -44,7 +44,7 @@ def update_nautobot(args) -> UUID:
 def update_nautobot_for_provisioning(
     nb_url, nb_token, device_id: UUID, interface_mac: str
 ):
-    new_status = "Provisioning Interface"
+    new_status = "Provisioning-Interface"
     nautobot = Nautobot(nb_url, nb_token, logger=logger)
 
     interface = nautobot.update_switch_interface_status(


### PR DESCRIPTION
The undersync expects the port status to be `Provisioning-Interface`, not `Provisioning Interface`. This is also what is created by the Ansible.