### PR TITLE
fix(nova): adjust default quotas higher

### DIFF
--- a/components/nova/aio-values.yaml
+++ b/components/nova/aio-values.yaml
@@ -63,6 +63,10 @@ conf:
       # this is where we populate our hardware
       project_domain_name: infra
       project_name: baremetal
+  quota:
+    # adjust default quotas to make it possible to use baremetal
+    cores: 512
+    ram: 512000
 
 
 console:


### PR DESCRIPTION
The default quotas are too low for bare metal gear to be able to even build one machine so increase the values up.