### PR TITLE
fix: ensure prerequisite resources are created before we create a server

### DIFF
--- a/examples/tf-multi-node-build/main.tf
+++ b/examples/tf-multi-node-build/main.tf
@@ -61,4 +61,10 @@ resource "openstack_compute_instance_v2" "tenant_server" {
   network {
     uuid = openstack_networking_network_v2.tenant_net.id
   }
+
+  depends_on = [
+    openstack_networking_subnet_v2.tenant_subnet,
+    openstack_networking_network_v2.tenant_net,
+    openstack_compute_keypair_v2.ssh_keypair
+  ]
 }


### PR DESCRIPTION
Terraform was issuing creation of the server before the subnt was fully created, causing an error. Notice the server gets created before subnet:

```
openstack_networking_network_v2.tenant_net: Creating...
openstack_compute_keypair_v2.ssh_keypair: Creating...
openstack_compute_keypair_v2.ssh_keypair: Creation complete after 1s [id=ringtail]
openstack_networking_network_v2.tenant_net: Creation complete after 7s [id=3d1a58d9-f869-4a81-b4a3-4d9a5ceec578]
openstack_compute_instance_v2.tenant_server[1]: Creating...
openstack_compute_instance_v2.tenant_server[0]: Creating...
openstack_networking_subnet_v2.tenant_subnet: Creating...
openstack_networking_subnet_v2.tenant_subnet: Creation complete after 6s [id=fbf46959-cea2-48e5-aa08-f3e3ec58194e]
openstack_compute_instance_v2.tenant_server[1]: Still creating... [10s elapsed]
Error: Error creating OpenStack server: Bad request with: [POST https://nova.dev.undercloud.rackspace.net/v2.1/d3c2c85bdbf24ff5843f323524b63768/servers], error message: {"badRequest": {"code": 400, "message": "Network 3d1a58d9-f869-4a81-b4a3-4d9a5ceec578 requires a subnet in order to boot instances on."}}
  with openstack_compute_instance_v2.tenant_server[0],
  on main.tf line 54, in resource "openstack_compute_instance_v2" "tenant_server":
  54: resource "openstack_compute_instance_v2" "tenant_server" {
Error: Error waiting for instance (4013e286-17ef-4cc7-b6eb-6615973eef1f) to become ready: unexpected state 'ERROR', wanted target 'ACTIVE'. last error: %!s(<nil>)
  with openstack_compute_instance_v2.tenant_server[1],
  on main.tf line 54, in resource "openstack_compute_instance_v2" "tenant_server":
  54: resource "openstack_compute_instance_v2" "tenant_server" {
Error: Terraform exited with code 1.
```

This adds resource dependencies to the terraform so that the required resources are created before we issue the server build.