### PR TITLE
fix: update keystone memcached cache settings

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -251,6 +251,8 @@ conf:
           - http://localhost:9990/auth/websso/
           # - https://yourinstance.of.horizon.example.com/auth/websso/
       default_authorization_ttl: 720
+    cache:
+      backend_argument: memcached_expire_time:3600
     DEFAULT:
       max_token_size: 512
   wsgi_keystone: |


### PR DESCRIPTION
I believe we've hit an old issue described here: https://bugs.launchpad.net/keystone/+bug/1901124
