### PR TITLE
fix: do not delete whitespace between dnsmasq options

### DIFF
--- a/containers/dnsmasq/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq/dnsmasq.conf.j2
@@ -67,7 +67,7 @@ shared-network={{ env.PROVISIONER_INTERFACE | default("eth0") }},{{ env[dhcp_pro
 {% set option_prefix = 'option:' -%}
 {% endif -%}
 dhcp-option={{ tag }}{{ option_prefix }}{{ option|replace('_', '-')|lower }},{{ value }}
-{%- endfor %}
+{% endfor %}
 {% if env[dhcp_allowed] is defined and env[dhcp_allowed] %}
 {{ dhcp_allowed_srvids_list.append(env[dhcp_allowed]) or '' }}
 {%- endif %}


### PR DESCRIPTION
This minus sign causes us to delete all whitespace prior which creates all the for loop items on the same line creating an invalid config. They need to be on their own line.