### PR TITLE
fix: enroll-server: remove unnecesary parameter definition

### DIFF
--- a/workflows/argo-events/workflowtemplates/enroll-server.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-server.yaml
@@ -48,9 +48,6 @@ spec:
                   value: "{{steps.enroll-server.outputs.result}}"
             when: "{{steps.server-manage-state.outputs.result}} == manageable"
     - name: enroll-server
-      inputs:
-        parameters:
-          - name: ip_address
       container:
         image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
         command:


### PR DESCRIPTION
`input.parameters` section defines the local input parameters, but the container template uses  `"{{workflow.parameters.ip_address}}"` which refers to the global parameter which is already defined [here](https://github.com/rackerlabs/understack/blob/98576ce56dcbd36ae5dd8669e87e27018b34dc51/workflows/argo-events/workflowtemplates/enroll-server.yaml#L12).