### PR TITLE
fix: back port allowing newer boot methods on iDRAC

### DIFF
--- a/components/openstack-2024.1-jammy.yaml
+++ b/components/openstack-2024.1-jammy.yaml
@@ -23,12 +23,12 @@ images:
     keystone_fernet_setup: "ghcr.io/rackerlabs/understack/keystone:2024.1-ubuntu_jammy"
 
     # ironic
-    ironic_api: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
-    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
-    ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
-    ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
+    ironic_api: "ghcr.io/rackerlabs/understack/ironic:pr-332"
+    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:pr-332"
+    ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:pr-332"
+    ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:pr-332"
     ironic_pxe_http: "docker.io/nginx:1.13.3"
-    ironic_db_sync: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
+    ironic_db_sync: "ghcr.io/rackerlabs/understack/ironic:pr-332"
     # these want curl which apparently is in the heat image
     ironic_manage_cleaning_network: "docker.io/openstackhelm/heat:2024.1-ubuntu_jammy"
     ironic_retrive_cleaning_network: "docker.io/openstackhelm/heat:2024.1-ubuntu_jammy"

--- a/containers/ironic/Dockerfile.ironic
+++ b/containers/ironic/Dockerfile.ironic
@@ -11,7 +11,9 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY containers/ironic/drac-boot.patch /tmp/
+COPY containers/ironic/bios-apply-no-ipa.patch /tmp/
 RUN patch -d /var/lib/openstack/lib/python3.10/site-packages -p1 < /tmp/drac-boot.patch
+RUN patch -d /var/lib/openstack/lib/python3.10/site-packages -p1 < /tmp/bios-apply-no-ipa.patch
 
 COPY python/ironic-understack /tmp/ironic-understack
 RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack sushy-oem-idrac==5.0.0

--- a/containers/ironic/Dockerfile.ironic
+++ b/containers/ironic/Dockerfile.ironic
@@ -7,7 +7,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         genisoimage \
         isolinux \
+        patch \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY containers/ironic/drac-boot.patch /tmp/
+RUN patch -d /var/lib/openstack/lib/python3.10/site-packages -p1 < /tmp/drac-boot.patch
 
 COPY python/ironic-understack /tmp/ironic-understack
 RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack sushy-oem-idrac==5.0.0

--- a/containers/ironic/bios-apply-no-ipa.patch
+++ b/containers/ironic/bios-apply-no-ipa.patch
@@ -1,0 +1,26 @@
+diff --git a/ironic/drivers/modules/redfish/bios.py b/ironic/drivers/modules/redfish/bios.py
+index 6e72f0bfd..09dc10c94 100644
+--- a/ironic/drivers/modules/redfish/bios.py
++++ b/ironic/drivers/modules/redfish/bios.py
+@@ -142,8 +142,8 @@ class RedfishBIOS(base.BIOSInterface):
+             objects.BIOSSettingList.delete(
+                 task.context, node_id, delete_names)
+
+-    @base.clean_step(priority=0)
++    @base.clean_step(priority=0, requires_ramdisk=False)
+     @base.deploy_step(priority=0)
+     @base.cache_bios_settings
+     def factory_reset(self, task):
+         """Reset the BIOS settings of the node to the factory default.
+@@ -186,9 +186,9 @@ class RedfishBIOS(base.BIOSInterface):
+                       {'node_uuid': node.uuid, 'attrs': current_attrs})
+             self._clear_reboot_requested(task)
+
+-    @base.service_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO)
+-    @base.clean_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO)
++    @base.service_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO, requires_ramdisk=False)
++    @base.clean_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO, requires_ramdisk=False)
+     @base.deploy_step(priority=0, argsinfo=_APPLY_CONFIGURATION_ARGSINFO)
+     @base.cache_bios_settings
+     def apply_configuration(self, task, settings):
+         """Apply the BIOS settings to the node.

--- a/containers/ironic/drac-boot.patch
+++ b/containers/ironic/drac-boot.patch
@@ -1,0 +1,23 @@
+diff --git a/ironic/drivers/drac.py b/ironic/drivers/drac.py
+index a4ca8004b..2f8f65db9 100644
+--- a/ironic/drivers/drac.py
++++ b/ironic/drivers/drac.py
+@@ -28,6 +28,7 @@ from ironic.drivers.modules.drac import vendor_passthru
+ from ironic.drivers.modules import ipxe
+ from ironic.drivers.modules import noop
+ from ironic.drivers.modules import pxe
++from ironic.drivers.modules.redfish import boot as redfish_boot
+ from ironic.drivers.modules.redfish import firmware as redfish_firmware
+ 
+ 
+@@ -42,7 +43,9 @@ class IDRACHardware(generic.GenericHardware):
+     @property
+     def supported_boot_interfaces(self):
+         """List of supported boot interfaces."""
+-        return [ipxe.iPXEBoot, pxe.PXEBoot, boot.DracRedfishVirtualMediaBoot]
++        return [ipxe.iPXEBoot, pxe.PXEBoot, ipxe.iPXEHttpBoot,
++                boot.DracRedfishVirtualMediaBoot,
++                redfish_boot.RedfishHttpsBoot]
+ 
+     @property
+     def supported_management_interfaces(self):


### PR DESCRIPTION
With OpenStack Ironic 2024.2 we'll be able to use HTTP based boot methods. This back ports this to our 2024.1