### PR TITLE
fix: Nautobot status 'Decom' doesn't exist; switch to Decommissioning

### DIFF
--- a/python/understack-workflows/understack_workflows/ironic/provision_state_mapper.py
+++ b/python/understack-workflows/understack_workflows/ironic/provision_state_mapper.py
@@ -12,7 +12,7 @@ class ProvisionStateMapper:
         "inspecting": "Provisioning",
         "deploying": "Provisioning",
         "cleaning": "Quarantine",
-        "deleting": "Decom",
+        "deleting": "Decommissioning",
     }
     ALL_IRONIC_STATES = [
         "enroll",


### PR DESCRIPTION
Nautobot status 'Decom' doesn't exist but 'Decommissioning' does. Switches to the correct status.