### PR TITLE
ci: avoid building containers on PR close

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   openstack:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     strategy:
@@ -67,6 +68,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
 
   dnsmasq:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The PR close trigger should clean up our containers and not build them when the PR is closed.