### PR TITLE
feat: Detect and Avoid Duplicate DRAC IP address on server Enroll

### DIFF
--- a/python/understack-workflows/understack_workflows/bmc_chassis_info.py
+++ b/python/understack-workflows/understack_workflows/bmc_chassis_info.py
@@ -21,6 +21,7 @@ class InterfaceInfo:
     dhcp: bool = False
     remote_switch_mac_address: str | None = None
     remote_switch_port_name: str | None = None
+    remote_switch_data_stale: bool = False
 
 
 @dataclass(frozen=True)
@@ -232,16 +233,19 @@ def parse_lldp_port(port_data: dict[str, str]) -> dict:
     """
     mac = str(port_data["SwitchConnectionID"]).upper()
     port_name = normalize_interface_name(port_data["SwitchPortConnectionID"])
+    stale = str(port_data["StaleData"]) != "NotStale"
 
     if mac in ["NOT AVAILABLE", "NO LINK", "NOT SUPPORTED"]:
         return {
             "remote_switch_mac_address": None,
             "remote_switch_port_name": None,
+            "remote_switch_data_stale": stale,
         }
     else:
         return {
             "remote_switch_mac_address": mac,
             "remote_switch_port_name": port_name,
+            "remote_switch_data_stale": stale,
         }
 
 

--- a/python/understack-workflows/understack_workflows/nautobot_device.py
+++ b/python/understack-workflows/understack_workflows/nautobot_device.py
@@ -169,6 +169,9 @@ def nautobot_switches(nautobot, mac_addresses: set[str]) -> dict[str, dict]:
 
 
 def nautobot_switch(all_switches: dict[str, Any], interface: InterfaceInfo):
+    if interface.remote_switch_data_stale:
+        logger.info(f"Warning: BMC marked LLDP data stale for {interface.name}")
+
     if not interface.remote_switch_mac_address or not interface.remote_switch_port_name:
         raise ValueError(f"missing LDLDP info in {interface}")
 


### PR DESCRIPTION
This improves diagnostic messages during various enroll failure scenarios, to provide a more detailed error message about what went wrong.

It also detects two extra failure cases when DRAC IP is already in use on another device, and when DRAC interface already has an IP address.  This is designed to prevent any "duplicate" IP assignments in Nautobot.

closes PUC-690