### PR TITLE
fix(argo_utils): require the user to supply owner info

### DIFF
--- a/containers/argo_utils/code/argo_python/README.md
+++ b/containers/argo_utils/code/argo_python/README.md
@@ -2,8 +2,8 @@
 
 A quick helper method to write kubernetes secrets. This accomplishes a couple things.
 
-1) Allows us to share sensitive data to subsequent Workflows.
-2) Sets metadata.ownerReferences (to the Pod), which allows this secret to be garbage collected upon Pod removal.
+1) Allows us to share sensitive data to subsequent steps in the workflow
+2) Sets metadata.ownerReferences to the workflow where it is cleaned up once the workflow is
 
 note: to add the ownerReference for garbage collection, the Pod's uid needs to be obtained. This can either be done by
 providing get permission on the pods resource for the service account running this Pod, or by passing the Pod uid into
@@ -11,10 +11,12 @@ the container with something like:
 
 ```yaml
         env:
-        - name: KUBERNETES_POD_UID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.uid
+        - name: WF_UID
+          value: "{{workflow.uid}}"
+        - name: WF_NAME
+          value: "{{workflow.name}}"
+        - name: WF_NS
+          value: "{{workflow.namespace}}"
 ```
 
 ### Example
@@ -22,16 +24,17 @@ the container with something like:
 
     from argo_python import ArgoWorkflow
     import base64
+    import os
+    import uuid
 
     data = {
         'username': base64.b64encode("<username>".encode("utf-8")).decode(),
         'password': base64.b64encode("<password>".encode("utf-8")).decode(),
     }
 
-    workflow = ArgoWorkflow()
-    secret_name = workflow.create_secret("creds", data)
+    workflow = ArgoWorkflow(os.getenv("WF_NS"), os.getenv("WF_NAME"), os.getenv("WF_UID"))
+    secret_name = workflow.create_secret(f"creds-{uuid.uuid4()}", data)
     print(secret_name)
 
     # example output: "creds-97794d2b-338c-44c6-8587-e3086e6a1bf7"
 ```
-

--- a/containers/argo_utils/code/argo_python/__init__.py
+++ b/containers/argo_utils/code/argo_python/__init__.py
@@ -1,5 +1,4 @@
 from kubernetes import client, config
-import os
 from typing import Dict
 import logging
 
@@ -7,76 +6,61 @@ logger = logging.getLogger(__name__)
 
 
 class ArgoWorkflow:
-    def __init__(self, namespace="argo-events", config_file=None):
-
+    def __init__(self, namespace: str, name: str, uid: str, api_version="argoproj.io/v1alpha1", config_file=None):
         if config_file:
             config.load_kube_config(config_file)
         else:
             config.load_incluster_config()
 
         self.kube = client.CoreV1Api()
-        self.kube_custom = client.CustomObjectsApi()
         self.namespace = namespace
+        self.name = name
+        self.uid = uid
+        self.api_version = api_version
 
     def get_pod(self, name):
         r = self.kube.read_namespaced_pod(name, self.namespace)
         return r.metadata
 
-    def create_secret(self, name: str, data: Dict, persist=False) -> str:
+    def create_secret(self, name: str, data: Dict) -> str:
         """
         create_secret creates a kubernetes secret, setting ownerReferences to provide garbage collection.
 
         :param name: metadata.name of the kubernetes secret
         :param data: data dict to be stored in the secret
-        :param persist: whether this secret should persist or be removed with the owning Workflow
         :return: the name of the kubernetes secret
         """
 
-        secret = client.V1Secret()
-        secret.api_version = "v1"
-        secret.data = data
-        secret.kind = "Secret"
-        secret.type = "Opaque"
-        secret.metadata = {"name": f"{name}"}
+        owner = client.V1OwnerReference(
+            api_version=self.api_version,
+            kind="Workflow",
+            name=self.name,
+            uid=self.uid,
+            block_owner_deletion=True,
+            controller=True,
+        )
 
-        # to allow for kubernetes' garbage collection to reap this secret, we attempt to detect the owning resource,
-        # and then add it to the ownerReferences list.
-        if not persist:
-            try:
-                # if KUBERNETES_POD_UID is not explicitly defined in the container env, pod get permissions will need
-                # be set for the service account running this workflow
-                owner_name = os.environ["HOSTNAME"]
-                owner_id = os.getenv("KUBERNETES_POD_UID")
-                if not owner_id:
-                    owner_metadata = self.get_pod(owner_name)
-                    owner_id = owner_metadata.uid
+        meta = client.V1ObjectMeta(
+            name=name,
+            owner_references=[owner],
+        )
 
-                secret.metadata.update(
-                    {
-                        "name": f"{name}-{owner_id}",
-                        "ownerReferences": [
-                            {
-                                "apiVersion": "v1",
-                                "blockOwnerDeletion": True,
-                                "controller": True,
-                                "kind": "Pod",
-                                "name": owner_name,
-                                "uid": owner_id,
-                            }
-                        ],
-                    }
-                )
-            except KeyError:
-                raise Exception("Unable to determine ownership of secret.")
+        secret = client.V1Secret(
+            api_version="v1",
+            kind="Secret",
+            type="Opaque",
+            metadata=meta,
+            data=data,
+        )
 
         # create or update secret
         try:
-            self.kube.read_namespaced_secret(secret.metadata["name"], self.namespace)
-            r = self.kube.patch_namespaced_secret(secret.metadata["name"], self.namespace, secret)
+            self.kube.read_namespaced_secret(name, self.namespace)
+            r = self.kube.patch_namespaced_secret(name, self.namespace, secret)
             return r.metadata.name
         except client.exceptions.ApiException as e:
             if e.status == 404:
                 r = self.kube.create_namespaced_secret(self.namespace, secret)
                 return r.metadata.name
             else:
-                raise Exception(e)
+                raise

--- a/docs/component-argo-workflows.md
+++ b/docs/component-argo-workflows.md
@@ -46,11 +46,10 @@ To facilitate the ability to pass data securely between Workflows the [argo-pyth
 This Python Class writes Kubernetes Secrets directly to the Kubernetes API from the Workflow's Pod, allowing these
 Secrets to be securely mounted into a subsequent Workflow's environment.
 
-By default these Secrets are created with an ownerReference set to the Pod which created them, which allows them to be
-garbage collected when that Pod is terminated. This ownerReference requires a Kubernetes Pod uid which can be obtained
-from the Kubernetes API, requiring Pod `get` permissions to be granted to the Workflow's Service Account. Alternatively
-the Pod's uid can be passed via the `KUBERNETES_POD_UID` environment variable. To allow the owner Pod to be removed at
-completion of the Workflow `.spec.podGC.strategy` can be set to `OnWorkflowCompletion`.
+By default these Secrets are created with an ownerReference set to the Workflow which created them, which allows
+them to be garbage collected when that Workflow is terminated. The ownerReference requires details about the
+Workflow to be passed in. This is available in the Workflow from the
+[workflow variable](https://argo-workflows.readthedocs.io/en/latest/variables/#global).
 
 An example WorkflowTemplate demonstrating argo-python usage can be found
 [here](https://github.com/rackerlabs/understack/blob/main/workflows/argo-events/workflowtemplates/get-bmc-creds.yaml).

--- a/workflows/argo-events/workflowtemplates/get-bmc-creds.yaml
+++ b/workflows/argo-events/workflowtemplates/get-bmc-creds.yaml
@@ -9,10 +9,6 @@ metadata:
       Defined in `workflows/argo-events/workflowtemplates/get-bmc-creds.yaml`.
       An example template to return the name of a Kubernetes Secret which containing device's BMC credentials.
 spec:
-  # garbage collection on the secret is tied to this pod. we remove this pod only after workflow completion to
-  # allow access to this secret from subsequent workflow/steps.
-  podGC:
-    strategy: OnWorkflowCompletion
   serviceAccountName: workflow
   entrypoint: main
   arguments:
@@ -34,7 +30,11 @@ spec:
         source: |
           from argo_python import ArgoWorkflow
           import base64
+          import os
 
+          WF_NS = os.getenv("WF_NS")
+          WF_NAME = os.getenv("WF_NAME")
+          WF_UID = os.getenv("WF_UID")
           SECRET_NAME="example-secret"
           USERNAME="foo"
           PASSWORD="bar"
@@ -44,17 +44,17 @@ spec:
               'password': base64.b64encode(PASSWORD.encode("utf-8")).decode(),
           }
 
-          workflow = ArgoWorkflow()
+          workflow = ArgoWorkflow(WF_NS, WF_NAME, WF_UID)
           secret_name = workflow.create_secret(SECRET_NAME, data)
           with open("/tmp/output.txt", "w") as f:
               f.write(secret_name)
         env:
-        # pass this Pod's uid into the pod env to make it available to the argo secrets method, otherwise pod get
-        # permissions are required for the service account specified above.
-        - name: KUBERNETES_POD_UID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.uid
+        - name: WF_UID
+          value: "{{workflow.uid}}"
+        - name: WF_NAME
+          value: "{{workflow.name}}"
+        - name: WF_NS
+          value: "{{workflow.namespace}}"
         # only needed in this example Template as it's written using a ScriptTemplate which apparently doesn't seem
         # to honor the workingDir directive, and mounts the above script at /argo/staging/script.
         - name: PYTHONPATH


### PR DESCRIPTION
Instead of relying on a specific environment variable to exist in the context of running this code, require the user to supply the proper ownership information on the call of create_secret().