### PR TITLE
fix: set keystone federation default_authorization_ttl to 12 hours

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -250,6 +250,7 @@ conf:
         values:
           - http://localhost:9990/auth/websso/
           # - https://yourinstance.of.horizon.example.com/auth/websso/
+      default_authorization_ttl: 720
     DEFAULT:
       max_token_size: 512
   wsgi_keystone: |


### PR DESCRIPTION
Problem creating application credentials in keystone: 

```
❯ openstack application credential create terraform-cred --restricted
BadRequestException: 400: Client Error for url: https://keystone.internal/v3/users/b22322eb26e893803f1839640e7de6c9647892c8cffe75b7603f9b168ef1afec/application_credentials, Invalid application credential: Could not find role assignment with role: 4a5321ded95d4c2caa3ebb329fd12dd5, user or group: b22322eb26e893803f1839640e7de6c9647892c8cffe75b7603f9b168ef1afec, project, domain, or system: 9c5848c68f1c41d181365eea45ed804b.
```

I came across some keystone bug reports:

* https://bugs.launchpad.net/keystone/+bug/1978833 
* https://bugs.launchpad.net/keystone/+bug/1832092 

Which led to the same solution, setting default_authorization_ttl to something greater than 0 when federating:

* https://docs.openstack.org/keystone/latest/configuration/config-options.html#federation.default_authorization_ttl 

 I just gave this a try in dev and was able to successfully create an application credential:

<img width="754" alt="Screenshot 2024-12-09 at 1 22 42 PM" src="https://github.com/user-attachments/assets/ffae4f3c-fa54-4763-a441-ed6483f3548a">
