### PR TITLE
fix: fix router plugin

### DIFF
--- a/components/neutron/aio-values.yaml
+++ b/components/neutron/aio-values.yaml
@@ -52,7 +52,7 @@ conf:
         type_drivers: "vlan,local,understack_vxlan"
   neutron:
     DEFAULT:
-      service_plugins: "l3_understack,segments,port_forwarding"
+      service_plugins: "l3_understack,segments"
       # we don't want HA L3 routers. It's a Python value so we need to quote it in YAML.
       l3_ha: "False"
       # we aren't using availability zones so having calls attempt to add things to

--- a/python/neutron-understack/neutron_understack/l3_service_plugin.py
+++ b/python/neutron-understack/neutron_understack/l3_service_plugin.py
@@ -3,6 +3,7 @@ from pprint import pprint
 
 from neutron.services.l3_router.l3_router_plugin import L3RouterPlugin
 from neutron_lib.context import Context
+from neutron_lib.db import resource_extend
 
 LOG = logging.getLogger(__name__)
 
@@ -24,14 +25,14 @@ def print_post_commit_data(method: str, data: dict) -> None:
     pprint(data)
 
 
+@resource_extend.has_resource_extenders
 class UnderStackL3ServicePlugin(L3RouterPlugin):
-    def __init__(self):
-        """Understack L3 plugin.
+    """Understack L3 plugin.
 
-        L3 plugin to deal with Understack infrastructure.
-        """
-        super().__init__()
+    L3 plugin to deal with Understack infrastructure.
+    """
 
+    @classmethod
     def get_plugin_type(self):
         return "L3_ROUTER_NAT"
 


### PR DESCRIPTION
The core port_forwarding plugin is hard coded to use the default "router" plugin so we can't use it with our UnderStackL3ServicePlugin. ATM we don't use the port_forwarding so we're removing it for now, if needed in the future, we can create our own by just subclassing the core port_forwarding plugin and point it to use our UnderStackL3ServicePlugin