### PR TITLE
chore(ironic): bump sushy-oem-idrac for 2024.2

### DIFF
--- a/containers/ironic/Dockerfile.ironic
+++ b/containers/ironic/Dockerfile.ironic
@@ -10,4 +10,4 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY python/ironic-understack /tmp/ironic-understack
-RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack sushy-oem-idrac==5.0.0
+RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack sushy-oem-idrac==6.0.0


### PR DESCRIPTION
Use the latest sushy-oem-idrac which has some fixes around virtual media attachment and handling of jobs.