### PR TITLE
feat: add Crossplane and disable flavor bootstrap script (PUC-598)

### DIFF
--- a/apps/appsets/operators.yaml
+++ b/apps/appsets/operators.yaml
@@ -88,6 +88,23 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
                       ref: deploy
+                - component: crossplane
+                  skipComponent: '{{has "crossplane" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
+                  sources:
+                    - repoURL: https://charts.crossplane.io/stable
+                      chart: crossplane
+                      targetRevision: 1.17.1
+                      helm:
+                        releaseName: crossplane
+                        valueFiles:
+                          - $deploy/helm-configs/{{.name}}/crossplane.yaml
+                        ignoreMissingValueFiles: true
+                    - repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
+                      targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
+                      path: 'components/crossplane'
+                    - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
+                      targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
+                      ref: deploy
             selector:
               # by setting the key in the elements 'skipComponent' to 'true' it will skip installing it
               # ArgoCD's templating operates with strings so it's the string "true"

--- a/components/crossplane/kustomization.yaml
+++ b/components/crossplane/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- provider-openstack.yaml

--- a/components/crossplane/provider-openstack.yaml
+++ b/components/crossplane/provider-openstack.yaml
@@ -1,0 +1,6 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-openstack
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-openstack:v0.4.0

--- a/components/keystone/kustomization.yaml
+++ b/components/keystone/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - keystone-mariadb-db.yaml
   - keystone-rabbitmq-queue.yaml
   - external-secret-keystone-sso.yaml
+  - secret-keystone-admin-crossplane.yaml
+  - provider-openstack-config.yaml

--- a/components/keystone/provider-openstack-config.yaml
+++ b/components/keystone/provider-openstack-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: openstack.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: provider-openstack-config
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      key: config
+      name: keystone-admin-crossplane
+      namespace: openstack

--- a/components/keystone/secret-keystone-admin-crossplane.yaml
+++ b/components/keystone/secret-keystone-admin-crossplane.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: keystone-admin-crossplane
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openstack
+  target:
+    name: keystone-admin-crossplane
+    template:
+      engineVersion: v2
+      data:
+        config: |
+          {
+            "auth_url": "{{ .OS_AUTH_URL }}",
+            "user_domain_name": "{{ .OS_USER_DOMAIN_NAME }}",
+            "user_name": "{{ .OS_USERNAME }}",
+            "password": "{{ .OS_PASSWORD }}",
+            "project_domain_name": "{{ .OS_PROJECT_DOMAIN_NAME }}",
+            "tenant_name": "{{ .OS_PROJECT_NAME }}",
+            "insecure": "false"
+          }
+  dataFrom:
+    - extract:
+        key: keystone-keystone-admin
+        # necessary to avoid argoproj/argo-cd#13004
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/components/nova/aio-values.yaml
+++ b/components/nova/aio-values.yaml
@@ -45,6 +45,12 @@ conf:
       project_domain_name: infra
       project_name: baremetal
 
+bootstrap:
+  # disable using the bootstrap script for flavors since it is too limited for our needs
+  # we'll use crossplane at this time and eventually an operator
+  structured:
+    flavors:
+      enabled: false
 
 console:
   # we are working with baremetal nodes and not QEMU so we don't need novnc or spice

--- a/docs/deploy-guide/define-flavors.md
+++ b/docs/deploy-guide/define-flavors.md
@@ -1,0 +1,30 @@
+# Defining OpenStack Nova Flavors
+
+Flavors are used to advertise to the user what hardware types are available
+for consumption. Flavors must be defined and configured to map to Ironic
+hardware types that are available.
+
+## Flavor Definition with Crossplane
+
+Create the following YAML to load.
+
+```yaml
+apiVersion: compute.openstack.crossplane.io/v1alpha1
+kind: FlavorV2
+metadata:
+  name: gp1-small
+spec:
+  forProvider:
+    name: gp1.small
+    vcpus: 16
+    ram: 98304
+    disk: 480
+    isPublic: true
+    extraSpecs:
+      'resources:CUSTOM_BAREMETAL_GP1SMALL': '1'
+      'resources:DISK_GB': '0'
+      'resources:MEMORY_MB': '0'
+      'resources:VCPU': '0'
+  providerConfigRef:
+    name: provider-openstack-config
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
     - deploy-guide/extra-regions.md
     - deploy-guide/external-argocd.md
     - deploy-guide/add-remove-app.md
+    - deploy-guide/define-flavors.md
   - 'User Guide':
     - user-guide/index.md
     - user-guide/openstack-cli.md


### PR DESCRIPTION
Add Crossplane to be deployed and configured with the OpenStack provider so that we can use that to create OpenStack resources from Crossplane. Configured Crossplane with the Keystone admin user. Added some information on how to define a flavor in nova using Crossplane and disabled the nova bootstrap script creating flavors.