### PR TITLE
feat(workflows): enroll-server moves it to available state

### DIFF
--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -125,6 +125,10 @@ def main():
 
     logger.info(f"{__file__} complete for {bmc.ip_address}")
 
+    # argo workflows captures stdout as the results which we can use
+    # return the device UUID
+    print(str(nb_device.id))
+
 
 def argument_parser():
     parser = argparse.ArgumentParser(

--- a/workflows/argo-events/workflowtemplates/enroll-server.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-server.yaml
@@ -8,10 +8,45 @@ metadata:
       Defined in `workflows/argo-events/workflowtemplates/enroll-server.yaml`
 kind: WorkflowTemplate
 spec:
+  entrypoint: main
   arguments:
     parameters:
       - name: ip_address
   templates:
+    - name: main
+      steps:
+        - - name: enroll-server
+            template: enroll-server
+        - - name: server-enroll-state
+            template: openstack-state-cmd
+            arguments:
+              parameters:
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
+        - - name: manage-server
+            template: openstack-wait-cmd
+            arguments:
+              parameters:
+                - name: operation
+                  value: "manage"
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
+            when: "{{steps.server-enroll-state.outputs.result}} == enroll"
+        - - name: server-manage-state
+            template: openstack-state-cmd
+            arguments:
+              parameters:
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
+        - - name: avail-server
+            template: openstack-wait-cmd
+            arguments:
+              parameters:
+                - name: operation
+                  value: "provide"
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
+            when: "{{steps.server-manage-state.outputs.result}} == manageable"
     - name: enroll-server
       inputs:
         parameters:
@@ -47,6 +82,61 @@ spec:
         - name: nb-token
           secret:
             secretName: nautobot-token
+        - name: openstack-svc-acct
+          secret:
+            secretName: openstack-svc-acct
+    - name: openstack-wait-cmd
+      inputs:
+        parameters:
+          - name: operation
+          - name: device_id
+      container:
+        image: ghcr.io/rackerlabs/understack/openstack-client:2024.2-ubuntu_jammy
+        command:
+          - openstack
+        args:
+          - baremetal
+          - node
+          - "{{inputs.parameters.operation}}"
+          - --wait
+          - "0"
+          - "{{inputs.parameters.device_id}}"
+        env:
+          - name: OS_CLOUD
+            value: understack
+        volumeMounts:
+          - mountPath: /etc/openstack
+            name: openstack-svc-acct
+            readOnly: true
+      volumes:
+        - name: openstack-svc-acct
+          secret:
+            secretName: openstack-svc-acct
+    - name: openstack-state-cmd
+      inputs:
+        parameters:
+          - name: device_id
+      container:
+        image: ghcr.io/rackerlabs/understack/openstack-client:2024.2-ubuntu_jammy
+        command:
+          - openstack
+        args:
+          - baremetal
+          - node
+          - show
+          - "-f"
+          - value
+          - "-c"
+          - provision_state
+          - "{{inputs.parameters.device_id}}"
+        env:
+          - name: OS_CLOUD
+            value: understack
+        volumeMounts:
+          - mountPath: /etc/openstack
+            name: openstack-svc-acct
+            readOnly: true
+      volumes:
         - name: openstack-svc-acct
           secret:
             secretName: openstack-svc-acct


### PR DESCRIPTION
Make the enroll-server script return the device UUID so we can use it for future steps. Then add the process to move the node from enroll to manage and then finally to available.