### PR TITLE
fix: adds service account to keystone argo event source

### DIFF
--- a/workflows/argo-events/workflowtemplates/keystone-event-project.yaml
+++ b/workflows/argo-events/workflowtemplates/keystone-event-project.yaml
@@ -17,6 +17,7 @@ metadata:
 kind: WorkflowTemplate
 spec:
   entrypoint: sync-keystone
+  serviceAccountName: workflow
   arguments:
     parameters:
       - name: event_type


### PR DESCRIPTION
I noticed my test tenants aren't getting deleted in nautobot when I delete them in keystone. Upon investigating, I found the argo event is failing with an error regarding the service account: 

```
Error (exit code 1): pods "keystone-event-project-mtl4s" is forbidden: User "system:serviceaccount:argo-events:default" cannot patch resource "pods" in API group "" in the namespace "argo-events"
```

I believe the default user is old.. it's mentioned in https://github.com/rackerlabs/understack/blob/main/components/argo-events/default-role.yaml  but this file seems unused. The other workflows are using a `workflow` user, so I set this keystone workflow to the same, and the argo events are successfully completing now, and the projects are getting deleted in nautobot as expected.

<img width="1346" alt="Screenshot 2024-12-09 at 5 06 22 PM" src="https://github.com/user-attachments/assets/4d26fa21-4545-4a59-afbb-de2ec71113a1">
