### PR TITLE
ci: fix to build on containers on main merge

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   openstack:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
 
     strategy:
@@ -68,7 +68,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
 
   dnsmasq:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
 
     steps:
@@ -109,6 +109,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   workflows:
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
We should be building their containers when things are merged into main and cleaning them up on PRs being closed.