### PR TITLE
fix: sync_interfaces: make the port names unique

### DIFF
--- a/python/understack-workflows/understack_workflows/port_configuration.py
+++ b/python/understack-workflows/understack_workflows/port_configuration.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from pydantic import BaseModel
 from pydantic import StringConstraints
+from pydantic import field_serializer
 
 
 class PortConfiguration(BaseModel):
@@ -11,3 +12,8 @@ class PortConfiguration(BaseModel):
     uuid: str  # using a str here to due to ironicclient Port attribute
     node_uuid: str  # using a str here due to ironicclient Port attribute
     name: str  # port name
+
+    # Ironic requires the port names to be globally unique
+    @field_serializer('name')
+    def serialize_name(self, name: str):
+        return f"{self.uuid} {name}"


### PR DESCRIPTION
Ironic's database schema requires the baremetal port names to be unique so we prepend the Node ID.