### PR TITLE
fix(ironic-imaages): Adds package-installs element to include addition of extra useful packages

### DIFF
--- a/ironic-images/ipa-debian-bookworm/ipa-debian-bookworm.yaml
+++ b/ironic-images/ipa-debian-bookworm/ipa-debian-bookworm.yaml
@@ -4,4 +4,5 @@
   - debian-minimal
   - dynamic-login
   - journal-to-console
+  - package-installs
   - undercloud-ipa


### PR DESCRIPTION
Adds `package-installs` element to include our extra useful packages in https://github.com/rackerlabs/understack/blob/main/ironic-images/ipa-debian-bookworm/package-installs.yaml