### PR TITLE
feat: stop waiting for all interfaces to be online in IPA

### DIFF
--- a/ironic-images/ipa-debian-bookworm.yaml
+++ b/ironic-images/ipa-debian-bookworm.yaml
@@ -6,3 +6,4 @@
   - journal-to-console
   - package-installs
   - undercloud-ipa
+  - install-static

--- a/ironic-images/static/etc/systemd/system/systemd-networkd-wait-online.service.d/justone.conf
+++ b/ironic-images/static/etc/systemd/system/systemd-networkd-wait-online.service.d/justone.conf
@@ -1,0 +1,4 @@
+[Service]
+ExecStart=
+# Wait for at least one interface to become online and have IPv4 address
+ExecStart=/lib/systemd/systemd-networkd-wait-online --any -4 --timeout 60


### PR DESCRIPTION
This changes behavior of `systemd-networkd-wait-online` so that it does not wait the default 120s for all of interfaces to become online, which in reality never comes effectively delaying boot for 2 minutes.

Instead, we are satisfied with just one interface reaching the IPv4 routable state.

Closes PUC-580