### PR TITLE
fix: flavors: temporary fix to load the specs

### DIFF
--- a/workflows/argo-events/workflowtemplates/enroll-server.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-server.yaml
@@ -82,6 +82,8 @@ spec:
           value: "{{workflow.name}}"
         - name: WF_UID
           value: "{{workflow.uid}}"
+        - name: FLAVORS_ENV
+          value: nonprod
       volumes:
         - name: bmc-master
           secret:


### PR DESCRIPTION
This sets the `FLAVORS_ENV` to 'nonprod', so that the enroll server workflow can recognize which flavors to use.

In future versions, this needs to be changed so that this environment variable can be modified for each of the environments.