### PR TITLE
feat: enables monitoring and metrics in helm charts

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -1,3 +1,4 @@
+# Defaults: https://opendev.org/openstack/openstack-helm/src/branch/master/keystone/values.yaml
 ---
 release_group: null
 

--- a/components/nautobot/cloudnative-postgres-nautobot.yaml
+++ b/components/nautobot/cloudnative-postgres-nautobot.yaml
@@ -8,6 +8,8 @@ spec:
   instances: 3
   storage:
     size: 20Gi
+  monitoring:
+    enablePodMonitor: true
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup

--- a/components/nautobot/values.yaml
+++ b/components/nautobot/values.yaml
@@ -1,3 +1,4 @@
+# Defaults: https://github.com/nautobot/helm-charts/blob/develop/charts/nautobot/values.yaml
 ---
 
 nautobot:
@@ -62,3 +63,10 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: understack-cluster-issuer
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+
+# (nicholas.kuechler) seeing something unexpected:
+# https://networktocode.slack.com/archives/C01NWPK6WHL/p1736445485521569
+metrics:
+  enabled: true
+  prometheusRule:
+    enabled: true

--- a/components/openstack/mariadb-instance.yaml
+++ b/components/openstack/mariadb-instance.yaml
@@ -44,5 +44,9 @@ spec:
       key: password
       name: mariadb-metrics-password
       generate: true
-    serviceMonitor: {}
+    serviceMonitor:
+      prometheusRelease: kube-prometheus-stack
+      jobLabel: mariadb-monitoring
+      interval: 10s
+      scrapeTimeout: 10s
     username: mariadb-metrics

--- a/operators/cnpg-system/values.yaml
+++ b/operators/cnpg-system/values.yaml
@@ -1,0 +1,6 @@
+# Defaults: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+
+monitoring:
+  podMonitorEnabled: true
+  grafanaDashboard:
+    create: true

--- a/operators/external-secrets/kustomization.yaml
+++ b/operators/external-secrets/kustomization.yaml
@@ -9,3 +9,4 @@ helmCharts:
   releaseName: external-secrets
   version: 0.11.0
   repo: https://charts.external-secrets.io
+  valuesFile: values.yaml

--- a/operators/external-secrets/values.yaml
+++ b/operators/external-secrets/values.yaml
@@ -1,0 +1,4 @@
+# Defaults: https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml
+
+serviceMonitor:
+  enabled: true

--- a/operators/mariadb-operator/values.yaml
+++ b/operators/mariadb-operator/values.yaml
@@ -1,0 +1,4 @@
+# Defaults: https://github.com/mariadb-operator/mariadb-operator/blob/main/deploy/charts/mariadb-operator/values.yaml
+
+metrics:
+  enabled: true

--- a/operators/monitoring/values.yaml
+++ b/operators/monitoring/values.yaml
@@ -6,3 +6,43 @@ defaultRules:
     kubeProxy: false
 kubeProxy:
   enabled: false
+prometheus:
+  prometheusSpec:
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+
+grafana:
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: "default"
+          orgId: 1
+          folder: ""
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/default
+  dashboards:
+    default:
+      # mariadb-operator dashboards
+      # https://github.com/mariadb-operator/mariadb-operator/blob/main/hack/config/kube-prometheus-stack.yaml
+      mysql-overview:
+        gnetId: 7362
+        revision: 5
+        datasource: Prometheus
+      mysql-replication:
+        gnetId: 7371
+        revision: 1
+        datasource: Prometheus
+      mariadb-galera:
+        gnetId: 13106
+        revision: 3
+        datasource: Prometheus
+      mysql-quickstart:
+        gnetId: 14057
+        revision: 1
+        datasource: Prometheus

--- a/operators/rook/values-operator.yaml
+++ b/operators/rook/values-operator.yaml
@@ -1,2 +1,5 @@
 # Defaults
 # https://github.com/rook/rook/blob/release-1.15/deploy/charts/rook-ceph/values.yaml
+
+monitoring:
+  enabled: true


### PR DESCRIPTION
We have the prometheus operator already in place. This enables the helm chart option to set up prometheus metrics+monitoring for charts where that feature exists.