### PR TITLE
fix: NIC matching on server enroll

### DIFF
--- a/python/understack-workflows/understack_workflows/bmc_chassis_info.py
+++ b/python/understack-workflows/understack_workflows/bmc_chassis_info.py
@@ -211,7 +211,9 @@ def parse_lldp_port(port_data: dict[str, str]) -> dict:
 
 
 def interface_is_relevant(url: str) -> bool:
-    return bool(re.match(r".*(iDRAC.Embedded.*|NIC.(Integrated|Slot).\d-\d)$", url))
+    return bool(
+        re.match(r".*(iDRAC.Embedded.*|NIC.(Integrated|Slot).\d-\d(:?-\d)?)$", url)
+    )
 
 
 def server_interface_name(name: str) -> str:


### PR DESCRIPTION
Before:

    >>> interface_is_relevant("NIC.Slot.2-1-1")
    False
    >>> interface_is_relevant("NIC.Slot.2-1")
    True

After:

    >>> interface_is_relevant("NIC.Slot.2-1-1")
    True
    >>> interface_is_relevant("NIC.Slot.2-1")
    True
    >>>

Closes PUC-658