### PR TITLE
chore: flips the deploy paths and rename for clarity

### DIFF
--- a/apps/appsets/argocd/appset-argocd.yaml
+++ b/apps/appsets/argocd/appset-argocd.yaml
@@ -48,7 +48,7 @@ spec:
                     value: {{.name}}-cluster-issuer
         - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
           targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-          path: '{{.name}}/secrets/argocd'
+          path: '{{.name}}/manifests/argocd'
       ignoreDifferences:
         - kind: Secret
           namespace: argocd

--- a/apps/appsets/argocd/appset-argocd.yaml
+++ b/apps/appsets/argocd/appset-argocd.yaml
@@ -48,7 +48,7 @@ spec:
                     value: {{.name}}-cluster-issuer
         - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
           targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-          path: 'secrets/{{.name}}/argocd'
+          path: '{{.name}}/secrets/argocd'
       ignoreDifferences:
         - kind: Secret
           namespace: argocd

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -42,7 +42,7 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
                       ref: deploy
-                      path: '{{.name}}/secrets/dex'
+                      path: '{{.name}}/manifests/dex'
                     - repoURL: https://charts.dexidp.io
                       chart: dex
                       targetRevision: 0.16.0
@@ -65,7 +65,7 @@ spec:
                       path: 'components/openstack'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: '{{.name}}/secrets/openstack'
+                      path: '{{.name}}/manifests/openstack'
                 - component: undersync
                   skipComponent: '{{has "undersync" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
                   sources:
@@ -74,7 +74,7 @@ spec:
                       path: 'components/undersync'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: '{{.name}}/secrets/undersync'
+                      path: '{{.name}}/manifests/undersync'
                 - component: nautobot
                   skipComponent: '{{has "nautobot" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
                   sources:
@@ -85,7 +85,7 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
                       ref: deploy
-                      path: '{{.name}}/secrets/nautobot'
+                      path: '{{.name}}/manifests/nautobot'
                     - repoURL: https://nautobot.github.io/helm-charts/
                       chart: nautobot
                       targetRevision: 2.1.3
@@ -169,7 +169,7 @@ spec:
                       path: 'components/argo-events'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: '{{.name}}/secrets/argo-events'
+                      path: '{{.name}}/manifests/argo-events'
                 - component: understack-workflows
                   componentNamespace: argo-events
                   skipComponent: '{{has "understack-workflows" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -41,7 +41,7 @@ spec:
                                 value: 'understack-cluster-issuer'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      ref: secrets
+                      ref: deploy
                       path: '{{.name}}/secrets/dex'
                     - repoURL: https://charts.dexidp.io
                       chart: dex
@@ -55,7 +55,7 @@ spec:
                             DNS_ZONE: '{{index .metadata.annotations "dns_zone" }}'
                         valueFiles:
                           - $understack/components/dex/values.yaml
-                          - $secrets/{{.name}}/helm-configs/dex.yaml
+                          - $deploy/{{.name}}/helm-configs/dex.yaml
                         ignoreMissingValueFiles: true
                 - component: openstack
                   skipComponent: '{{has "openstack" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
@@ -84,7 +84,7 @@ spec:
                       ref: understack
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      ref: secrets
+                      ref: deploy
                       path: '{{.name}}/secrets/nautobot'
                     - repoURL: https://nautobot.github.io/helm-charts/
                       chart: nautobot
@@ -99,7 +99,7 @@ spec:
                             hostname: 'nautobot.{{index .metadata.annotations "dns_zone" }}'
                         valueFiles:
                           - $understack/components/nautobot/nautobot-values.yaml
-                          - $secrets/{{.name}}/helm-configs/nautobot.yaml
+                          - $deploy/{{.name}}/helm-configs/nautobot.yaml
                         ignoreMissingValueFiles: true
                         fileParameters:
                           - name: nautobot.config
@@ -169,7 +169,6 @@ spec:
                       path: 'components/argo-events'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      ref: secrets
                       path: '{{.name}}/secrets/argo-events'
                 - component: understack-workflows
                   componentNamespace: argo-events
@@ -197,14 +196,14 @@ spec:
                       ref: understack
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      ref: secrets
+                      ref: deploy
                     - repoURL: registry.scs.community/openstack-exporter
                       chart: prometheus-openstack-exporter
                       targetRevision: 0.4.5
                       helm:
                         releaseName: prometheus-openstack-exporter
                         valueFiles:
-                          - $secrets/{{.name}}/helm-configs/openstack-exporter.yaml
+                          - $deploy/{{.name}}/helm-configs/openstack-exporter.yaml
                         ignoreMissingValueFiles: true
             selector:
               # by setting the key in the elements 'skipComponent' to 'true' it will skip installing it

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -42,7 +42,7 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
                       ref: secrets
-                      path: 'secrets/{{.name}}/dex'
+                      path: '{{.name}}/secrets/dex'
                     - repoURL: https://charts.dexidp.io
                       chart: dex
                       targetRevision: 0.16.0
@@ -55,7 +55,7 @@ spec:
                             DNS_ZONE: '{{index .metadata.annotations "dns_zone" }}'
                         valueFiles:
                           - $understack/components/dex/values.yaml
-                          - $secrets/helm-configs/{{.name}}/dex.yaml
+                          - $secrets/{{.name}}/helm-configs/dex.yaml
                         ignoreMissingValueFiles: true
                 - component: openstack
                   skipComponent: '{{has "openstack" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
@@ -65,7 +65,7 @@ spec:
                       path: 'components/openstack'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: 'secrets/{{.name}}/openstack'
+                      path: '{{.name}}/secrets/openstack'
                 - component: undersync
                   skipComponent: '{{has "undersync" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
                   sources:
@@ -74,7 +74,7 @@ spec:
                       path: 'components/undersync'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: 'secrets/{{.name}}/undersync'
+                      path: '{{.name}}/secrets/undersync'
                 - component: nautobot
                   skipComponent: '{{has "nautobot" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
                   sources:
@@ -85,7 +85,7 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
                       ref: secrets
-                      path: 'secrets/{{.name}}/nautobot'
+                      path: '{{.name}}/secrets/nautobot'
                     - repoURL: https://nautobot.github.io/helm-charts/
                       chart: nautobot
                       targetRevision: 2.1.3
@@ -99,7 +99,7 @@ spec:
                             hostname: 'nautobot.{{index .metadata.annotations "dns_zone" }}'
                         valueFiles:
                           - $understack/components/nautobot/nautobot-values.yaml
-                          - $secrets/helm-configs/{{.name}}/nautobot.yaml
+                          - $secrets/{{.name}}/helm-configs/nautobot.yaml
                         ignoreMissingValueFiles: true
                         fileParameters:
                           - name: nautobot.config
@@ -170,7 +170,7 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
                       ref: secrets
-                      path: 'secrets/{{.name}}/argo-events'
+                      path: '{{.name}}/secrets/argo-events'
                 - component: understack-workflows
                   componentNamespace: argo-events
                   skipComponent: '{{has "understack-workflows" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
@@ -204,7 +204,7 @@ spec:
                       helm:
                         releaseName: prometheus-openstack-exporter
                         valueFiles:
-                          - $secrets/helm-configs/{{.name}}/openstack-exporter.yaml
+                          - $secrets/{{.name}}/helm-configs/openstack-exporter.yaml
                         ignoreMissingValueFiles: true
             selector:
               # by setting the key in the elements 'skipComponent' to 'true' it will skip installing it

--- a/apps/appsets/infra.yaml
+++ b/apps/appsets/infra.yaml
@@ -55,14 +55,14 @@ spec:
                   sources:
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      ref: secrets
+                      ref: deploy
                     - repoURL: https://kubernetes.github.io/ingress-nginx
                       chart: ingress-nginx
                       targetRevision: 4.9.1
                       helm:
                         releaseName: ingress-nginx
                         valueFiles:
-                          - $secrets/{{.name}}/helm-configs/ingress-nginx.yaml
+                          - $deploy/{{.name}}/helm-configs/ingress-nginx.yaml
                         ignoreMissingValueFiles: true
                     - repoURL: https://kubernetes.github.io/ingress-nginx
                       chart: ingress-nginx
@@ -79,7 +79,7 @@ spec:
                               default: false
                               controllerValue: "k8s.io/provisioning-ingress-nginx"  # default: k8s.io/ingress-nginx
                         valueFiles:
-                          - $secrets/{{.name}}/helm-configs/provisioning-ingress-nginx.yaml
+                          - $deploy/{{.name}}/helm-configs/provisioning-ingress-nginx.yaml
                         ignoreMissingValueFiles: true
                 - component: cilium
                   skipComponent: '{{has "cilium" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'

--- a/apps/appsets/infra.yaml
+++ b/apps/appsets/infra.yaml
@@ -29,7 +29,7 @@ spec:
                             enabled: true
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: 'secrets/{{.name}}/cert-manager'
+                      path: '{{.name}}/secrets/cert-manager'
                 - component: metallb-system
                   skipComponent: '{{has "metallb" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
                   sources:
@@ -38,7 +38,7 @@ spec:
                       path: 'bootstrap/metallb'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: 'secrets/{{.name}}/metallb'
+                      path: '{{.name}}/secrets/metallb'
                   ignoreDifferences:
                     - group: "apiextensions.k8s.io"
                       kind: CustomResourceDefinition
@@ -62,7 +62,7 @@ spec:
                       helm:
                         releaseName: ingress-nginx
                         valueFiles:
-                          - $secrets/helm-configs/{{.name}}/ingress-nginx.yaml
+                          - $secrets/{{.name}}/helm-configs/ingress-nginx.yaml
                         ignoreMissingValueFiles: true
                     - repoURL: https://kubernetes.github.io/ingress-nginx
                       chart: ingress-nginx
@@ -79,7 +79,7 @@ spec:
                               default: false
                               controllerValue: "k8s.io/provisioning-ingress-nginx"  # default: k8s.io/ingress-nginx
                         valueFiles:
-                          - $secrets/helm-configs/{{.name}}/provisioning-ingress-nginx.yaml
+                          - $secrets/{{.name}}/helm-configs/provisioning-ingress-nginx.yaml
                         ignoreMissingValueFiles: true
                 - component: cilium
                   skipComponent: '{{has "cilium" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
@@ -88,7 +88,7 @@ spec:
                     # and environment specific stuff here
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: 'secrets/{{.name}}/cilium'
+                      path: '{{.name}}/secrets/cilium'
             selector:
               # by setting the key in the elements 'skipComponent' to 'true' it will skip installing it
               # ArgoCD's templating operates with strings so it's the string "true"

--- a/apps/appsets/infra.yaml
+++ b/apps/appsets/infra.yaml
@@ -29,7 +29,7 @@ spec:
                             enabled: true
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: '{{.name}}/secrets/cert-manager'
+                      path: '{{.name}}/manifests/cert-manager'
                 - component: metallb-system
                   skipComponent: '{{has "metallb" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
                   sources:
@@ -38,7 +38,7 @@ spec:
                       path: 'bootstrap/metallb'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: '{{.name}}/secrets/metallb'
+                      path: '{{.name}}/manifests/metallb'
                   ignoreDifferences:
                     - group: "apiextensions.k8s.io"
                       kind: CustomResourceDefinition
@@ -88,7 +88,7 @@ spec:
                     # and environment specific stuff here
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: '{{.name}}/secrets/cilium'
+                      path: '{{.name}}/manifests/cilium'
             selector:
               # by setting the key in the elements 'skipComponent' to 'true' it will skip installing it
               # ArgoCD's templating operates with strings so it's the string "true"

--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -45,7 +45,7 @@ spec:
         - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
           targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
           path: '{{.name}}/secrets/{{.component}}'
-          ref: secrets
+          ref: deploy
         - repoURL: https://tarballs.opendev.org/openstack/openstack-helm/
           chart: '{{.component}}'
           targetRevision: '{{.chartVersion}}'
@@ -54,8 +54,8 @@ spec:
             valueFiles:
               - $understack/components/openstack-2024.1-jammy.yaml
               - $understack/components/{{.component}}/aio-values.yaml
-              - $secrets/{{.name}}/secrets/secret-openstack.yaml
-              - $secrets/{{.name}}/helm-configs/{{.component}}.yaml
+              - $deploy/{{.name}}/secrets/secret-openstack.yaml
+              - $deploy/{{.name}}/helm-configs/{{.component}}.yaml
             # don't require all the values files
             ignoreMissingValueFiles: true
       ignoreDifferences:

--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -44,7 +44,7 @@ spec:
           ref: understack
         - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
           targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-          path: 'secrets/{{.name}}/{{.component}}'
+          path: '{{.name}}/secrets/{{.component}}'
           ref: secrets
         - repoURL: https://tarballs.opendev.org/openstack/openstack-helm/
           chart: '{{.component}}'
@@ -54,8 +54,8 @@ spec:
             valueFiles:
               - $understack/components/openstack-2024.1-jammy.yaml
               - $understack/components/{{.component}}/aio-values.yaml
-              - $secrets/secrets/{{.name}}/secret-openstack.yaml
-              - $secrets/helm-configs/{{.name}}/{{.component}}.yaml
+              - $secrets/{{.name}}/secrets/secret-openstack.yaml
+              - $secrets/{{.name}}/helm-configs/{{.component}}.yaml
             # don't require all the values files
             ignoreMissingValueFiles: true
       ignoreDifferences:

--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -44,7 +44,7 @@ spec:
           ref: understack
         - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
           targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-          path: '{{.name}}/secrets/{{.component}}'
+          path: '{{.name}}/manifests/{{.component}}'
           ref: deploy
         - repoURL: https://tarballs.opendev.org/openstack/openstack-helm/
           chart: '{{.component}}'
@@ -54,7 +54,7 @@ spec:
             valueFiles:
               - $understack/components/openstack-2024.1-jammy.yaml
               - $understack/components/{{.component}}/aio-values.yaml
-              - $deploy/{{.name}}/secrets/secret-openstack.yaml
+              - $deploy/{{.name}}/manifests/secret-openstack.yaml
               - $deploy/{{.name}}/helm-configs/{{.component}}.yaml
             # don't require all the values files
             ignoreMissingValueFiles: true

--- a/apps/appsets/operators.yaml
+++ b/apps/appsets/operators.yaml
@@ -34,7 +34,7 @@ spec:
                         releaseName: rook-ceph
                         valueFiles:
                           - $understack/operators/rook/values-operator.yaml
-                          - $deploy/helm-configs/{{.name}}/rook-operator.yaml
+                          - $deploy/{{.name}}/helm-configs/rook-operator.yaml
                         ignoreMissingValueFiles: true
                     - repoURL: https://charts.rook.io/release
                       chart: rook-ceph-cluster
@@ -43,7 +43,7 @@ spec:
                         releaseName: rook-ceph-cluster
                         valueFiles:
                           - $understack/operators/rook/values-cluster.yaml
-                          - $deploy/helm-configs/{{.name}}/rook-cluster.yaml
+                          - $deploy/{{.name}}/helm-configs/rook-cluster.yaml
                         ignoreMissingValueFiles: true
                 - component: cnpg-system
                   skipComponent: '{{has "cnpg-system" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
@@ -87,7 +87,7 @@ spec:
                         releaseName: kube-prometheus-stack
                         valueFiles:
                           - $understack/operators/monitoring/values.yaml
-                          - $deploy/helm-configs/{{.name}}/monitoring.yaml
+                          - $deploy/{{.name}}/helm-configs/monitoring.yaml
                         ignoreMissingValueFiles: true
             selector:
               # by setting the key in the elements 'skipComponent' to 'true' it will skip installing it

--- a/docs/deploy-guide/add-remove-app.md
+++ b/docs/deploy-guide/add-remove-app.md
@@ -18,7 +18,7 @@ repo.
 
 ### Kustomize
 
-To make changes you will need to add or modify files in `$DEPLOY_NAME/secrets/$APPLICATION/`
+To make changes you will need to add or modify files in `$DEPLOY_NAME/manifests/$APPLICATION/`
 in your deployment repo.
 
 ## Removing an application for a specific deploy

--- a/docs/deploy-guide/add-remove-app.md
+++ b/docs/deploy-guide/add-remove-app.md
@@ -13,12 +13,12 @@ first determine if it's being deployed with Helm or Kustomize.
 ### Helm
 
 Most of the applications can have their Helm values overridden by adding
-or modifying `helm-configs/$DEPLOY_NAME/$APPLICATION.yaml` in your deployment
+or modifying `$DEPLOY_NAME/helm-configs/$APPLICATION.yaml` in your deployment
 repo.
 
 ### Kustomize
 
-To make changes you will need to add or modify files in `secrets/$DEPLOY_NAME/$APPLICATION/`
+To make changes you will need to add or modify files in `$DEPLOY_NAME/secrets/$APPLICATION/`
 in your deployment repo.
 
 ## Removing an application for a specific deploy

--- a/docs/deploy-guide/auth.md
+++ b/docs/deploy-guide/auth.md
@@ -8,7 +8,7 @@ services and a connector must be configured to provide authentication.
     Unfortunately we need to use the domain ID (UUID) and not the domain name in the
     Dex configuration. This is not known before hand. So at this time you must copy
     the `config.connectors` section from `values-generic.yaml` or `values-azure.yaml`
-    into `helm-configs/${DEPLOY_NAME}/dexidp.yaml` and change the value of the
+    into `${DEPLOY_NAME}/helm-configs/dexidp.yaml` and change the value of the
     `domain` key in the `keystone_internal` section to the UUID of the `operator`
     domain.
 
@@ -41,11 +41,11 @@ You will then make a note of the following pieces of information for your applic
 
 #### Azure Dex Configuration
 
-In `clusters/${DEPLOY_NAME}/components/dexidp.yaml` under the `valuesFiles` key
+In `${DEPLOY_NAME}/helm-configs/dexidp.yaml` under the `valuesFiles` key
 add `$values/components/dexidp/values-azure.yaml` beneath  `values-generic.yaml`
 like:
 
-```yaml title="clusters/${DEPLOY_NAME}/components/dexidp.yaml"
+```yaml title="${DEPLOY_NAME}/helm-configs/dexidp.yaml"
 spec:
   sources:
     - chart: dex
@@ -55,7 +55,7 @@ spec:
         valuesFiles:
             - $values/components/dexidp/values-generic.yaml
             - $values/components/dexidp/values-azure.yaml
-            - $secrets/helm-configs/YOUR_CLUSTER/dexidp.yaml
+            - $secrets/YOUR_CLUSTER/helm-configs/dexidp.yaml
 # rest omitted
 ```
 
@@ -68,7 +68,7 @@ kubectl --namespace dex \
     --from-literal=client-id={client_id} \
     --from-literal=client-secret={client_secret} \
     --from-literal=redirect-uri=https://dex.${DNS_ZONE}/callback \
-    -o yaml > ${UC_DEPLOY}/secrets/${DEPLOY_NAME}/secret-oidc-sso-dex.yaml
+    -o yaml > ${UC_DEPLOY}/${DEPLOY_NAME}/secrets/secret-oidc-sso-dex.yaml
 ```
 
 You must remember to add this secret to your secret storage (e.g. for
@@ -92,9 +92,9 @@ to different parts of the system. The default groups through the system are:
 ### Nautobot
 
 To customize the administrator group set the following in your
-`helm-configs/${DEPLOY_NAME}/nautobot.yaml`
+`${DEPLOY_NAME}/helm-configs/nautobot.yaml`
 
-```yaml title="helm-configs/${DEPLOY_NAME}/nautobot.yaml"
+```yaml title="${DEPLOY_NAME}/helm-configs/nautobot.yaml"
 nautobot:
   extraEnvVars:
     # ignoring existing values here, don't remove

--- a/docs/deploy-guide/auth.md
+++ b/docs/deploy-guide/auth.md
@@ -53,9 +53,9 @@ spec:
       helm:
         # context omitted
         valuesFiles:
-            - $values/components/dexidp/values-generic.yaml
-            - $values/components/dexidp/values-azure.yaml
-            - $secrets/YOUR_CLUSTER/helm-configs/dexidp.yaml
+            - $understack/components/dexidp/values-generic.yaml
+            - $understack/components/dexidp/values-azure.yaml
+            - $deploy/YOUR_CLUSTER/helm-configs/dexidp.yaml
 # rest omitted
 ```
 

--- a/docs/deploy-guide/auth.md
+++ b/docs/deploy-guide/auth.md
@@ -68,7 +68,7 @@ kubectl --namespace dex \
     --from-literal=client-id={client_id} \
     --from-literal=client-secret={client_secret} \
     --from-literal=redirect-uri=https://dex.${DNS_ZONE}/callback \
-    -o yaml > ${UC_DEPLOY}/${DEPLOY_NAME}/secrets/secret-oidc-sso-dex.yaml
+    -o yaml > ${UC_DEPLOY}/${DEPLOY_NAME}/manifests/secret-oidc-sso-dex.yaml
 ```
 
 You must remember to add this secret to your secret storage (e.g. for

--- a/docs/deploy-guide/extra-regions.md
+++ b/docs/deploy-guide/extra-regions.md
@@ -42,7 +42,7 @@ for production deployments.
 # from your understack checkout
 ./scripts/gitops-secrets-gen.sh ${UC_DEPLOY}/my-region.env
 pushd "${UC_DEPLOY}"
-git add secrets/my-region
+git add my-region
 git commit -m "my-region: secrets generation"
 popd
 ```
@@ -51,7 +51,7 @@ popd
 
 Now you must generate a configuration for your cluster, which will need to
 live where you deploy ArgoCD Applications. Within this repos scripts that
-would be `$UC_DEPLOY/secrets/$MAIN_DEPLOY/argocd/` and then you must
+would be `$UC_DEPLOY/$MAIN_DEPLOY/secrets/argocd/` and then you must
 add the file to the `kustomization.yaml` resources.
 
 ```bash title="generating a cluster config"
@@ -91,7 +91,7 @@ Once you've completed your cluster config you can run it through `kubeseal`
 with:
 
 ```bash
-cat cluster-config.yaml | kubeseal -o yaml -w $UC_DEPLOY/secrets/$MAIN_DEPLOY/argocd/secret-my-region-cluster.yaml
+cat cluster-config.yaml | kubeseal -o yaml -w $UC_DEPLOY/$MAIN_DEPLOY/secrets/argocd/secret-my-region-cluster.yaml
 ```
 
 [gitops]: <https://about.gitlab.com/topics/gitops/>

--- a/docs/deploy-guide/gitops-install.md
+++ b/docs/deploy-guide/gitops-install.md
@@ -174,13 +174,13 @@ to your git server so that ArgoCD can access it.
 Configure your ArgoCD to be aware of your cluster:
 
 ```bash
-kubectl -n argocd apply -f "${UC_DEPLOY}/${DEPLOY_NAME}/secrets/argocd/secret-*-cluster.yaml"
+kubectl -n argocd apply -f "${UC_DEPLOY}/${DEPLOY_NAME}/manifests/argocd/secret-*-cluster.yaml"
 ```
 
 Now configure your ArgoCD to have the credential access to your deploy repo:
 
 ```bash
-kubectl -n argocd apply -f "${UC_DEPLOY}/${DEPLOY_NAME}/secrets/argocd/secret-deploy-repo.yaml"
+kubectl -n argocd apply -f "${UC_DEPLOY}/${DEPLOY_NAME}/manifests/argocd/secret-deploy-repo.yaml"
 ```
 
 Label the node(s) to allow OpenStack control plane installation:

--- a/docs/deploy-guide/gitops-install.md
+++ b/docs/deploy-guide/gitops-install.md
@@ -132,7 +132,7 @@ for production deployments.
 # from your understack checkout
 ./scripts/gitops-secrets-gen.sh ${UC_DEPLOY}/my-k3s.env
 pushd "${UC_DEPLOY}"
-git add secrets/my-k3s
+git add my-k3s
 git commit -m "my-k3s: secrets generation"
 popd
 ```
@@ -146,8 +146,7 @@ the deployment of all the components of UnderStack.
 # from your understack checkout
 ./scripts/gitops-deploy.sh ${UC_DEPLOY}/my-k3s.env
 pushd "${UC_DEPLOY}"
-git add clusters/my-k3s
-git add helm-configs/my-k3s
+git add my-k3s
 git commit -m "my-k3s: initial cluster config"
 popd
 ```
@@ -163,7 +162,7 @@ ensure that you `git push` your `$UC_DEPLOY` repo so that ArgoCD can access it.
 
 For authentication, please review the [authentication](auth.md) documentation.
 
-For OpenStack Helm components, an empty file in `$UC_DEPLOY/helm-configs/my-k3s`
+For OpenStack Helm components, an empty file in `$UC_DEPLOY/my-k3s/helm-configs`
 has been created for each component for you to use for customization.
 
 ## Doing the Deployment
@@ -175,13 +174,13 @@ to your git server so that ArgoCD can access it.
 Configure your ArgoCD to be aware of your cluster:
 
 ```bash
-kubectl -n argocd apply -f "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/argocd/secret-*-cluster.yaml"
+kubectl -n argocd apply -f "${UC_DEPLOY}/${DEPLOY_NAME}/secrets/argocd/secret-*-cluster.yaml"
 ```
 
 Now configure your ArgoCD to have the credential access to your deploy repo:
 
 ```bash
-kubectl -n argocd apply -f "${UC_DEPLOY}/secrets/${DEPLOY_NAME}/argocd/secret-deploy-repo.yaml"
+kubectl -n argocd apply -f "${UC_DEPLOY}/${DEPLOY_NAME}/secrets/argocd/secret-deploy-repo.yaml"
 ```
 
 Label the node(s) to allow OpenStack control plane installation:

--- a/scripts/gitops-deploy.sh
+++ b/scripts/gitops-deploy.sh
@@ -27,6 +27,7 @@ fi
 # set temp path so we can reset it after import
 UC_REPO_PATH="$(cd "${SCRIPTS_DIR}" && git rev-parse --show-toplevel)"
 
+# shellcheck disable=SC1090
 . "$1"
 
 # set the value again after import

--- a/scripts/gitops-deploy.sh
+++ b/scripts/gitops-deploy.sh
@@ -47,10 +47,8 @@ if [ "x${DEPLOY_NAME}" = "x" ]; then
     usage
 fi
 
-UC_REPO_APPS="${UC_REPO}/apps"
 UC_REPO_COMPONENTS="${UC_REPO}/components"
-UC_DEPLOY_CLUSTER="${UC_DEPLOY}/clusters/${DEPLOY_NAME}"
-UC_DEPLOY_HELM_CFG="${UC_DEPLOY}/helm-configs/${DEPLOY_NAME}"
+UC_DEPLOY_HELM_CFG="${UC_DEPLOY}/${DEPLOY_NAME}/helm-configs"
 
 export DNS_ZONE
 export UC_DEPLOY_GIT_URL

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -60,8 +60,8 @@ fi
 
 export DNS_ZONE
 export DEPLOY_NAME
-mkdir -p "${UC_DEPLOY}/secrets/${DEPLOY_NAME}"
-DEST_DIR="${UC_DEPLOY}/secrets/${DEPLOY_NAME}"
+DEST_DIR="${UC_DEPLOY}/${DEPLOY_NAME}/secrets"
+mkdir -p "${DEST_DIR}"
 
 ###
 ### start of secrets for each component

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -60,7 +60,7 @@ fi
 
 export DNS_ZONE
 export DEPLOY_NAME
-DEST_DIR="${UC_DEPLOY}/${DEPLOY_NAME}/secrets"
+DEST_DIR="${UC_DEPLOY}/${DEPLOY_NAME}/manifests"
 mkdir -p "${DEST_DIR}"
 
 ###


### PR DESCRIPTION
Flipped the paths in the deploy repo so that the name of the deployment is at the top-level. Renamed secrets to manifests since there is more in there than secrets and folks have complained. Renamed the reference to the deploy repo to deploy from secrets.