### PR TITLE
fix: ironic image builds without the ironic_understack module

### DIFF
--- a/containers/ironic/Dockerfile.ironic
+++ b/containers/ironic/Dockerfile.ironic
@@ -10,5 +10,5 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY python/ironic-understack /tmp/ironic-understack
-COPY python/understack-flavor-matcher /tmp/ironic-understack
-RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack sushy-oem-idrac==6.0.0
+COPY python/understack-flavor-matcher /tmp/understack-flavor-matcher
+RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack /tmp/understack-flavor-matcher sushy-oem-idrac==6.0.0


### PR DESCRIPTION
The original intention was to copy both modules into /tmp/ironic-understack/ but the trailing / was missed. Instead, make it more explicit to ensure that both are installed.

Closes #506 