### PR TITLE
chore: update renovate configs for reuse and enable some auto merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
     ":prNotPending",
     ":rebaseStalePrs",
     "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
+    ":maintainLockFilesMonthly",
     ":automergeDigest"
   ],
   "customDatasources": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
     ":approveMajorUpdates",
     ":prNotPending",
     ":rebaseStalePrs",
+    "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
     ":automergeDigest"
   ],
   "customDatasources": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,16 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "configMigration": true,
   "extends": [
-    "config:recommended",
-    "customManagers:dockerfileVersions",
-    "customManagers:githubActionsVersions",
-    "helpers:pinGitHubActionDigests",
-    ":approveMajorUpdates",
-    "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
-    "github>rackerlabs/understack//.github/renovate/precommit",
-    "github>rackerlabs/understack//.github/renovate/nautobot",
-    ":maintainLockFilesMonthly",
-    ":automergeDigest"
+    "github>rackerlabs/understack//.github/renovate/default",
+    "github>rackerlabs/understack//.github/renovate/nautobot"
   ],
   "customDatasources": {
     "openstackhelm": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
     "helpers:pinGitHubActionDigests",
     ":approveMajorUpdates",
     "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
+    "github>rackerlabs/understack//.github/renovate/precommit",
     ":maintainLockFilesMonthly",
     ":automergeDigest"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
     ":approveMajorUpdates",
     "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
     "github>rackerlabs/understack//.github/renovate/precommit",
+    "github>rackerlabs/understack//.github/renovate/nautobot",
     ":maintainLockFilesMonthly",
     ":automergeDigest"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,8 +7,6 @@
     "customManagers:githubActionsVersions",
     "helpers:pinGitHubActionDigests",
     ":approveMajorUpdates",
-    ":prNotPending",
-    ":rebaseStalePrs",
     "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
     ":maintainLockFilesMonthly",
     ":automergeDigest"

--- a/.github/renovate/automergeGitHubActions.json
+++ b/.github/renovate/automergeGitHubActions.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    }
+  ]
+}

--- a/.github/renovate/default.json
+++ b/.github/renovate/default.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "configMigration": true,
+  "extends": [
+    "config:recommended",
+    "customManagers:dockerfileVersions",
+    "customManagers:githubActionsVersions",
+    "helpers:pinGitHubActionDigests",
+    ":approveMajorUpdates",
+    "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
+    "github>rackerlabs/understack//.github/renovate/precommit",
+    ":maintainLockFilesMonthly",
+    ":automergeDigest"
+  ]
+}

--- a/.github/renovate/nautobot.json
+++ b/.github/renovate/nautobot.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "groupName": "nautobot",
+      "matchPackageNames": ["nautobot"],
+      "matchPackagePatterns": [".*/nautobot$"],
+      "datasources": ["pypi", "docker"]
+    }
+  ]
+}

--- a/.github/renovate/precommit.json
+++ b/.github/renovate/precommit.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.pre-commit-config.yaml$"],
+      "matchStrings": [
+        "python: python(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "python-version",
+      "versioningTemplate": "python",
+      "depNameTemplate": "python"
+    }
+  ]
+}


### PR DESCRIPTION
Split up the renovate configs so we can reuse them in some other repos. Enabled auto merging of GitHub Actions minor and patch updates.