### PR TITLE
fix: we don't want the env name in the flavor

### DIFF
--- a/operators/nova-flavors/nova_flavors/flavor_synchronizer.py
+++ b/operators/nova-flavors/nova_flavors/flavor_synchronizer.py
@@ -44,15 +44,13 @@ class FlavorSynchronizer:
         existing_flavors = self._nova.flavors.list()
         for flavor in desired_flavors:
             nova_flavor = next(
-                (flv for flv in existing_flavors if flv.name == flavor.stripped_name),
+                (flv for flv in existing_flavors if flv.name == flavor.name),
                 None,
             )
 
             update_needed = False
             if nova_flavor:
-                logger.info(
-                    f"Flavor: {flavor.stripped_name} already exists. Syncing values"
-                )
+                logger.info(f"Flavor: {flavor.name} already exists. Syncing values")
                 if nova_flavor.ram != flavor.memory_mib:
                     logger.info(
                         f"{flavor.name} RAM mismatch - {nova_flavor.ram=} {flavor.memory_mib=}"
@@ -86,7 +84,7 @@ class FlavorSynchronizer:
 
     def _create(self, flavor: FlavorSpec):
         nova_flavor = self._nova.flavors.create(
-            flavor.stripped_name,
+            flavor.name,
             flavor.memory_mib,
             flavor.cpu_cores,
             min(flavor.drives),

--- a/operators/nova-flavors/tests/test_flavor_synchronizer.py
+++ b/operators/nova-flavors/tests/test_flavor_synchronizer.py
@@ -54,7 +54,7 @@ def test_flavor_synchronizer_reconcile_new_flavor(
     mock_nova_client.return_value.flavors.list.return_value = []
     flavor_synchronizer.reconcile([flavor])
     mock_nova_client.return_value.flavors.create.assert_called_once_with(
-        flavor.stripped_name, flavor.memory_mib, flavor.cpu_cores, min(flavor.drives)
+        flavor.name, flavor.memory_mib, flavor.cpu_cores, min(flavor.drives)
     )
 
 
@@ -62,7 +62,7 @@ def test_flavor_synchronizer_reconcile_existing_flavor(
     flavor_synchronizer, mock_nova_client, flavor
 ):
     existing_flavor = MagicMock()
-    existing_flavor.name = flavor.stripped_name
+    existing_flavor.name = flavor.name
     existing_flavor.ram = flavor.memory_mib
     existing_flavor.disk = max(flavor.drives)
     existing_flavor.vcpus = flavor.cpu_cores
@@ -75,7 +75,7 @@ def test_flavor_synchronizer_reconcile_existing_flavor_update_needed(
     flavor_synchronizer, mock_nova_client, flavor
 ):
     existing_flavor = MagicMock()
-    existing_flavor.name = flavor.stripped_name
+    existing_flavor.name = flavor.name
     existing_flavor.ram = flavor.memory_mib + 1
     existing_flavor.disk = max(flavor.drives)
     existing_flavor.vcpus = flavor.cpu_cores
@@ -84,7 +84,7 @@ def test_flavor_synchronizer_reconcile_existing_flavor_update_needed(
     flavor_synchronizer.reconcile([flavor])
     existing_flavor.delete.assert_called_once()
     mock_nova_client.return_value.flavors.create.assert_called_once_with(
-        flavor.stripped_name, flavor.memory_mib, flavor.cpu_cores, min(flavor.drives)
+        flavor.name, flavor.memory_mib, flavor.cpu_cores, min(flavor.drives)
     )
 
 
@@ -94,7 +94,7 @@ def test_flavor_synchronizer_create_flavor(
     mock_create_flavor = mock_nova_client.return_value.flavors.create.return_value
     flavor_synchronizer._create(flavor)
     mock_nova_client.return_value.flavors.create.assert_called_once_with(
-        flavor.stripped_name, flavor.memory_mib, flavor.cpu_cores, min(flavor.drives)
+        flavor.name, flavor.memory_mib, flavor.cpu_cores, min(flavor.drives)
     )
     mock_create_flavor.set_keys.assert_called_once_with(
         {

--- a/python/understack-flavor-matcher/flavor_matcher/flavor_spec.py
+++ b/python/understack-flavor-matcher/flavor_matcher/flavor_spec.py
@@ -39,30 +39,14 @@ class FlavorSpec:
             pci=data.get("pci", []),
         )
 
-    @staticmethod
-    def configured_envtype():
-        return os.getenv("FLAVORS_ENV", "unconfigured")
-
-    @property
-    def stripped_name(self):
-        """Returns actual flavor name with the prod/nonprod prefix removed."""
-        _, name = self.name.split(".", 1)
-        if not name:
-            raise Exception(f"Unable to strip envtype from flavor: {self.name}")
-        return name
-
     @property
     def baremetal_nova_resource_class(self):
         """Returns flavor name converted to be used with Nova flavor resources.
 
         https://docs.openstack.org/ironic/latest/install/configure-nova-flavors.html
         """
-        converted_name = re.sub(r"[^\w]", "_", self.stripped_name).upper()
+        converted_name = re.sub(r"[^\w]", "_", self.name).upper()
         return f"resources:CUSTOM_BAREMETAL_{converted_name}"
-
-    @property
-    def env_type(self):
-        return self.name.split(".")[0]
 
     @property
     def memory_mib(self):
@@ -80,8 +64,6 @@ class FlavorSpec:
                         with open(filepath, "r") as file:
                             yaml_content = file.read()
                             flavor_spec = FlavorSpec.from_yaml(yaml_content)
-                            if flavor_spec.env_type != FlavorSpec.configured_envtype():
-                                continue
                             flavor_specs.append(flavor_spec)
                     except yaml.YAMLError as e:
                         print(f"Error parsing YAML file {filename}: {e}")

--- a/python/understack-flavor-matcher/tests/test_flavor_spec.py
+++ b/python/understack-flavor-matcher/tests/test_flavor_spec.py
@@ -11,7 +11,7 @@ from flavor_matcher.machine import Machine
 def valid_yaml():
     return """
 ---
-name: nonprod.gp2.ultramedium
+name: gp2.ultramedium
 manufacturer: Dell
 model: PowerEdge R7615
 memory_gb: 7777
@@ -46,8 +46,7 @@ def yaml_directory(tmp_path, valid_yaml, invalid_yaml):
 
 def test_from_yaml(valid_yaml):
     spec = FlavorSpec.from_yaml(valid_yaml)
-    assert spec.name == "nonprod.gp2.ultramedium"
-    assert spec.stripped_name == "gp2.ultramedium"
+    assert spec.name == "gp2.ultramedium"
     assert spec.manufacturer == "Dell"
     assert spec.model == "PowerEdge R7615"
     assert spec.memory_gb == 7777
@@ -76,7 +75,7 @@ def test_from_directory(mocked_open, mock_walk, valid_yaml, invalid_yaml):
     specs = FlavorSpec.from_directory("/etc/flavors/")
 
     assert len(specs) == 1
-    assert specs[0].name == "nonprod.gp2.ultramedium"
+    assert specs[0].name == "gp2.ultramedium"
     assert specs[0].memory_gb == 7777
     assert specs[0].cpu_cores == 245
 
@@ -86,7 +85,7 @@ def test_from_directory_with_real_files(yaml_directory):
     specs = FlavorSpec.from_directory(str(yaml_directory))
 
     assert len(specs) == 1
-    assert specs[0].name == "nonprod.gp2.ultramedium"
+    assert specs[0].name == "gp2.ultramedium"
     assert specs[0].memory_gb == 7777
     assert specs[0].cpu_cores == 245
 
@@ -332,8 +331,3 @@ def test_baremetal_nova_resource_class(valid_yaml):
         flv.baremetal_nova_resource_class
         == "resources:CUSTOM_BAREMETAL_GP2_ULTRAMEDIUM"
     )
-
-
-def test_envtype(valid_yaml):
-    flv = FlavorSpec.from_yaml(valid_yaml)
-    assert flv.env_type == "nonprod"

--- a/python/understack-workflows/understack_workflows/flavor_detect.py
+++ b/python/understack-workflows/understack_workflows/flavor_detect.py
@@ -30,6 +30,6 @@ def guess_machine_flavor(device_info: ChassisInfo, bmc: Bmc) -> str:
         raise Exception(
             f"Machine: {machine} could not be classified into any flavor {FLAVORS=}"
         )
-    logger.info(f"Device has been classified as flavor: {flavor_name.stripped_name}")
+    logger.info(f"Device has been classified as flavor: {flavor_name.name}")
 
-    return flavor_name.stripped_name
+    return flavor_name.name

--- a/workflows/argo-events/workflowtemplates/enroll-server.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-server.yaml
@@ -73,7 +73,6 @@ spec:
             readOnly: true
           - mountPath: /etc/understack_flavors/
             name: understack-flavors
-            subPath: current/flavors/
             readOnly: true
         env:
         - name: WF_NS
@@ -82,6 +81,12 @@ spec:
           value: "{{workflow.name}}"
         - name: WF_UID
           value: "{{workflow.uid}}"
+        - name: FLAVORS_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: understack-flavors
+              key: FLAVORS_DIR
+              optional: true
       volumes:
         - name: bmc-master
           secret:


### PR DESCRIPTION
We don't want to be prefixing the flavor names with an environment name. Just put the environment data in the correct place.