### PR TITLE
fix: Corrupted transfers from Glance

### DIFF
--- a/components/glance/aio-values.yaml
+++ b/components/glance/aio-values.yaml
@@ -70,6 +70,22 @@ pod:
       api:
         min_available: 1
 
+  probes:
+    api:
+      glance-api:
+        readiness:
+          enabled: true
+          params:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+        liveness:
+          enabled: true
+          params:
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 8
+            failureThreshold: 6
 manifests:
   job_db_init: false
   job_rabbit_init: false

--- a/components/glance/aio-values.yaml
+++ b/components/glance/aio-values.yaml
@@ -69,7 +69,8 @@ pod:
     disruption_budget:
       api:
         min_available: 1
-
+  resources:
+    enabled: true
   probes:
     api:
       glance-api:

--- a/components/glance/aio-values.yaml
+++ b/components/glance/aio-values.yaml
@@ -87,6 +87,16 @@ pod:
             periodSeconds: 10
             timeoutSeconds: 8
             failureThreshold: 6
+
+conf:
+  glance_api_uwsgi:
+    uwsgi:
+      # This should be set to anything larger than 1.
+      # Otherwise uWSGI is not able to serve multiple requests at the same time
+      # under heavy load, which results in liveness probe failures in
+      # Kubernetes environment.
+      processes: 2
+
 manifests:
   job_db_init: false
   job_rabbit_init: false


### PR DESCRIPTION
OK, so this is summary of what problem does that solve:

Kubelet executes a liveness probe every 10 seconds to check if Glance is alive, but Glance is not able to respond in time when under load.
This causes the liveness probe to fail, making kubelet ask containerd to stop the container. This is first part of the problem.
The second part of the problem is that upon receiving SIGTERM from kubelet, the uWSGI master process is supposed to gracefully shut down and wait for the ongoing requests to complete, but in reality it sends SIGHUP to the child immediately.

Combination of these two issues results in the image transfers being interrupted.

The first part of the problem partially stems from the fact that each glance-api pod is by default configured to run only a single process, running a single thread. If the worker is already serving a request and the healthcheck request arrives, it will be queued until the original request completes.
Often this will take longer than a default of 5 seconds. This configuration seems inappropriately restrictive. In the initial testing, raising the number of pre-started workers to 4 resolved the problem.

Closes PUC-665