### PR TITLE
chore: renovate should as for minor Python releases

### DIFF
--- a/.github/renovate/default.json
+++ b/.github/renovate/default.json
@@ -9,6 +9,7 @@
     ":approveMajorUpdates",
     "github>rackerlabs/understack//.github/renovate/automergeGitHubActions",
     "github>rackerlabs/understack//.github/renovate/precommit",
+    "github>rackerlabs/understack//.github/renovate/pythonMinorApprove",
     ":maintainLockFilesMonthly",
     ":automergeDigest"
   ]

--- a/.github/renovate/pythonMinorApprove.json
+++ b/.github/renovate/pythonMinorApprove.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "dependencyDashboardApproval": true,
+      "matchPackageNames": ["python"],
+      "matchUpdateTypes": ["major", "minor"]
+    }
+  ]
+}


### PR DESCRIPTION
Many of our dependencies cannot just bump up to the next Python release so we need to get approval to bump up to the next minor release of Python.