### PR TITLE
fix: update kube-prometheus-stack default alerts to not include kube-proxy

### DIFF
--- a/operators/monitoring/values.yaml
+++ b/operators/monitoring/values.yaml
@@ -1,0 +1,8 @@
+# Disable the default kube-proxy alert since we don't have it,
+# we have cilium instead.
+# https://github.com/prometheus-community/helm-charts/issues/1718
+defaultRules:
+  rules:
+    kubeProxy: false
+kubeProxy:
+  enabled: false


### PR DESCRIPTION
The kube-prometheus-stack includes a number of default alerts, including one for kube-proxy. We don't have kube-proxy as we're using cilium, so the alert continually fires. This disables the kube-proxy default monitoring.