### PR TITLE
fix(nautobot): remove unused dexauth mount

### DIFF
--- a/components/nautobot/values.yaml
+++ b/components/nautobot/values.yaml
@@ -23,10 +23,6 @@ nautobot:
     existingSecretApiTokenKey: apitoken
 
   extraVolumes:
-    - name: nautobot-dexauth
-      configMap:
-        name: dexauth
-        defaultMode: 420
     - name: nautobot-sso
       secret:
         secretName: nautobot-sso
@@ -34,10 +30,6 @@ nautobot:
         optional: false
 
   extraVolumeMounts:
-    - name: nautobot-dexauth
-      mountPath: /opt/nautobot/dexauth.py
-      readOnly: true
-      subPath: dexauth.py
     - name: nautobot-sso
       mountPath: /opt/nautobot/sso/
       readOnly: true


### PR DESCRIPTION
We don't use this anymore now that we have the upstreamed group_sync.