### PR TITLE
feat(neutron): enable trunk plugin

### DIFF
--- a/components/neutron/aio-values.yaml
+++ b/components/neutron/aio-values.yaml
@@ -52,10 +52,12 @@ conf:
         type_drivers: "vlan,local,understack_vxlan"
   neutron:
     DEFAULT:
+      # the 'trunk' plugin allows for us to create and configure trunk ports to allow
+      # multiple networks to be trunked into the node and let the node apply the VLAN
       # the 'network_segment_range' plugin allows us to set the allowed VNIs or VLANs
       # for a given network and let's OpenStack select one from the available pool. We
       # are also able to see which ones are used from the OpenStack API.
-      service_plugins: "l3_understack,network_segment_range"
+      service_plugins: "l3_understack,trunk,network_segment_range"
       # we don't want HA L3 routers. It's a Python value so we need to quote it in YAML.
       l3_ha: "False"
       # we aren't using availability zones so having calls attempt to add things to

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -14,6 +14,7 @@ from oslo_config import cfg
 
 from neutron_understack import config
 from neutron_understack.nautobot import Nautobot
+from neutron_understack.trunk import UnderStackTrunkDriver
 from neutron_understack.undersync import Undersync
 
 LOG = logging.getLogger(__name__)
@@ -110,6 +111,7 @@ class UnderstackDriver(MechanismDriver):
         conf = cfg.CONF.ml2_understack
         self.nb = Nautobot(conf.nb_url, conf.nb_token)
         self.undersync = Undersync(conf.undersync_token, conf.undersync_url)
+        self.trunk_driver = UnderStackTrunkDriver.create(self)
 
     def create_network_precommit(self, context):
         log_call("create_network_precommit", context)

--- a/python/neutron-understack/neutron_understack/trunk.py
+++ b/python/neutron-understack/neutron_understack/trunk.py
@@ -1,0 +1,28 @@
+from neutron.services.trunk.drivers import base as trunk_base
+from neutron_lib.api.definitions import portbindings
+from neutron_lib.services.trunk import constants as trunk_consts
+from oslo_config import cfg
+
+SUPPORTED_INTERFACES = (portbindings.VIF_TYPE_OTHER,)
+
+SUPPORTED_SEGMENTATION_TYPES = (trunk_consts.SEGMENTATION_TYPE_VLAN,)
+
+
+class UnderStackTrunkDriver(trunk_base.DriverBase):
+    @property
+    def is_loaded(self):
+        try:
+            return "understack" in cfg.CONF.ml2.mechanism_drivers
+        except cfg.NoSuchOptError:
+            return False
+
+    @classmethod
+    def create(cls, plugin_driver):
+        cls.plugin_driver = plugin_driver
+        return cls(
+            "understack",
+            SUPPORTED_INTERFACES,
+            SUPPORTED_SEGMENTATION_TYPES,
+            None,
+            can_trunk_bound_port=True,
+        )


### PR DESCRIPTION
Enables the trunk plugin so that we can create trunk ports. This provides a stub interface for our understack ML2 driver so that it can load. 