### PR TITLE
fix(ironic): always use our container for ironic

### DIFF
--- a/components/openstack-2024.1-jammy.yaml
+++ b/components/openstack-2024.1-jammy.yaml
@@ -23,12 +23,12 @@ images:
     keystone_fernet_setup: "ghcr.io/rackerlabs/understack/keystone:2024.1-ubuntu_jammy"
 
     # ironic
-    ironic_api: "docker.io/openstackhelm/ironic:2024.1-ubuntu_jammy"
+    ironic_api: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
     ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
-    ironic_pxe: "docker.io/openstackhelm/ironic:2024.1-ubuntu_jammy"
-    ironic_pxe_init: "docker.io/openstackhelm/ironic:2024.1-ubuntu_jammy"
+    ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
+    ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
     ironic_pxe_http: "docker.io/nginx:1.13.3"
-    ironic_db_sync: "docker.io/openstackhelm/ironic:2024.1-ubuntu_jammy"
+    ironic_db_sync: "ghcr.io/rackerlabs/understack/ironic:2024.1-ubuntu_jammy"
     # these want curl which apparently is in the heat image
     ironic_manage_cleaning_network: "docker.io/openstackhelm/heat:2024.1-ubuntu_jammy"
     ironic_retrive_cleaning_network: "docker.io/openstackhelm/heat:2024.1-ubuntu_jammy"


### PR DESCRIPTION
We're building our own container. We should use it for more than just the conductor to keep things in sync.