### PR TITLE
feat: script to easily display BMC password

### DIFF
--- a/python/understack-workflows/devbox.json
+++ b/python/understack-workflows/devbox.json
@@ -16,7 +16,7 @@
     "init_hook": [
       "echo 'Welcome to Understack understack_workflows devbox!' > /dev/null",
       ". $VENV_DIR/bin/activate",
-      "poetry install --with=test"
+      "poetry install --with=test -q"
     ],
     "scripts": {
       "test": [

--- a/python/understack-workflows/devbox.lock
+++ b/python/understack-workflows/devbox.lock
@@ -411,7 +411,7 @@
     },
     "python3@3.11": {
       "last_modified": "2024-06-12T20:55:33Z",
-      "plugin_version": "0.0.3",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/a9858885e197f984d92d7fe64e9fff6b2e488d40#python3",
       "source": "devbox-search",
       "version": "3.11.9",

--- a/python/understack-workflows/pyproject.toml
+++ b/python/understack-workflows/pyproject.toml
@@ -47,6 +47,8 @@ sync-provision-state = "understack_workflows.main.sync_provision_state:main"
 undersync-switch = "understack_workflows.main.undersync_switch:main"
 undersync-device = "understack_workflows.main.undersync_device:main"
 enroll-server = "understack_workflows.main.enroll_server:main"
+bmc-password = "understack_workflows.main.print_bmc_password:main"
+bmc-kube-password = "understack_workflows.main.bmc_display_password:main"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/python/understack-workflows/understack_workflows/main/bmc_display_password.py
+++ b/python/understack-workflows/understack_workflows/main/bmc_display_password.py
@@ -1,0 +1,41 @@
+import base64
+import subprocess
+import sys
+
+from understack_workflows import bmc_password_standard
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: bmc-kube-password <ip_addr>", file=sys.stderr)
+        sys.exit(1)
+
+    ip_addr = sys.argv[1]
+    master_key = (
+        subprocess.check_output(
+            [
+                "kubectl",
+                "get",
+                "secret",
+                "-n",
+                "argo-events",
+                "bmc-master",
+                "-o",
+                "jsonpath={.data.key}",
+            ]
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    master_key = base64.b64decode(master_key).decode("utf-8")
+    if not master_key:
+        print("Unable to obtain master secret", file=sys.stderr)
+        sys.exit(2)
+
+    print(
+        bmc_password_standard.standard_password(ip_addr=ip_addr, master_key=master_key)
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This hooks up existing  Steve's script, but also adds another that will automatically retrieve the current value of the BMC master key from the cluster that user is connected to.

Example run:

```
$ devbox run bmc-kube-password 10.4.13.1
lREDACTEDREDACTEDRED
$
```