### PR TITLE
chore: use SSO exclusively for authenticating users

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -36,7 +36,7 @@ bootstrap:
                     },
                     "groups": "{3}",
                      "domain": {
-                        "id": "default"
+                        "name": "sso"
                     }
                 }
             ],
@@ -76,13 +76,17 @@ bootstrap:
     # create the federation protocol 'openid' to use the identity provider 'sso' with the 'sso_mapping'
     openstack federation protocol show openid --identity-provider sso || openstack federation protocol create openid --mapping sso_mapping --identity-provider sso
 
-    # create groups which map to our groups claim from dex which can be mapped to permissions
     for group in ucadmin ucuser ucneteng ucdctech; do
-      openstack group create ${group} --or-show
-      openstack role add --group ${group} --domain default member
+      # create groups which map to our groups claim from dex which can be mapped to permissions
+      openstack group create --domain "${sso_domain_id}" ${group} --or-show
+      # give each of the groups the member role on the domain and have them inherit it to each project
+      # in the domain
+      openstack role add --group-domain "${sso_domain_id}" --group ${group} --inherited --domain default member
     done
-    openstack role add --group ucadmin --domain default admin
-    openstack role add --group ucadmin --domain infra admin
+    # ucadmin can manage the standard project domain
+    openstack role add --group-domain "${sso_domain_id}" --group ucadmin --inherited --domain default manager
+    # ucadmin can manage the infra domain
+    openstack role add --group-domain "${sso_domain_id}" --group ucadmin --inherited --domain infra manager
 
     # TODO: only create this actually requested
     # create 'demo' user with sufficient permissions

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -256,7 +256,7 @@ conf:
 
         # OIDC
         OIDCClaimPrefix "OIDC-"
-        OIDCRemoteUserClaim preferred_username ^(.*)@
+        OIDCRemoteUserClaim preferred_username
         OIDCSessionType server-cache
         OIDCXForwardedHeaders X-Forwarded-Host X-Forwarded-Proto X-Forwarded-Port
         OIDCResponseType "code"

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -88,13 +88,6 @@ bootstrap:
     # ucadmin can manage the infra domain
     openstack role add --group-domain "${sso_domain_id}" --group ucadmin --inherited --domain infra manager
 
-    # TODO: only create this actually requested
-    # create 'demo' user with sufficient permissions
-    openstack user create --or-show --password demo --email 'demo@example.com' demo
-    openstack user set --email 'demo@example.com' demo
-    # add 'demo' user to 'ucuser' group
-    openstack group add user ucuser demo
-
 network:
   # configure OpenStack Helm to use Undercloud's ingress
   # instead of expecting the ingress controller provided

--- a/docs/user-guide/openstack-cli.md
+++ b/docs/user-guide/openstack-cli.md
@@ -12,6 +12,7 @@ to already have Python on your system.
 
     ``` bash
     apt install python3-openstackclient
+    # TODO: install keystoneauth-websso
     ```
 
 === "macOS"
@@ -26,7 +27,7 @@ to already have Python on your system.
     # create Python virtualenv at $HOME/.openstack
     python -m venv $HOME/.openstack
     # install the tools
-    $HOME/.openstack/bin/pip install python-openstackclient 'python-ironicclient[cli]'
+    $HOME/.openstack/bin/pip install python-openstackclient 'python-ironicclient[cli]' keystoneauth-websso
 
     # create a binary wrapper to the virtualenv
     mkdir -p $HOME/.bin
@@ -54,17 +55,13 @@ The easiest way to configure your client is via `clouds.yaml`.
 ```yaml title="$HOME/.config/openstack/clouds.yaml"
 clouds:
   understack:
+    auth_type: v3websso
+    identity_provider: sso
+    protocol: openid
     auth:
       auth_url: https://your.endpoint.url/v3
-      user_domain_name: mydomain
-      username: myuser
-      password: mypass
       project_domain_name: mydomain
       project_name: myproject
-    region_name:
-      - MyRegion
-    interface: public
-    identity_api_version: 3
 ```
 
 With the above configuration in `$HOME/.config/openstack/clouds.yaml` you


### PR DESCRIPTION
Have users use SSO exclusively for authentication against OpenStack services.