### PR TITLE
chore: upgrade mariadb-operator to 0.31.0

### DIFF
--- a/components/openstack/mariadb-instance.yaml
+++ b/components/openstack/mariadb-instance.yaml
@@ -7,6 +7,7 @@ spec:
   rootPasswordSecretKeyRef:
     name: mariadb
     key: root-password
+    generate: false
 
   # renovate: image:mariadb
   image: mariadb:11.0.3

--- a/operators/mariadb-operator/kustomization.yaml
+++ b/operators/mariadb-operator/kustomization.yaml
@@ -14,5 +14,5 @@ helmCharts:
   namespace: mariadb-operator
   valuesFile: values.yaml
   releaseName: mariadb-operator
-  version: 0.27.0
+  version: 0.31.0
   repo: https://mariadb-operator.github.io/mariadb-operator


### PR DESCRIPTION
The CRD changes are able to be done fairly cleanly to this point. After this version they've separated out the CRDs into their own chart and install them differently which will require a bigger effort so let's upgrade to this point.