### PR TITLE
chore: enable merge_group trigger for GHA

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -17,6 +17,8 @@ on:
       - "containers/bmc-utils/**"
       - "containers/python311_alpine/**"
       - "containers/python312_alpine/**"
+  merge_group:
+    types: [checks_requested]
 
 # bump container versions here, they will be populated to tags and labels
 env:

--- a/.github/workflows/build-ironic-images.yaml
+++ b/.github/workflows/build-ironic-images.yaml
@@ -11,6 +11,8 @@ on:
       - main
     paths:
       - 'ironic-images/**'
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   build-ironic-images:

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -12,6 +12,8 @@ on:
       - "python/**"
       - ".github/workflows/code-test.yaml"
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 # limit rapid succession from pushes
 concurrency:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -15,6 +15,8 @@ on:
       - ".github/workflows/containers.yaml"
       - "python/**"
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   openstack:

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -14,6 +14,8 @@ on:
       - "docs/**"
       - ".github/workflows/mkdocs.yml"
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -3,6 +3,8 @@ name: "Lint PR"
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 # IMPORTANT: No checkout actions, scripts, or builds should be added to this workflow. Permissions should always be used
 # with extreme caution. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   pre-commit:

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -5,6 +5,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   spellcheck:

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   lint-yaml:


### PR DESCRIPTION
This is in preparation to enable merge queues.
The `merge_group` trigger is [mandatory](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) when using [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)