### PR TITLE
chore: argo-workflows: keep the successful workflows for 36 hours

### DIFF
--- a/components/argo/workflow-defaults
+++ b/components/argo/workflow-defaults
@@ -3,5 +3,5 @@ spec:
     strategy: OnWorkflowSuccess  # to allow garbage collection of secrets (created by pods) upon workflow completion
     deleteDelayDuration: 72h
   ttlStrategy:
-    secondsAfterSuccess: 300
+    secondsAfterSuccess: 129600  # 36 hours
     secondsAfterFailure: 259200  # 3 days


### PR DESCRIPTION
5 minutes is not enough for development use cases. If that becomes a scalability problem, we can adjust on a per-environment basis.