### PR TITLE
feat: refactor cert-manager issuer for better default

### DIFF
--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -50,9 +50,6 @@ spec:
                               - op: replace
                                 path: /spec/tls/0/hosts/0
                                 value: dex.{{index .metadata.annotations "dns_zone" }}
-                              - op: replace
-                                path: '/metadata/annotations/cert-manager.io~1cluster-issuer'
-                                value: 'understack-cluster-issuer'
                     - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
                       ref: deploy
@@ -85,9 +82,6 @@ spec:
                         releaseName: nautobot
                         valuesObject:
                           ingress:
-                            annotations:
-                              cert-manager.io/cluster-issuer: 'understack-cluster-issuer'
-                              nginx.ingress.kubernetes.io/backend-protocol: HTTPS
                             hostname: 'nautobot.{{index .metadata.annotations "dns_zone" }}'
                         valueFiles:
                           - $understack/components/nautobot/nautobot-values.yaml
@@ -158,9 +152,6 @@ spec:
                             - op: replace
                               path: /spec/tls/0/hosts/0
                               value: workflows.{{index .metadata.annotations "dns_zone" }}
-                            - op: replace
-                              path: '/metadata/annotations/cert-manager.io~1cluster-issuer'
-                              value: 'understack-cluster-issuer'
                 - component: argo-events
                   skipComponent: '{{has "argo-events" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'
                   sources:

--- a/components/argo/ingress.yaml
+++ b/components/argo/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: understack-cluster-issuer
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   name: argo-workflows

--- a/components/dex/ingress.yaml
+++ b/components/dex/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: dex
   annotations:
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: understack-cluster-issuer
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
 spec:
   ingressClassName: nginx

--- a/components/glance/aio-values.yaml
+++ b/components/glance/aio-values.yaml
@@ -17,12 +17,25 @@ endpoints:
         public: 443
     scheme:
       public: https
+    host_fqdn_override:
+      public:
+        tls:
+          secretName: glance-tls-public
+          issuerRef:
+            name: understack-cluster-issuer
+            kind: ClusterIssuer
 
 network:
   # configure OpenStack Helm to use Undercloud's ingress
   # instead of expecting the ingress controller provided
   # by OpenStack Helm
   use_external_ingress_controller: true
+  api:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        # set our default issuer
+        cert-manager.io/cluster-issuer: understack-cluster-issuer
 
 # Glance storage backend
 # we'll switch to radosgw in the future

--- a/components/horizon/aio-values.yaml
+++ b/components/horizon/aio-values.yaml
@@ -14,11 +14,27 @@ conf:
         allowed_hosts:
           - '*'
 
+endpoints:
+  dashboard:
+    host_fqdn_override:
+      public:
+        tls:
+          secretName: keystone-tls-public
+          issuerRef:
+            name: understack-cluster-issuer
+            kind: ClusterIssuer
+
 network:
   # configure OpenStack Helm to use Undercloud's ingress
   # instead of expecting the ingress controller provided
   # by OpenStack Helm
   use_external_ingress_controller: true
+  dashboard:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        # set our default issuer
+        cert-manager.io/cluster-issuer: understack-cluster-issuer
 
 # (nicholas.kuechler) updating the jobs list to remove the 'horizon-db-init' job.
 dependencies:

--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -82,6 +82,13 @@ endpoints:
         public: 443
     scheme:
       public: https
+    host_fqdn_override:
+      public:
+        tls:
+          secretName: ironic-tls-public
+          issuerRef:
+            name: understack-cluster-issuer
+            kind: ClusterIssuer
 
 network:
   api:
@@ -92,6 +99,8 @@ network:
         cluster: "nginx-openstack"
       annotations:
         nginx.ingress.kubernetes.io/rewrite-target: /
+        # set our default issuer
+        cert-manager.io/cluster-issuer: understack-cluster-issuer
     external_policy_local: false
     node_port:
       enabled: false

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -98,6 +98,12 @@ network:
   # instead of expecting the ingress controller provided
   # by OpenStack Helm
   use_external_ingress_controller: true
+  api:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        # set our default issuer
+        cert-manager.io/cluster-issuer: understack-cluster-issuer
 
 dependencies:
   static:
@@ -317,6 +323,13 @@ endpoints:
     port:
       api:
         public: 443
+    host_fqdn_override:
+      public:
+        tls:
+          secretName: keystone-tls-public
+          issuerRef:
+            name: understack-cluster-issuer
+            kind: ClusterIssuer
 
 manifests:
   job_credential_cleanup: false

--- a/components/nautobot/nautobot-values.yaml
+++ b/components/nautobot/nautobot-values.yaml
@@ -66,5 +66,5 @@ ingress:
   tls: true
   secretName: "nautobot-ingress-tls"
   annotations:
-    cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+    cert-manager.io/cluster-issuer: understack-cluster-issuer
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS

--- a/components/neutron/aio-values.yaml
+++ b/components/neutron/aio-values.yaml
@@ -17,6 +17,13 @@ endpoints:
         public: 443
     scheme:
       public: https
+    host_fqdn_override:
+      public:
+        tls:
+          secretName: neutron-tls-public
+          issuerRef:
+            name: understack-cluster-issuer
+            kind: ClusterIssuer
 
 
 network:
@@ -28,6 +35,12 @@ network:
   # instead of expecting the ingress controller provided
   # by OpenStack Helm
   use_external_ingress_controller: true
+  server:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        # set our default issuer
+        cert-manager.io/cluster-issuer: understack-cluster-issuer
 
 conf:
   plugins:

--- a/components/nova/aio-values.yaml
+++ b/components/nova/aio-values.yaml
@@ -24,6 +24,13 @@ endpoints:
         public: 443
     scheme:
       public: https
+    host_fqdn_override:
+      public:
+        tls:
+          secretName: nova-tls-public
+          issuerRef:
+            name: understack-cluster-issuer
+            kind: ClusterIssuer
 
 network:
   # we're using ironic and actual switches
@@ -34,6 +41,12 @@ network:
   # instead of expecting the ingress controller provided
   # by OpenStack Helm
   use_external_ingress_controller: true
+  osapi:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        # set our default issuer
+        cert-manager.io/cluster-issuer: understack-cluster-issuer
 
 conf:
   ceph:

--- a/components/openstack-secrets.tpl.yaml
+++ b/components/openstack-secrets.tpl.yaml
@@ -33,12 +33,6 @@ endpoints:
     host_fqdn_override:
       public:
         host: keystone.${DNS_ZONE}
-        tls:
-          # must match the value in the top level 'secrets' key for the public endpoint
-          secretName: keystone-tls-public
-          issuerRef:
-            name: understack-cluster-issuer
-            kind: ClusterIssuer
 
   # 'oslo_cache' is the memcache layer
   oslo_cache:
@@ -108,12 +102,6 @@ endpoints:
     host_fqdn_override:
       public:
         host: ironic.${DNS_ZONE}
-        tls:
-          # must match the value in the top level 'secrets' key for the public endpoint
-          secretName: ironic-tls-public
-          issuerRef:
-            name: understack-cluster-issuer
-            kind: ClusterIssuer
 
   # 'image' is the glance service
   image:
@@ -121,12 +109,6 @@ endpoints:
     host_fqdn_override:
       public:
         host: glance.${DNS_ZONE}
-        tls:
-          # must match the value in the top level 'secrets' key for the public endpoint
-          secretName: glance-tls-public
-          issuerRef:
-            name: understack-cluster-issuer
-            kind: ClusterIssuer
 
   # 'network' is the neutron service
   network:
@@ -134,12 +116,6 @@ endpoints:
     host_fqdn_override:
       public:
         host: neutron.${DNS_ZONE}
-        tls:
-          # must match the value in the top level 'secrets' key for the public endpoint
-          secretName: neutron-tls-public
-          issuerRef:
-            name: understack-cluster-issuer
-            kind: ClusterIssuer
 
   # 'compute' is the nova service
   compute:
@@ -147,12 +123,6 @@ endpoints:
     host_fqdn_override:
       public:
         host: nova.${DNS_ZONE}
-        tls:
-          # must match the value in the top level 'secrets' key for the public endpoint
-          secretName: nova-tls-public
-          issuerRef:
-            name: understack-cluster-issuer
-            kind: ClusterIssuer
 
   # 'placement' is the nova service
   placement:
@@ -160,12 +130,6 @@ endpoints:
     host_fqdn_override:
       public:
         host: placement.${DNS_ZONE}
-        tls:
-          # must match the value in the top level 'secrets' key for the public endpoint
-          secretName: placement-tls-public
-          issuerRef:
-            name: understack-cluster-issuer
-            kind: ClusterIssuer
 
   # 'dashboard' is the horizon service
   dashboard:
@@ -173,12 +137,6 @@ endpoints:
     host_fqdn_override:
       public:
         host: horizon.${DNS_ZONE}
-        tls:
-          # must match the value in the top level 'secrets' key for the public endpoint
-          secretName: horizon-tls-public
-          issuerRef:
-            name: understack-cluster-issuer
-            kind: ClusterIssuer
 
 # necessary cause the ingress definition in openstack-helm-infra helm-toolkit hardcodes this
 secrets:

--- a/components/placement/aio-values.yaml
+++ b/components/placement/aio-values.yaml
@@ -6,6 +6,12 @@ network:
   # instead of expecting the ingress controller provided
   # by OpenStack Helm
   use_external_ingress_controller: true
+  api:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        # set our default issuer
+        cert-manager.io/cluster-issuer: understack-cluster-issuer
 
 # (nicholas.kuechler) updating the jobs list to remove the 'placement-db-init' job.
 dependencies:
@@ -63,3 +69,10 @@ endpoints:
     port:
       api:
         public: 443
+    host_fqdn_override:
+      public:
+        tls:
+          secretName: placement-tls-public
+          issuerRef:
+            name: understack-cluster-issuer
+            kind: ClusterIssuer

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -144,7 +144,7 @@ if [ ! -f "${DEST_DIR}/cert-manager/cluster-issuer.yaml" ]; then
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: ${DEPLOY_NAME}-cluster-issuer
+  name: understack-cluster-issuer
   annotations:
     argocd.argoproj.io/sync-wave: "5"
 spec:


### PR DESCRIPTION
Default all the services to use the 'understack-cluster-issuer' which is documented as the issuer that needs to be provided to create HTTPS entries for everything. This removes the amount of configuration that needs to be done per deployment.