### PR TITLE
chore: Revert "chore(deps): update helm release argo-cd to v7.7.3"

### DIFF
--- a/bootstrap/argocd/kustomization.yaml
+++ b/bootstrap/argocd/kustomization.yaml
@@ -14,5 +14,5 @@ helmCharts:
   namespace: argocd
   valuesFile: values.yaml
   releaseName: argo-cd
-  version: 7.7.3
+  version: 7.6.12
   repo: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
Reverts rackerlabs/understack#438 because of the bug in ArgoCD 2.13.0

https://github.com/argoproj/argo-cd/issues/20171