### PR TITLE
fix: fix flavor to ironic resource class conversion

### DIFF
--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -168,9 +168,9 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
                       path: 'workflows'
-                    - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
-                      targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                      path: 'workflows'
+                    # - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
+                    #   targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
+                    #   path: 'workflows'
                 - component: chrony
                   componentNamespace: openstack
                   skipComponent: '{{has "chrony" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -168,9 +168,6 @@ spec:
                     - repoURL: '{{index .metadata.annotations "uc_repo_git_url"}}'
                       targetRevision: '{{index .metadata.annotations "uc_repo_ref"}}'
                       path: 'workflows'
-                    # - repoURL: '{{index .metadata.annotations "uc_deploy_git_url"}}'
-                    #   targetRevision: '{{index .metadata.annotations "uc_deploy_ref"}}'
-                    #   path: 'workflows'
                 - component: chrony
                   componentNamespace: openstack
                   skipComponent: '{{has "chrony" ((default "[]" (index .metadata.annotations "uc_skip_components") | fromJson))}}'

--- a/python/understack-flavor-matcher/flavor_matcher/flavor_spec.py
+++ b/python/understack-flavor-matcher/flavor_matcher/flavor_spec.py
@@ -45,6 +45,8 @@ class FlavorSpec:
         _, name = self.name.split(".", 1)
         if not name:
             raise Exception(f"Unable to strip envtype from flavor: {self.name}")
+        # need to strip '.' from the ironic flavor name
+        name = name.replace(".", "")
         return name
 
     @staticmethod


### PR DESCRIPTION
Resource class is coming in to ironic as:
```
| resource_class         | baremetal.gp2.small                                                                                                                                                                 |
```
But it should be `baremetal.gp2small`
