### PR TITLE
feat(neutron): enable network segment range but disable segments plugin

### DIFF
--- a/components/neutron/aio-values.yaml
+++ b/components/neutron/aio-values.yaml
@@ -52,7 +52,7 @@ conf:
         type_drivers: "vlan,local,understack_vxlan"
   neutron:
     DEFAULT:
-      service_plugins: "l3_understack,segments"
+      service_plugins: "l3_understack"
       # we don't want HA L3 routers. It's a Python value so we need to quote it in YAML.
       l3_ha: "False"
       # we aren't using availability zones so having calls attempt to add things to

--- a/components/neutron/aio-values.yaml
+++ b/components/neutron/aio-values.yaml
@@ -52,7 +52,10 @@ conf:
         type_drivers: "vlan,local,understack_vxlan"
   neutron:
     DEFAULT:
-      service_plugins: "l3_understack"
+      # the 'network_segment_range' plugin allows us to set the allowed VNIs or VLANs
+      # for a given network and let's OpenStack select one from the available pool. We
+      # are also able to see which ones are used from the OpenStack API.
+      service_plugins: "l3_understack,network_segment_range"
       # we don't want HA L3 routers. It's a Python value so we need to quote it in YAML.
       l3_ha: "False"
       # we aren't using availability zones so having calls attempt to add things to


### PR DESCRIPTION
The segments plugin is for routed L3 networks which we aren't using and don't have an intention to use at this time. But we do want to allow OpenStack to select our VLAN and VNIs for our fabric but we don't want this in a config file so enable the API extension to let us manage this directly.