### PR TITLE
fix: chrony NTP settings

### DIFF
--- a/components/chrony/deployment.yaml
+++ b/components/chrony/deployment.yaml
@@ -18,6 +18,6 @@ spec:
         image: dockurr/chrony@sha256:7dc19aa12f5e5da7aaa3640c6700012087d0eedd5bd4ece2a25cf42088637d62
         env:
         - name: NTP_SERVERS
-          value: time.rackspace.net
+          value: time.iad.rackspace.net,0.pool.ntp.org,1.pool.ntp.org
       restartPolicy: Always
       dnsPolicy: ClusterFirst

--- a/ironic-images/ipa-debian-bookworm.yaml
+++ b/ironic-images/ipa-debian-bookworm.yaml
@@ -6,3 +6,4 @@
   - journal-to-console
   - package-installs
   - undercloud-ipa
+  - install-static

--- a/ironic-images/static/etc/chrony/chrony.conf
+++ b/ironic-images/static/etc/chrony/chrony.conf
@@ -1,0 +1,41 @@
+# Include configuration files found in /etc/chrony/conf.d.
+confdir /etc/chrony/conf.d
+
+# Do not Use Debian vendor zone.
+# This was commented out to make sure that we only use NTP sources
+# configured through DHCP.
+# pool 2.debian.pool.ntp.org iburst
+
+# Use time sources from DHCP.
+sourcedir /run/chrony-dhcp
+
+# Use NTP sources found in /etc/chrony/sources.d.
+sourcedir /etc/chrony/sources.d
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can't be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3


### PR DESCRIPTION
The `time.rackspace.net` does not exist anymore, it has to be region specific now. This change also includes fallback to two other NTP pools.

This PR resolves a bug where the booted IPA image did not have the correct time set.

```
root@debian:~# chronyc tracking
Reference ID    : 0A04CC03 (10.4.204.3)
Stratum         : 4
Ref time (UTC)  : Wed Nov 13 12:22:59 2024
System time     : 0.000000373 seconds slow of NTP time
Last offset     : +0.000354720 seconds
RMS offset      : 0.000183107 seconds
Frequency       : 3.873 ppm slow
Residual freq   : +1.198 ppm
Skew            : 1.266 ppm
Root delay      : 0.011129249 seconds
Root dispersion : 0.018068938 seconds
Update interval : 130.0 seconds
Leap status     : Normal
root@debian:~#
```


Closes PUC-413