### PR TITLE
feat: Have Enroll power on server and retry fetching LLDP info

### DIFF
--- a/python/understack-workflows/tests/test_bmc_chassis_info.py
+++ b/python/understack-workflows/tests/test_bmc_chassis_info.py
@@ -40,6 +40,16 @@ def read_fixture(path, filename):
         return json.loads(f.read())
 
 
+def test_chassis_neighbors():
+    bmc = FakeBmc(read_fixtures("json_samples/bmc_chassis_info/R7615"))
+    chassis_info = bmc_chassis_info.chassis_info(bmc)
+    assert chassis_info.neighbors == {
+        "C4:7E:E0:E4:10:7F",
+        "C4:4D:84:48:61:80",
+        "C4:7E:E0:E4:32:DF",
+    }
+
+
 def test_chassis_info_R7615():
     bmc = FakeBmc(read_fixtures("json_samples/bmc_chassis_info/R7615"))
     assert bmc_chassis_info.chassis_info(bmc) == bmc_chassis_info.ChassisInfo(

--- a/python/understack-workflows/tests/test_bmc_chassis_info.py
+++ b/python/understack-workflows/tests/test_bmc_chassis_info.py
@@ -48,6 +48,7 @@ def test_chassis_info_R7615():
         serial_number="33GSW04",
         bios_version="1.6.10",
         bmc_ip_address="1.2.3.4",
+        power_on=True,
         interfaces=[
             bmc_chassis_info.InterfaceInfo(
                 name="iDRAC",

--- a/python/understack-workflows/tests/test_nautobot_device.py
+++ b/python/understack-workflows/tests/test_nautobot_device.py
@@ -118,6 +118,7 @@ def test_find_or_create(dell_nautobot_device):
         serial_number="33GSW04",
         bios_version="1.6.10",
         bmc_ip_address="1.2.3.4",
+        power_on=True,
         interfaces=[
             InterfaceInfo(
                 name="iDRAC",

--- a/python/understack-workflows/understack_workflows/bmc_chassis_info.py
+++ b/python/understack-workflows/understack_workflows/bmc_chassis_info.py
@@ -30,6 +30,7 @@ class ChassisInfo:
     serial_number: str
     bmc_ip_address: str
     bios_version: str
+    power_on: bool
     interfaces: list[InterfaceInfo]
 
     @property
@@ -67,6 +68,7 @@ def chassis_info(bmc: Bmc) -> ChassisInfo:
         model_number=chassis_data["Model"],
         serial_number=chassis_data["SKU"],
         bios_version=chassis_data["BiosVersion"],
+        power_on=(chassis_data["PowerState"] == "On"),
         bmc_ip_address=bmc.ip_address,
         interfaces=interfaces,
     )

--- a/python/understack-workflows/understack_workflows/bmc_chassis_info.py
+++ b/python/understack-workflows/understack_workflows/bmc_chassis_info.py
@@ -41,6 +41,15 @@ class ChassisInfo:
     def bmc_hostname(self) -> str:
         return str(self.bmc_interface.hostname)
 
+    @property
+    def neighbors(self) -> set:
+        """A set of switch MAC addresses to which this chassis is connected."""
+        return {
+            interface.remote_switch_mac_address
+            for interface in self.interfaces
+            if interface.remote_switch_mac_address
+        }
+
 
 REDFISH_SYSTEM_ENDPOINT = "/redfish/v1/Systems/System.Embedded.1/"
 REDFISH_ETHERNET_ENDPOINT = f"{REDFISH_SYSTEM_ENDPOINT}EthernetInterfaces/"

--- a/python/understack-workflows/understack_workflows/bmc_power.py
+++ b/python/understack-workflows/understack_workflows/bmc_power.py
@@ -1,0 +1,13 @@
+from understack_workflows.bmc import Bmc
+from understack_workflows.helpers import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def bmc_power_on(bmc: Bmc):
+    """Make a redfish call to switch on the power to the system."""
+    bmc.redfish_request(
+        "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+        payload={"ResetType": "On"},
+        method="POST",
+    )

--- a/python/understack-workflows/understack_workflows/discover.py
+++ b/python/understack-workflows/understack_workflows/discover.py
@@ -1,0 +1,44 @@
+import time
+
+from understack_workflows.bmc import Bmc
+from understack_workflows.bmc_chassis_info import ChassisInfo
+from understack_workflows.bmc_chassis_info import chassis_info
+from understack_workflows.bmc_power import bmc_power_on
+from understack_workflows.helpers import setup_logger
+
+logger = setup_logger(__name__)
+
+MIN_REQURED_NEIGHBOR_COUNT = 3
+
+
+def discover_chassis_info(bmc: Bmc) -> ChassisInfo:
+    """Query redfish, retrying until we get data that is acceptable.
+
+    If the server is off, power it on.
+
+    Make sure that we have at lease MIN_REQURED_NEIGHBOR_COUNT LLDP neighbors in
+    the returned ChassisInfo.  If that can't be achieved in a reasonable time
+    then raise an Exception.
+    """
+    device_info = chassis_info(bmc)
+
+    if not device_info.power_on:
+        logger.info(f"Server is powered off, sending power-on command to {bmc}")
+        bmc_power_on(bmc)
+
+    attempts_remaining = 6
+    while len(device_info.neighbors) < MIN_REQURED_NEIGHBOR_COUNT:
+        logger.info(
+            f"{bmc} does not have enough LLDP neighbors "
+            f"(saw {device_info.neighbors}), need at "
+            f"least {MIN_REQURED_NEIGHBOR_COUNT}. "
+        )
+        if not attempts_remaining:
+            raise Exception("No neighbors appeared")
+        logger.info(f"Retry in 30 seconds ({attempts_remaining=})")
+        attempts_remaining = attempts_remaining - 1
+
+        time.sleep(30)
+        device_info = chassis_info(bmc)
+
+    return device_info

--- a/python/understack-workflows/understack_workflows/discover.py
+++ b/python/understack-workflows/understack_workflows/discover.py
@@ -8,7 +8,7 @@ from understack_workflows.helpers import setup_logger
 
 logger = setup_logger(__name__)
 
-MIN_REQURED_NEIGHBOR_COUNT = 3
+MIN_REQUIRED_NEIGHBOR_COUNT = 3
 
 
 def discover_chassis_info(bmc: Bmc) -> ChassisInfo:
@@ -16,7 +16,7 @@ def discover_chassis_info(bmc: Bmc) -> ChassisInfo:
 
     If the server is off, power it on.
 
-    Make sure that we have at lease MIN_REQURED_NEIGHBOR_COUNT LLDP neighbors in
+    Make sure that we have at lease MIN_REQUIRED_NEIGHBOR_COUNT LLDP neighbors in
     the returned ChassisInfo.  If that can't be achieved in a reasonable time
     then raise an Exception.
     """
@@ -27,11 +27,11 @@ def discover_chassis_info(bmc: Bmc) -> ChassisInfo:
         bmc_power_on(bmc)
 
     attempts_remaining = 6
-    while len(device_info.neighbors) < MIN_REQURED_NEIGHBOR_COUNT:
+    while len(device_info.neighbors) < MIN_REQUIRED_NEIGHBOR_COUNT:
         logger.info(
             f"{bmc} does not have enough LLDP neighbors "
             f"(saw {device_info.neighbors}), need at "
-            f"least {MIN_REQURED_NEIGHBOR_COUNT}. "
+            f"least {MIN_REQUIRED_NEIGHBOR_COUNT}. "
         )
         if not attempts_remaining:
             raise Exception("No neighbors appeared")

--- a/python/understack-workflows/understack_workflows/helpers.py
+++ b/python/understack-workflows/understack_workflows/helpers.py
@@ -17,6 +17,7 @@ def setup_logger(name: str | None = None, level: int = logging.DEBUG):
     """
     logging.basicConfig(
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S %z",
         level=level,
     )
     return logging.getLogger(name)

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -23,7 +23,7 @@ from understack_workflows.nautobot_device import NautobotDevice
 
 logger = setup_logger(__name__)
 
-MIN_REQURED_NEIGHBOR_COUNT = 4
+MIN_REQUIRED_NEIGHBOR_COUNT = 4
 
 
 def main():

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -53,8 +53,6 @@ def main():
 
     - TODO: create and install SSL certificate
 
-    - TODO: update BMC firmware
-
     - TODO: set NTP Server IPs for DRAC
       (NTP server IP addresses are different per region)
 

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -23,8 +23,6 @@ from understack_workflows.nautobot_device import NautobotDevice
 
 logger = setup_logger(__name__)
 
-MIN_REQUIRED_NEIGHBOR_COUNT = 4
-
 
 def main():
     """On-board new or Refresh existing baremetal node.


### PR DESCRIPTION
When the server is powered off the network interfaces are down, so we don't get LLDP information.

Therefore, Enroll should power on the server, then wait for LLDP information to appear before continuing.