### PR TITLE
feat: argocd: configure oauth2 client id for CLI usage

### DIFF
--- a/bootstrap/argocd/components/sso/kustomization.yaml
+++ b/bootstrap/argocd/components/sso/kustomization.yaml
@@ -17,3 +17,4 @@ patches:
           clientID: $argocd-sso:client-id
           clientSecret: $argocd-sso:client-secret
           requestedIDTokenClaims: {"groups": {"essential": true}}
+          cliClientID: argocdcli


### PR DESCRIPTION
This is a public client so has to be separate from the web one.

Related:
https://github.com/RSS-Engineering/undercloud-deploy/pull/195