### PR TITLE
fix: bump ironic chart to 0.2.21

### DIFF
--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -23,7 +23,7 @@ spec:
                 - component: ironic
                   openstackRelease: 2024.2
                   # renovate: datasource=custom.openstackhelm depName=ironic
-                  chartVersion: 0.2.20
+                  chartVersion: 0.2.21
                 - component: placement
                   openstackRelease: 2024.2
                   # renovate: datasource=custom.openstackhelm depName=placement


### PR DESCRIPTION
Fixes:
```
2024-11-14 18:26:57.277 1 ERROR ironic.drivers.modules.ipmitool [None req-80f11e0d-0a17-4f09-a611-dc5b904b5ec2 - - - - - -] Ipmitool drivers need to be able to create temporary files to pass password to ipmitool. Encountered error: Path /var/lib/openstack-helm/tmp does not exist.: ironic.common.exception.PathNotFound: Path /var/lib/openstack-helm/tmp does not exist.
```

Related: 
https://review.opendev.org/c/openstack/openstack-helm/+/935019
https://review.opendev.org/c/openstack/openstack-helm/+/934132
