### PR TITLE
feat: Hardcode uids in dockerfiles

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -12,7 +12,6 @@ on:
     branches:
       - main
     paths:
-      - "containers/argo_utils/**"
       - "containers/bmc-utils/**"
       - "containers/python311_alpine/**"
       - "containers/python312_alpine/**"
@@ -39,7 +38,6 @@ jobs:
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
 
       - name: Login to ghcr.io
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: "ghcr.io"

--- a/containers/bmc-utils/Dockerfile.bmc_utils
+++ b/containers/bmc-utils/Dockerfile.bmc_utils
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19:latest
+ARG BASE=ghcr.io/rackerlabs/understack/python3.11.8-alpine3.19:latest
 
 FROM ${BASE} AS builder
 

--- a/containers/bmc-utils/Dockerfile.bmc_utils
+++ b/containers/bmc-utils/Dockerfile.bmc_utils
@@ -2,21 +2,10 @@ ARG BASE=ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19:latest
 
 FROM ${BASE} AS builder
 
-ARG APP_PATH=/app
-ARG APP_USER=appuser
-ARG APP_GROUP=appgroup
-ARG APP_USER_UID=1000
-ARG APP_GROUP_GID=1000
-
-COPY --chown=${APP_USER}:${APP_GROUP} requirements.txt /app
+COPY --chown=appuser:appgroup requirements.txt /app
 RUN --mount=type=cache,target=/root/.cache/.pip pip install --no-cache-dir -r /app/requirements.txt
 
 FROM ${BASE} AS prod
-ARG APP_PATH=/app
-ARG APP_USER=appuser
-ARG APP_GROUP=appgroup
-ARG APP_USER_UID=1000
-ARG APP_GROUP_GID=1000
 
 LABEL org.opencontainers.image.title="Python 3.11 image with BMC utils"
 LABEL org.opencontainers.image.base.name="ghcr.io/rackerlabs/understack/argo-bmc-utils-python3.11.8"
@@ -26,8 +15,6 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY  --from=builder /opt/venv /opt/venv
 
 WORKDIR /app
-
-USER $APP_USER
-
-COPY --chown=${APP_USER}:${APP_GROUP} code/ /app
+USER appuser
+COPY --chown=appuser:appgroup code/ /app
 CMD ["python", "-"]

--- a/containers/ironic-nautobot-client/Dockerfile.ironic-nautobot-client
+++ b/containers/ironic-nautobot-client/Dockerfile.ironic-nautobot-client
@@ -1,12 +1,6 @@
 ARG BASE=ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19:latest
 FROM ${BASE} AS builder
 
-ARG APP_PATH=/app
-ARG APP_USER=appuser
-ARG APP_GROUP=appgroup
-ARG APP_USER_UID=1000
-ARG APP_GROUP_GID=1000
-
 RUN --mount=type=cache,target=/var/cache/apk apk add --virtual build-deps gcc python3-dev musl-dev linux-headers
 RUN --mount=type=cache,target=/root/.cache/.pip pip install 'wheel==0.43.0'
 RUN --mount=type=cache,target=/root/.cache/.pip \
@@ -15,29 +9,21 @@ RUN --mount=type=cache,target=/root/.cache/.pip \
     /opt/poetry/bin/poetry self add 'poetry-dynamic-versioning[plugin]==1.3.0'
 
 # copy in the code
-COPY --chown=${APP_USER}:${APP_GROUP} python/understack-workflows /app
-COPY --chown=${APP_USER}:${APP_GROUP} python/understack-flavor-matcher /understack-flavor-matcher
+COPY --chown=appuser:appgroup python/understack-workflows /app
+COPY --chown=appuser:appgroup python/understack-flavor-matcher /understack-flavor-matcher
 # need netifaces built as a wheel
 RUN --mount=type=cache,target=/root/.cache/.pip pip wheel --wheel-dir /app/dist netifaces
 # build wheels and requirements.txt, skip hashes due to building of netifaces above which won't match
 RUN cd /app && /opt/poetry/bin/poetry build -f wheel && /opt/poetry/bin/poetry export --without-hashes -f requirements.txt -o dist/requirements.txt
 
 FROM ${BASE} AS prod
-ARG APP_PATH=/app
-ARG APP_USER=appuser
-ARG APP_GROUP=appgroup
-ARG APP_USER_UID=1000
-ARG APP_GROUP_GID=1000
-
-
 LABEL org.opencontainers.image.description="UnderStack Workflows"
-
 WORKDIR /app
 
 RUN mkdir -p /opt/venv/wheels/
 COPY --from=builder /app/dist/*.whl /app/dist/requirements.txt /opt/venv/wheels/
-COPY --chown=${APP_USER}:${APP_GROUP} python/understack-flavor-matcher /understack-flavor-matcher
+COPY --chown=appuser:appgroup python/understack-flavor-matcher /understack-flavor-matcher
 
 RUN --mount=type=cache,target=/root/.cache/.pip /opt/venv/bin/pip install --find-links /opt/venv/wheels/ --only-binary netifaces -r /opt/venv/wheels/requirements.txt understack-workflows
 
-USER $APP_USER
+USER appuser

--- a/containers/ironic-nautobot-client/Dockerfile.ironic-nautobot-client
+++ b/containers/ironic-nautobot-client/Dockerfile.ironic-nautobot-client
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19:latest
+ARG BASE=ghcr.io/rackerlabs/understack/python3.11.8-alpine3.19:latest
 FROM ${BASE} AS builder
 
 RUN --mount=type=cache,target=/var/cache/apk apk add --virtual build-deps gcc python3-dev musl-dev linux-headers

--- a/containers/python311_alpine/Dockerfile.python311_alpine
+++ b/containers/python311_alpine/Dockerfile.python311_alpine
@@ -9,29 +9,21 @@ ENV PYTHONUNBUFFERED=1
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-ARG APP_PATH=/app
-ARG APP_USER=appuser
-ARG APP_GROUP=appgroup
-ARG APP_USER_UID=1000
-ARG APP_GROUP_GID=1000
-
-RUN addgroup -g $APP_GROUP_GID -S $APP_GROUP && \
-  adduser -S -s /sbin/nologin -u $APP_USER_UID -G $APP_GROUP $APP_USER && \
-  mkdir $APP_PATH && \
-  chown $APP_USER:$APP_GROUP $APP_PATH
+RUN addgroup -g 1000 -S appgroup && \
+  adduser -S -s /sbin/nologin -u 1000 -G appgroup appuser && \
+  mkdir /app && \
+  chown appuser:appgroup /app
 WORKDIR /app
 CMD ["python", "-"]
 
+# Instructions for using this template as a base image:
+# 1. Place your Python code in /app.
+# 2. A pre-created Python virtual environment is available in /opt/venv.
+# 3. Run your application as user 'appuser' with UID=1000. This account has been pre-created.
+#    Note: After installing dependencies, switch back to `USER appuser` if root access was required at build time.
+#
 # Example usage in final image
 # FROM ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19
-#
-#  # This section needs to be repeated in child images
-#  ARG APP_PATH=/app
-#  ARG APP_USER=appuser
-#  ARG APP_GROUP=appgroup
-#  ARG APP_USER_UID=1000
-#  ARG APP_GROUP_GID=1000
-#
 #
 # RUN --mount=type=cache,target=/var/cache/apk apk add --virtual build-deps gcc python3-dev musl-dev linux-headers
 # RUN --mount=type=cache,target=/root/.cache/.pip pip install --no-cache-dir python-ironicclient==5.4.0
@@ -39,6 +31,8 @@ CMD ["python", "-"]
 # FROM ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19 as prod
 # ENV PATH="/opt/venv/bin:$PATH"
 # COPY --from=builder /opt/venv /opt/venv
+# USER appuser
 #
+# COPY --chown=appuser:appgroup src/ /app/code
 # WORKDIR /app
 # CMD ["python", "-"]

--- a/containers/python311_alpine/Dockerfile.python311_alpine
+++ b/containers/python311_alpine/Dockerfile.python311_alpine
@@ -1,7 +1,7 @@
 FROM python:3.11.8-alpine3.19 AS builder
 
 LABEL org.opencontainers.image.title="Python 3.11 image base image"
-LABEL org.opencontainers.image.base.name="ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19"
+LABEL org.opencontainers.image.base.name="ghcr.io/rackerlabs/understack/python3.11.8-alpine3.19"
 LABEL org.opencontainers.image.source=https://github.com/rackerlabs/understack
 
 ENV PYTHONUNBUFFERED=1
@@ -23,12 +23,12 @@ CMD ["python", "-"]
 #    Note: After installing dependencies, switch back to `USER appuser` if root access was required at build time.
 #
 # Example usage in final image
-# FROM ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19
+# FROM ghcr.io/rackerlabs/understack/python3.11.8-alpine3.19
 #
 # RUN --mount=type=cache,target=/var/cache/apk apk add --virtual build-deps gcc python3-dev musl-dev linux-headers
 # RUN --mount=type=cache,target=/root/.cache/.pip pip install --no-cache-dir python-ironicclient==5.4.0
 #
-# FROM ghcr.io/rackerlabs/understack/argo-python3.11.8-alpine3.19 as prod
+# FROM ghcr.io/rackerlabs/understack/python3.11.8-alpine3.19 as prod
 # ENV PATH="/opt/venv/bin:$PATH"
 # COPY --from=builder /opt/venv /opt/venv
 # USER appuser

--- a/containers/python312_alpine/Dockerfile.python312_alpine
+++ b/containers/python312_alpine/Dockerfile.python312_alpine
@@ -1,7 +1,7 @@
 FROM python:3.12.2-alpine3.19 AS builder
 
 LABEL org.opencontainers.image.title="Python 3.12 image base image"
-LABEL org.opencontainers.image.base.name="ghcr.io/rackerlabs/understack/argo-python3.12.2-alpine3.19"
+LABEL org.opencontainers.image.base.name="ghcr.io/rackerlabs/understack/python3.12.2-alpine3.19"
 LABEL org.opencontainers.image.source=https://github.com/rackerlabs/understack
 
 ENV PYTHONUNBUFFERED=1
@@ -23,12 +23,12 @@ CMD ["python", "-"]
 #    Note: After installing dependencies, switch back to `USER appuser` if root access was required at build time.
 #
 # Example usage in final image
-# FROM ghcr.io/rackerlabs/understack/argo-python3.12.2-alpine3.19
+# FROM ghcr.io/rackerlabs/understack/python3.12.2-alpine3.19
 #
 # RUN --mount=type=cache,target=/var/cache/apk apk add --virtual build-deps gcc python3-dev musl-dev linux-headers
 # RUN --mount=type=cache,target=/root/.cache/.pip pip install --no-cache-dir python-ironicclient==5.4.0
 #
-# FROM ghcr.io/rackerlabs/understack/argo-python3.12.2-alpine3.19 as prod
+# FROM ghcr.io/rackerlabs/understack/python3.12.2-alpine3.19 as prod
 # ENV PATH="/opt/venv/bin:$PATH"
 # COPY --from=builder /opt/venv /opt/venv
 # USER appuser

--- a/containers/python312_alpine/Dockerfile.python312_alpine
+++ b/containers/python312_alpine/Dockerfile.python312_alpine
@@ -9,29 +9,21 @@ ENV PYTHONUNBUFFERED=1
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-ARG APP_PATH=/app
-ARG APP_USER=appuser
-ARG APP_GROUP=appgroup
-ARG APP_USER_UID=1000
-ARG APP_GROUP_GID=1000
-
-RUN addgroup -g $APP_GROUP_GID -S $APP_GROUP && \
-  adduser -S -s /sbin/nologin -u $APP_USER_UID -G $APP_GROUP $APP_USER && \
-  mkdir $APP_PATH && \
-  chown $APP_USER:$APP_GROUP $APP_PATH
+RUN addgroup -g 1000 -S appgroup && \
+  adduser -S -s /sbin/nologin -u 1000 -G appgroup appuser && \
+  mkdir /app && \
+  chown appuser:appgroup /app
 WORKDIR /app
 CMD ["python", "-"]
 
+# Instructions for using this template as a base image:
+# 1. Place your Python code in /app.
+# 2. A pre-created Python virtual environment is available in /opt/venv.
+# 3. Run your application as user 'appuser' with UID=1000. This account has been pre-created.
+#    Note: After installing dependencies, switch back to `USER appuser` if root access was required at build time.
+#
 # Example usage in final image
 # FROM ghcr.io/rackerlabs/understack/argo-python3.12.2-alpine3.19
-#
-#  # This section needs to be repeated in child images
-#  ARG APP_PATH=/app
-#  ARG APP_USER=appuser
-#  ARG APP_GROUP=appgroup
-#  ARG APP_USER_UID=1000
-#  ARG APP_GROUP_GID=1000
-#
 #
 # RUN --mount=type=cache,target=/var/cache/apk apk add --virtual build-deps gcc python3-dev musl-dev linux-headers
 # RUN --mount=type=cache,target=/root/.cache/.pip pip install --no-cache-dir python-ironicclient==5.4.0
@@ -39,6 +31,8 @@ CMD ["python", "-"]
 # FROM ghcr.io/rackerlabs/understack/argo-python3.12.2-alpine3.19 as prod
 # ENV PATH="/opt/venv/bin:$PATH"
 # COPY --from=builder /opt/venv /opt/venv
+# USER appuser
 #
+# COPY --chown=appuser:appgroup src/ /app/code
 # WORKDIR /app
 # CMD ["python", "-"]


### PR DESCRIPTION
Based on the discussion in https://github.com/rackerlabs/understack/pull/499#discussion_r1852786416 this commit removes the repetitive directives to set the application UIDs, GIDs as well as the name and home directory.
The new, standardized way is to use:
- user with name `appuser` and UID 1000
- group with name `appgroup` and GID 1000
- location of the code in `/app`