### PR TITLE
feat: Password standard

### DIFF
--- a/python/understack-workflows/tests/test_bmc_password_standard.py
+++ b/python/understack-workflows/tests/test_bmc_password_standard.py
@@ -1,0 +1,28 @@
+import pytest
+
+from understack_workflows.bmc_password_standard import standard_password
+
+
+def test_standard_password_good_1():
+    plaintext = standard_password("10.3.2.30", "ultra-secret string")
+    assert plaintext == "DdushPf7IUTs6oya3ADS0OM3"
+
+
+def test_standard_password_good_2():
+    plaintext = standard_password("1.2.3.4", "new secret string")
+    assert plaintext == "guW1SYE7HmrOrNXF75qmiscd"
+
+
+def test_standard_password_with_empty_input():
+    with pytest.raises(ValueError):
+        standard_password("", "new secret string")
+
+
+def test_standard_password_with_bad_input():
+    with pytest.raises(ValueError):
+        standard_password("elephants", "new secret string")
+
+
+def test_standard_password_with_empty_key():
+    with pytest.raises(ValueError):
+        standard_password("1.2.3.4", "")

--- a/python/understack-workflows/tests/test_node_config.py
+++ b/python/understack-workflows/tests/test_node_config.py
@@ -25,11 +25,13 @@ def bmc_ip(interface_event: dict) -> str:
 def ironic_client() -> IronicClient:
     return MagicMock(spec_set=IronicClient)
 
+
 @pytest.fixture
 def mock_creds(mocker):
     mock = mocker.patch("understack_workflows.node_configuration.credential")
     mock.return_value = "ultra-secret credential value"
     return mock
+
 
 def test_node_config_from_event_none_event():
     with pytest.raises(ValueError):

--- a/python/understack-workflows/tests/test_sync_bmc_creds.py
+++ b/python/understack-workflows/tests/test_sync_bmc_creds.py
@@ -28,6 +28,17 @@ def mock_args(monkeypatch):
 def fake_ironic_client(mocker):
     return mocker.patch("understack_workflows.ironic.client.IronicClient")
 
+@pytest.fixture(autouse=True)
+def mock_creds_node(mocker):
+    mock = mocker.patch("understack_workflows.node_configuration.credential")
+    mock.return_value = "ultra-secret credential value"
+    return mock
+
+@pytest.fixture(autouse=True)
+def mock_creds_here(mocker):
+    mock = mocker.patch("understack_workflows.main.sync_bmc_creds.credential")
+    mock.return_value = "ultra-secret credential value"
+    return mock
 
 def get_ironic_node_state(fake_ironic_client, node_data):
     node = IronicNodeConfiguration.from_event(

--- a/python/understack-workflows/tests/test_sync_bmc_creds.py
+++ b/python/understack-workflows/tests/test_sync_bmc_creds.py
@@ -28,17 +28,20 @@ def mock_args(monkeypatch):
 def fake_ironic_client(mocker):
     return mocker.patch("understack_workflows.ironic.client.IronicClient")
 
+
 @pytest.fixture(autouse=True)
 def mock_creds_node(mocker):
     mock = mocker.patch("understack_workflows.node_configuration.credential")
     mock.return_value = "ultra-secret credential value"
     return mock
 
+
 @pytest.fixture(autouse=True)
 def mock_creds_here(mocker):
     mock = mocker.patch("understack_workflows.main.sync_bmc_creds.credential")
     mock.return_value = "ultra-secret credential value"
     return mock
+
 
 def get_ironic_node_state(fake_ironic_client, node_data):
     node = IronicNodeConfiguration.from_event(

--- a/python/understack-workflows/tests/test_sync_nautobot_system_info.py
+++ b/python/understack-workflows/tests/test_sync_nautobot_system_info.py
@@ -7,11 +7,13 @@ from understack_workflows.main.sync_nautobot_system_info import argument_parser
 def fakebot(mocker):
     return mocker.patch("understack_workflows.nautobot.Nautobot", autospec=True)
 
+
 @pytest.fixture
 def mock_creds(mocker):
     mock = mocker.patch("understack_workflows.node_configuration.credential")
     mock.return_value = "ultra-secret credential value"
     return mock
+
 
 def test_parse_device_name(mock_creds):
     parser = argument_parser(__name__)

--- a/python/understack-workflows/tests/test_sync_nautobot_system_info.py
+++ b/python/understack-workflows/tests/test_sync_nautobot_system_info.py
@@ -7,35 +7,20 @@ from understack_workflows.main.sync_nautobot_system_info import argument_parser
 def fakebot(mocker):
     return mocker.patch("understack_workflows.nautobot.Nautobot", autospec=True)
 
+@pytest.fixture
+def mock_creds(mocker):
+    mock = mocker.patch("understack_workflows.node_configuration.credential")
+    mock.return_value = "ultra-secret credential value"
+    return mock
 
-def test_parse_device_name():
+def test_parse_device_name(mock_creds):
     parser = argument_parser(__name__)
     with pytest.raises(SystemExit):
-        parser.parse_args(
-            [
-                "--device-id",
-                "FOO",
-                "--bmc_username",
-                "root",
-                "--bmc_password",
-                "password",
-            ]
-        )
+        parser.parse_args(["--device-id", "FOO"])
 
 
-def test_parse_device_id(device_id, bmc_username, bmc_password):
+def test_parse_device_id(device_id, mock_creds):
     parser = argument_parser(__name__)
-    args = parser.parse_args(
-        [
-            "--device-id",
-            str(device_id),
-            "--bmc_username",
-            bmc_username,
-            "--bmc_password",
-            bmc_password,
-        ]
-    )
+    args = parser.parse_args(["--device-id", str(device_id)])
 
     assert args.device_id == device_id
-    assert args.bmc_username == bmc_username
-    assert args.bmc_password == bmc_password

--- a/python/understack-workflows/tests/test_sync_server.py
+++ b/python/understack-workflows/tests/test_sync_server.py
@@ -30,6 +30,7 @@ def mock_args(monkeypatch):
 def fake_client(mocker):
     return mocker.patch("understack_workflows.ironic.client.IronicClient")
 
+
 @pytest.fixture
 def mock_creds(mocker):
     mock = mocker.patch("understack_workflows.node_configuration.credential")

--- a/python/understack-workflows/tests/test_sync_server.py
+++ b/python/understack-workflows/tests/test_sync_server.py
@@ -30,6 +30,12 @@ def mock_args(monkeypatch):
 def fake_client(mocker):
     return mocker.patch("understack_workflows.ironic.client.IronicClient")
 
+@pytest.fixture
+def mock_creds(mocker):
+    mock = mocker.patch("understack_workflows.node_configuration.credential")
+    mock.return_value = "ultra-secret credential value"
+    return mock
+
 
 def get_ironic_node_state(fake_client, node_data):
     node = IronicNodeConfiguration.from_event(
@@ -47,7 +53,7 @@ def test_args():
     assert var["data"]["ip_addresses"][0]["host"] == "10.46.96.156"
 
 
-def test_ironic_node_allowing_states(fake_client):
+def test_ironic_node_allowing_states(fake_client, mock_creds):
     ironic_node_state = get_ironic_node_state(
         fake_client,
         json.loads(read_json_samples("json_samples/ironic-enroll-node-data.json")),
@@ -55,7 +61,7 @@ def test_ironic_node_allowing_states(fake_client):
     assert ironic_node_state in ["enroll", "manageable"]
 
 
-def test_ironic_non_allowing_states(fake_client):
+def test_ironic_non_allowing_states(fake_client, mock_creds):
     ironic_node_state = get_ironic_node_state(
         fake_client,
         json.loads(read_json_samples("json_samples/ironic-active-node-data.json")),
@@ -63,7 +69,7 @@ def test_ironic_non_allowing_states(fake_client):
     assert ironic_node_state not in ["enroll", "manageable"]
 
 
-def test_update_ironic_node(fake_client):
+def test_update_ironic_node(fake_client, mock_creds):
     node = IronicNodeConfiguration.from_event(
         json.loads(read_json_samples("json_samples/event-interface-update.json"))
     )

--- a/python/understack-workflows/understack_workflows/bmc_password_standard.py
+++ b/python/understack-workflows/understack_workflows/bmc_password_standard.py
@@ -1,0 +1,28 @@
+import ipaddress
+from base64 import b64encode
+from hashlib import sha256
+
+PASSWORD_LENGTH = 24
+
+
+def standard_password(ip_addr: str, master_key: str) -> str:
+    """Return a password string for the given IP address.
+
+    >>> standard_password("10.3.2.30", "ultra-secret string")
+    'DdushPf7IUTs6oya3ADS0OM3'
+    """
+    try:
+        ipaddress.ip_address(ip_addr)
+    except ValueError:
+        raise ValueError(f"Need an IPv4 address, not '{ip_addr}'") from None
+
+    if not master_key:
+        raise ValueError("Missing/empty master_key!")
+
+    long_password = _sha256_string(master_key + ip_addr)
+
+    return long_password[:PASSWORD_LENGTH]
+
+
+def _sha256_string(text: str) -> str:
+    return b64encode(sha256(bytes(text, "utf-8")).digest()).decode("utf-8")

--- a/python/understack-workflows/understack_workflows/bmc_sushy.py
+++ b/python/understack-workflows/understack_workflows/bmc_sushy.py
@@ -4,7 +4,7 @@ from understack_workflows.bmc_password_standard import standard_password
 from understack_workflows.helpers import credential
 
 
-def bmc_sushy_session(ip_addr, username = "root", password = None):
+def bmc_sushy_session(ip_addr, username="root", password=None):
     url = f"https://{ip_addr}"
 
     if password is None:

--- a/python/understack-workflows/understack_workflows/bmc_sushy.py
+++ b/python/understack-workflows/understack_workflows/bmc_sushy.py
@@ -1,0 +1,14 @@
+from sushy import Sushy
+
+from understack_workflows.bmc_password_standard import standard_password
+from understack_workflows.helpers import credential
+
+
+def bmc_sushy_session(ip_addr, username = "root", password = None):
+    url = f"https://{ip_addr}"
+
+    if password is None:
+        master_secret = credential("bmc_master", "key")
+        password = standard_password(ip_addr, master_secret)
+
+    return Sushy(url, username=username, password=password, verify=False)

--- a/python/understack-workflows/understack_workflows/helpers.py
+++ b/python/understack-workflows/understack_workflows/helpers.py
@@ -58,4 +58,3 @@ def credential(subpath, item):
     ref = pathlib.Path("/etc").joinpath(subpath).joinpath(item)
     with ref.open() as f:
         return f.read().strip()
-

--- a/python/understack-workflows/understack_workflows/helpers.py
+++ b/python/understack-workflows/understack_workflows/helpers.py
@@ -4,8 +4,6 @@ import pathlib
 from functools import partial
 from urllib.parse import urlparse
 
-import sushy
-
 
 def setup_logger(name: str | None = None, level: int = logging.DEBUG):
     """Standardize our logging.
@@ -61,15 +59,3 @@ def credential(subpath, item):
     with ref.open() as f:
         return f.read().strip()
 
-
-def oob_sushy_session(oob_ip, oob_username, oob_password):
-    return sushy.Sushy(
-        f"https://{oob_ip}",
-        username=oob_username,
-        password=oob_password,
-        verify=False,
-    )
-
-
-def is_off_board(interface):
-    return "Embedded ALOM" in interface.location or "Embedded" not in interface.location

--- a/python/understack-workflows/understack_workflows/main/get_bmc_password.py
+++ b/python/understack-workflows/understack_workflows/main/get_bmc_password.py
@@ -1,0 +1,20 @@
+import sys
+
+from understack_workflows.bmc_password_standard import standard_password
+from understack_workflows.helpers import credential
+
+
+def main(program_name, bmc_ip_address=None):
+    """CLI script to obtain standard BMC Password.
+
+    Requires the master secret to be available in /etc/bmc_master/key
+    """
+    if bmc_ip_address is None:
+        print(f"Usage: {program_name} <BMC IP Address>", file=sys.stderr)
+        exit(1)
+
+    master_secret = credential("bmc_master", "key")
+    print(standard_password(bmc_ip_address, master_secret))
+
+
+main(*sys.argv)

--- a/python/understack-workflows/understack_workflows/main/sync_bmc_creds.py
+++ b/python/understack-workflows/understack_workflows/main/sync_bmc_creds.py
@@ -48,7 +48,7 @@ def main():
         sys.exit(0)
 
     # Update BMC credentials
-    bmc_ip_address = interface_update_event['data']['ip_addresses'][0]['host']
+    bmc_ip_address = interface_update_event["data"]["ip_addresses"][0]["host"]
     master_secret = credential("bmc_master", "key")
     expected_username = "root"
     expected_password = standard_password(bmc_ip_address, master_secret)

--- a/python/understack-workflows/understack_workflows/main/sync_nautobot_interfaces.py
+++ b/python/understack-workflows/understack_workflows/main/sync_nautobot_interfaces.py
@@ -15,6 +15,7 @@ logger = setup_logger(__name__)
 def is_off_board(interface):
     return "Embedded ALOM" in interface.location or "Embedded" not in interface.location
 
+
 def argument_parser(name):
     parser = argparse.ArgumentParser(
         prog=os.path.basename(name), description="Nautobot Interface sync"

--- a/python/understack-workflows/understack_workflows/main/sync_nautobot_system_info.py
+++ b/python/understack-workflows/understack_workflows/main/sync_nautobot_system_info.py
@@ -2,8 +2,8 @@ import argparse
 import os
 from uuid import UUID
 
+from understack_workflows.bmc_sushy import bmc_sushy_session
 from understack_workflows.helpers import credential
-from understack_workflows.helpers import oob_sushy_session
 from understack_workflows.helpers import parser_nautobot_args
 from understack_workflows.helpers import setup_logger
 from understack_workflows.models import Chassis
@@ -19,15 +19,13 @@ def argument_parser(name):
     parser.add_argument(
         "--device-id", type=UUID, required=True, help="Nautobot device ID"
     )
-    parser.add_argument("--bmc_username", required=False, help="BMC username")
-    parser.add_argument("--bmc_password", required=False, help="BMC password")
     parser = parser_nautobot_args(parser)
     return parser
 
 
-def do_sync(device_id: UUID, nautobot: Nautobot, bmc_user: str, bmc_pass: str):
+def do_sync(device_id: UUID, nautobot: Nautobot):
     bmc_ip = nautobot.device_oob_ip(device_id)
-    bmc_obj = oob_sushy_session(bmc_ip, bmc_user, bmc_pass)
+    bmc_obj = bmc_sushy_session(bmc_ip)
 
     chassis = Chassis.from_redfish(bmc_obj)
     nautobot.update_system_info(device_id, chassis.system_info)
@@ -38,11 +36,9 @@ def main():
     args = parser.parse_args()
 
     nb_token = args.nautobot_token or credential("nb-token", "token")
-    bmc_user = args.oob_username or credential("bmc-secrets", "username")
-    bmc_pass = args.oob_password or credential("bmc-secrets", "password")
     nautobot = Nautobot(args.nautobot_url, nb_token, logger=logger)
 
-    do_sync(args.device_id, nautobot, bmc_user, bmc_pass)
+    do_sync(args.device_id, nautobot)
 
 
 if __name__ == "__main__":

--- a/python/understack-workflows/understack_workflows/node_configuration.py
+++ b/python/understack-workflows/understack_workflows/node_configuration.py
@@ -198,7 +198,7 @@ class IronicNodeConfiguration:
         driver = "idrac" if data["name"] == "iDRAC" else "redfish"
 
         bmc_master_key = credential("bmc_master", "key")
-        bmc_ip_address = data['ip_addresses'][0]['host']
+        bmc_ip_address = data["ip_addresses"][0]["host"]
         bmc_username = "root"
         bmc_password = standard_password(bmc_ip_address, bmc_master_key)
 
@@ -207,7 +207,7 @@ class IronicNodeConfiguration:
             redfish_verify_ca=False,
             redfish_username=bmc_username,
             redfish_password=bmc_password,
-            )
+        )
 
         return IronicNodeConfiguration(
             data["device"]["id"],


### PR DESCRIPTION
Historically we obtain DRAC passwords from CORE which has issues:

- in the future we don't want baremetal nodes in CORE/DCX
- requires manual deployment steps to assign locations in DCX and configure the physical DRAC
- prevents automation of the process because we have no way of knowing which arbitrary CORE device number belongs to each auto-discovered server

The changes here make DRAC passwords that are unique on each server, but without having to store each individual password in vault, CORE, etc.

The passwords are generated based on a cryptographic hash function of the IP address and a static master key.

Plan for Transition to new passwords:

1. back up the old passwords in a safe place
2. change the password on each existing baremetal node
3. update the passwords in CORE to reflect the new standard

Plan to release this code:

5. Make the master secret available to understack workflows https://github.com/RSS-Engineering/undercloud-deploy/pull/183
6. merge this PR and check the workflows are still functional