### PR TITLE
chore: nova: bump chart to 0.3.47

### DIFF
--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -39,7 +39,7 @@ spec:
                 - component: nova
                   openstackRelease: 2024.2
                   # renovate: datasource=custom.openstackhelm depName=nova
-                  chartVersion: 0.3.46
+                  chartVersion: 0.3.47
                 - component: horizon
                   openstackRelease: 2024.2
                   # renovate: datasource=custom.openstackhelm depName=horizon


### PR DESCRIPTION
This includes fixes from
https://review.opendev.org/c/openstack/openstack-helm/+/936258

Closes PUC-633