### PR TITLE
docs: adds additional info for monitoring documentation and adds monitoring user

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -19,6 +19,11 @@ bootstrap:
     # give 'argoworkflow' 'admin' over the 'baremetal' project
     openstack role add --user-domain infra --project-domain infra --user argoworkflow --project baremetal admin
 
+    # create 'monitoring' user for monitoring usage
+    openstack user create --or-show --domain infra --password monitoring_demo monitoring
+    # give 'monitoring' the 'admin' over the 'baremetal' project
+    openstack role add --user-domain infra --project-domain infra --user monitoring --project baremetal admin
+
     # this is too early because ironic won't exist
     openstack role add --project service --user ironic --user-domain service service
 

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -5,3 +5,25 @@ UnderStack uses the `kube-prometheus-stack` which is a prometheus + grafana moni
 <https://github.com/prometheus-operator/kube-prometheus>
 
 It uses the namespace: `monitoring`
+
+## Accessing Prometheus
+
+Prometheus is not exposed publicly so a port-forward needs to be created
+and then you'll be able to access the Prometheus UI.
+
+``` bash
+kubectl -n monitoring port-forward service/prometheus-operated 9090:9090
+```
+
+Once the port-forward is running, you can browse to <http://localhost:9090> to access Prometheus UI.
+
+## Accessing AlertManager
+
+AlertManager is not exposed publicly so a port-forward needs to be created
+and then you'll be able to access the AlertManager UI.
+
+``` bash
+kubectl -n monitoring port-forward service/alertmanager-operated 9093:9093
+```
+
+Once the port-forward is running, you can browse to <http://localhost:9093> to access AlertManager UI.


### PR DESCRIPTION
Adds some notes around how to access prometheus and alertmanager UIs running inside of the kubernetes cluster. Also adds monitoring user for use with openstack-exporter.