### PR TITLE
fix: argo_python: revert change of owner_name lookup

### DIFF
--- a/containers/argo_utils/code/argo_python/__init__.py
+++ b/containers/argo_utils/code/argo_python/__init__.py
@@ -45,7 +45,7 @@ class ArgoWorkflow:
             try:
                 # if KUBERNETES_POD_UID is not explicitly defined in the container env, pod get permissions will need
                 # be set for the service account running this workflow
-                owner_name = os.environ["DEVICE_ID"]
+                owner_name = os.environ["HOSTNAME"]
                 owner_id = os.getenv("KUBERNETES_POD_UID")
                 if not owner_id:
                     owner_metadata = self.get_pod(owner_name)


### PR DESCRIPTION
The owner_name variable refers to a pod name, so that Secret can be automatically cleaned up by kubernetes when the Pod is removed.