### PR TITLE
fix(workflows): fix bad python syntax

### DIFF
--- a/python/understack-workflows/understack_workflows/bmc_chassis_info.py
+++ b/python/understack-workflows/understack_workflows/bmc_chassis_info.py
@@ -87,7 +87,8 @@ def combine_lldp(lldp, interface) -> InterfaceInfo:
             f"LLDP info from BMC is missing for {name} or {alternate_name}, "
             f"we only have LLDP info for {list(lldp.keys())}"
         )
-    return InterfaceInfo(**interface, **lldp_entry)
+        interface.update(lldp_entry)
+    return InterfaceInfo(**interface)
 
 
 def bmc_interface(bmc) -> dict:


### PR DESCRIPTION
You cannot expand a none type so instead if there is data, update the existing data and just use the singular variable. Fixes the type error like the following.

```
2024-11-13 18:25:24,969 - understack_workflows.bmc_chassis_info - INFO - LLDP info from BMC is missing for NIC.Slot.1-2 or NIC.Slot.1-2-1, we only have LLDP info for ['iDRAC', 'NIC.Embedded.1-1-1', 'NIC.Embedded.2-1-1', 'NIC.Integrated.1-1-1', 'NIC.Integrated.1-2-1', 'NIC.Slot.1-1-1']
Traceback (most recent call last):
  File "/opt/venv/bin/enroll-server", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/main/enroll_server.py", line 110, in main
    device_info = chassis_info(bmc)
                  ^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/bmc_chassis_info.py", line 63, in chassis_info
    interfaces = interface_data(bmc)
                 ^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/bmc_chassis_info.py", line 78, in interface_data
    return [combine_lldp(lldp, interface) for interface in interfaces]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/bmc_chassis_info.py", line 78, in <listcomp>
    return [combine_lldp(lldp, interface) for interface in interfaces]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/bmc_chassis_info.py", line 90, in combine_lldp
    return InterfaceInfo(**interface, **lldp_entry)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: understack_workflows.bmc_chassis_info.InterfaceInfo() argument after ** must be a mapping, not NoneType
time="2024-11-13T18:25:25 UTC" level=info msg="sub-process exited" argo=true error="<nil>"
Error: exit status 1
```