### PR TITLE
fix(ironic): ensure ironic has access to nodes

### DIFF
--- a/components/ironic/ironic-ks-user-baremetal.yaml
+++ b/components/ironic/ironic-ks-user-baremetal.yaml
@@ -1,0 +1,158 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic-ks-user-role-add
+data:
+  ks-role-add.sh: |
+    #!/bin/bash -ex
+
+    IFS=','
+    for role in ${SERVICE_OS_ROLES}; do
+      openstack role add \
+        --project-domain infra --project baremetal \
+        --user-domain ${SERVICE_OS_USER_DOMAIN_NAME} --user ${SERVICE_OS_USERNAME} \
+        "${role}"
+    done
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ironic-ks-user-baremetal
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    app.kubernetes.io/component: ks-user-baremetal
+    app.kubernetes.io/instance: ironic
+    app.kubernetes.io/name: ironic
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ks-user-baremetal
+        app.kubernetes.io/instance: ironic
+        app.kubernetes.io/name: ironic
+    spec:
+      serviceAccountName: ironic-ks-user
+      restartPolicy: OnFailure
+      containers:
+      - name: ks-user-baremetal
+        image: ghcr.io/rackerlabs/understack/openstack-client:2024.2-ubuntu_jammy
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        - -c
+        - /tmp/ks-role-add.sh
+        volumeMounts:
+          - name: pod-tmp
+            mountPath: /tmp
+          - name: ks-user-role-add
+            mountPath: /tmp/ks-role-add.sh
+            subPath: ks-role-add.sh
+            readOnly: true
+        env:
+          - name: OS_IDENTITY_API_VERSION
+            value: "3"
+          - name: OS_AUTH_URL
+            valueFrom:
+              secretKeyRef:
+                key: OS_AUTH_URL
+                name: ironic-keystone-admin
+          - name: OS_REGION_NAME
+            valueFrom:
+              secretKeyRef:
+                key: OS_REGION_NAME
+                name: ironic-keystone-admin
+          - name: OS_INTERFACE
+            valueFrom:
+              secretKeyRef:
+                key: OS_INTERFACE
+                name: ironic-keystone-admin
+          - name: OS_ENDPOINT_TYPE
+            valueFrom:
+              secretKeyRef:
+                key: OS_INTERFACE
+                name: ironic-keystone-admin
+          - name: OS_PROJECT_DOMAIN_NAME
+            valueFrom:
+              secretKeyRef:
+                key: OS_PROJECT_DOMAIN_NAME
+                name: ironic-keystone-admin
+          - name: OS_PROJECT_NAME
+            valueFrom:
+              secretKeyRef:
+                key: OS_PROJECT_NAME
+                name: ironic-keystone-admin
+          - name: OS_USER_DOMAIN_NAME
+            valueFrom:
+              secretKeyRef:
+                key: OS_USER_DOMAIN_NAME
+                name: ironic-keystone-admin
+          - name: OS_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: OS_USERNAME
+                name: ironic-keystone-admin
+          - name: OS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: OS_PASSWORD
+                name: ironic-keystone-admin
+          - name: OS_DEFAULT_DOMAIN
+            valueFrom:
+              secretKeyRef:
+                key: OS_DEFAULT_DOMAIN
+                name: ironic-keystone-admin
+          - name: SERVICE_OS_USER_DOMAIN_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ironic-keystone-user
+                key: OS_USER_DOMAIN_NAME
+          - name: SERVICE_OS_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: ironic-keystone-user
+                key: OS_USERNAME
+          - name: SERVICE_OS_ROLES
+            value: "admin,service"
+      initContainers:
+      - name: init
+        image: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 65534
+        command:
+        - kubernetes-entrypoint
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INTERFACE_NAME
+          value: eth0
+        - name: PATH
+          value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/
+        - name: DEPENDENCY_SERVICE
+          value: openstack:keystone-api
+        - name: DEPENDENCY_DAEMONSET
+        - name: DEPENDENCY_JOB
+          value: ironic-ks-user
+        - name: DEPENDENCY_CONTAINER
+        - name: DEPENDENCY_POD_JSON
+        - name: DEPENDENCY_CUSTOM_RESOURCE
+      volumes:
+        - name: pod-tmp
+          emptyDir: {}
+        - name: ks-user-role-add
+          configMap:
+            name: ironic-ks-user-role-add
+            defaultMode: 0555

--- a/components/ironic/kustomization.yaml
+++ b/components/ironic/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - dnsmasq-cm.yaml
   - dnsmasq-ss.yaml
   - understack-data-pvc.yaml
+  - ironic-ks-user-baremetal.yaml


### PR DESCRIPTION
The nodes are created in the infra domain under the baremetal project so ensure that the ironic service account has access to that project.