### PR TITLE
fix: ironic-conductor fails to start with agent inspect interface is enabled

### DIFF
--- a/components/ironic/aio-values.yaml
+++ b/components/ironic/aio-values.yaml
@@ -36,7 +36,7 @@ conf:
       enabled_deploy_interfaces: direct,ramdisk
       enabled_firmware_interfaces: redfish,no-firmware
       enabled_hardware_types: redfish,idrac,ilo5,ilo
-      enabled_inspect_interfaces: redfish,agent,idrac-redfish,ilo
+      enabled_inspect_interfaces: redfish,idrac-redfish,ilo
       enabled_management_interfaces: ipmitool,redfish,idrac-redfish,ilo,ilo5
       enabled_network_interfaces: noop,neutron
       enabled_power_interfaces: redfish,ipmitool,idrac-redfish,ilo


### PR DESCRIPTION
Today I found one of our environment had an ironic-conductor failing to start. I'm not sure why, but the agent inspection interface caused ironic to crash without a stack trace. After troubleshooting, I ended up getting ironic to work by removing the agent interface from the list of enabled inspection interfaces.