### PR TITLE
chore: removes unused IdracRedfishSupport python module

### DIFF
--- a/containers/bmc-utils/requirements.txt
+++ b/containers/bmc-utils/requirements.txt
@@ -1,4 +1,3 @@
 requests==2.32.3
 pynautobot==2.4.1
 sushy==5.3.0
-IdracRedfishSupport==0.0.8


### PR DESCRIPTION
The IdracRedfishSupport has been replaced by: https://github.com/rackerlabs/understack/blob/4dea9bb5d9fc71e7e72f5384dd7a91ae44b9b472/python/understack-workflows/understack_workflows/bmc_settings.py#L9-L19
