### PR TITLE
feat(workflows): switch to nautobot native idempotent IDs

### DIFF
--- a/python/understack-workflows/tests/conftest.py
+++ b/python/understack-workflows/tests/conftest.py
@@ -110,7 +110,5 @@ def nautobot(requests_mock, nautobot_url: str, tenant_data: dict) -> Nautobot:
     )
     requests_mock.get(tenant_data["url"], json=tenant_data)
     requests_mock.delete(tenant_data["url"])
-    requests_mock.post(
-        f"{nautobot_url}/api/plugins/uuid-api-endpoints/tenant/", json=tenant_data
-    )
+    requests_mock.post(f"{nautobot_url}/api/tenancy/tenants/", json=tenant_data)
     return Nautobot(nautobot_url, "blah")

--- a/python/understack-workflows/understack_workflows/main/sync_keystone.py
+++ b/python/understack-workflows/understack_workflows/main/sync_keystone.py
@@ -67,7 +67,6 @@ def handle_project_create(conn: Connection, nautobot: Nautobot, project_id: uuid
     logger.info(f"got request to create tenant {project_id!s}")
     project = conn.identity.get_project(project_id.hex)  # type: ignore
     ten_api = nautobot.session.tenancy.tenants
-    ten_api.url = f"{ten_api.base_url}/plugins/uuid-api-endpoints/tenant"
     ten = ten_api.create(
         id=str(project_id), name=project.name, description=project.description
     )


### PR DESCRIPTION
Nautobot has integrated the idempotent IDs feature so switch to that instead of using our custom piece.