### PR TITLE
ci: split up code coverage reporting to support forks

### DIFF
--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -21,10 +21,6 @@ concurrency:
 
 jobs:
   python:
-    permissions:
-      contents: read
-      pull-requests: write
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -48,7 +44,24 @@ jobs:
       - run: poetry install --sync --with test
       - run: poetry build
       - run: "poetry run pytest --cov --cov-report xml:coverage.xml"
-      - uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
+      - uses: actions/upload-artifact@v4
         with:
-          coverageFile: python/${{ matrix.project }}/coverage.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
+          name: coverage-${{ matrix.project }}
+          path: python/${{ matrix.project }}/coverage.xml
+          retention-days: 1
+
+  coverage-upload:
+    needs: python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+      - run: |
+          npx cobertura-merge-globby -o output.xml --files=python/**/coverage.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage.xml
+          path: coverage.xml
+          retention-days: 1

--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -1,0 +1,27 @@
+name: Coverage Report
+
+on:
+  workflow_run:
+    workflows: ["code tests"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  coverage-report:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage.xml
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
+        with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Make it possible to support forks by splitting the code coverage reporting into two steps. Forks cannot make changes against the main repo so they cannot update the ticket so it must be split into two parts. Simplify the reporting as well by merging it together into one coverage file.