### PR TITLE
fix: move nova quota to nova conf section

### DIFF
--- a/components/nova/aio-values.yaml
+++ b/components/nova/aio-values.yaml
@@ -63,10 +63,11 @@ conf:
       # this is where we populate our hardware
       project_domain_name: infra
       project_name: baremetal
-  quota:
-    # adjust default quotas to make it possible to use baremetal
-    cores: 512
-    ram: 512000
+  nova:
+    quota:
+      # adjust default quotas to make it possible to use baremetal
+      cores: 512
+      ram: 512000
 
 
 console:


### PR DESCRIPTION
The nova quotas config should be under the nova conf in openstack-helm:
https://github.com/openstack/openstack-helm/blob/master/nova/values.yaml#L1385
https://docs.openstack.org/nova/latest/configuration/sample-config.html

I'm getting this error when I create a new project and try to build a server in the new project:
```
    details: 'Quota exceeded for cores, ram: Requested 32, 98304, but already used 0, 0 of 20, 51200 cores, ram'
    response: '{"forbidden": {"code": 403, "message": "Quota exceeded for cores, ram: Requested 32, 98304, but already used 0, 0 of 20, 51200 cores, ram"}}'
```
So it's using the 'default' nova quotas and not the ones we were intending to set, and the nova containers do not contain a quota section in /etc/nova/nova.conf.
