### PR TITLE
fix: nova-flavors: resolve the container build problem

### DIFF
--- a/containers/nova-flavors/Dockerfile.nova-flavors
+++ b/containers/nova-flavors/Dockerfile.nova-flavors
@@ -1,8 +1,8 @@
 FROM ghcr.io/rackerlabs/understack/argo-python3.12.2-alpine3.19 AS builder
 
 RUN --mount=type=cache,target=/var/cache/apk apk add --virtual build-deps gcc python3-dev musl-dev linux-headers
-RUN --mount=type=cache,target=/root/.cache/.pip pip install 'wheel==0.43.0'
-RUN --mount=type=cache,target=/root/.cache/.pip \
+RUN --mount=type=cache,target=/root/.cache/pip pip install 'wheel==0.43.0'
+RUN --mount=type=cache,target=/root/.cache/pip \
     python -m venv /opt/poetry && \
     /opt/poetry/bin/pip install 'poetry==1.7.1' && \
     /opt/poetry/bin/poetry self add 'poetry-dynamic-versioning[plugin]==1.3.0'
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/.pip \
 COPY --chown=appuser:appgroup operators/nova-flavors /app
 COPY --chown=appuser:appgroup python/understack-flavor-matcher /understack-flavor-matcher
 # need watchdog and psutil built AS a wheel
-RUN --mount=type=cache,target=/root/.cache/.pip pip wheel --wheel-dir /app/dist watchdog psutil
+RUN --mount=type=cache,target=/root/.cache/pip pip wheel --wheel-dir /app/dist watchdog psutil==6.1.0
 CMD ["nova-flavors-sync"]
 
 WORKDIR /app
@@ -29,7 +29,7 @@ RUN mkdir -p /opt/venv/wheels/
 COPY --from=builder /app/dist/*.whl /app/dist/requirements.txt /opt/venv/wheels/
 COPY --chown=appuser:appgroup python/understack-flavor-matcher /python/understack-flavor-matcher
 
-RUN --mount=type=cache,target=/root/.cache/.pip cd /app && /opt/venv/bin/pip install --find-links /opt/venv/wheels/ --only-binary watchdog psutil -r /opt/venv/wheels/requirements.txt nova-flavors
+RUN --mount=type=cache,target=/root/.cache/pip cd /app && /opt/venv/bin/pip install --find-links /opt/venv/wheels/ --only-binary watchdog --only-binary psutil -r /opt/venv/wheels/requirements.txt nova-flavors
 
 USER appuser
 CMD ["nova-flavors-sync"]

--- a/containers/nova-flavors/Dockerfile.nova-flavors
+++ b/containers/nova-flavors/Dockerfile.nova-flavors
@@ -18,7 +18,7 @@ WORKDIR /app
 RUN cd /app && /opt/poetry/bin/poetry build -f wheel && /opt/poetry/bin/poetry export --without-hashes -f requirements.txt -o dist/requirements.txt
 
 ######################## PROD  ########################
-FROM builder AS prod
+FROM ghcr.io/rackerlabs/understack/argo-python3.12.2-alpine3.19 AS prod
 
 ENV FLAVORS_DIR="/flavors"
 ENV NOVA_FLAVOR_MONITOR_LOGLEVEL="info"


### PR DESCRIPTION
This PR addresses a build failure after new version of the `psutil` has been released. The psutil required by dependencies is 6.1.0 and the builder stage used to deliver the latest which is now 6.1.1.

This PR also fixes the PIP cache directory which is `~/.cache/pip`and not `~/.cache/.pip`.

https://pip.pypa.io/en/stable/topics/caching/#default-paths

