### PR TITLE
fix: rename workflow parameters

### DIFF
--- a/python/understack-workflows/understack_workflows/main/undersync_device.py
+++ b/python/understack-workflows/understack_workflows/main/undersync_device.py
@@ -117,7 +117,7 @@ def call_undersync(args, vlan_group_id: UUID):
 
     try:
         return undersync.sync_devices(
-            [str(vlan_group_id)], dry_run=args.dry_run, force=args.force
+            str(vlan_group_id), dry_run=args.dry_run, force=args.force
         )
     except Exception as error:
         logger.error(error)

--- a/python/understack-workflows/understack_workflows/undersync/client.py
+++ b/python/understack-workflows/understack_workflows/undersync/client.py
@@ -13,16 +13,13 @@ class Undersync:
         self.token = auth_token
         self.api_url = api_url
 
-    def sync_devices(self, switch_uuids: str | list[str], force=False, dry_run=False):
-        if isinstance(switch_uuids, list):
-            switch_uuids = ",".join(switch_uuids)
-
+    def sync_devices(self, vlan_group_uuid: str, force=False, dry_run=False):
         if dry_run:
-            return self.dry_run(switch_uuids)
+            return self.dry_run(vlan_group_uuid)
         elif force:
-            return self.force(switch_uuids)
+            return self.force(vlan_group_uuid)
         else:
-            return self.sync(switch_uuids)
+            return self.sync(vlan_group_uuid)
 
     @cached_property
     def client(self):

--- a/workflows/argo-events/workflowtemplates/undersync-switch.yaml
+++ b/workflows/argo-events/workflowtemplates/undersync-switch.yaml
@@ -17,7 +17,7 @@ spec:
           - undersync-switch
         args:
           - --switch_uuids
-          - "{{workflow.parameters.switch_uuids}}"
+          - "{{workflow.parameters.vlan_group_uuid}}"
           - --dry-run
           - "{{workflow.parameters.dry_run}}"
           - --force
@@ -31,7 +31,7 @@ spec:
             readOnly: true
       inputs:
         parameters:
-          - name: switch_uuids
+          - name: vlan_group_uuid
           - name: force
           - name: dry_run
       volumes:

--- a/workflows/argo-events/workflowtemplates/undersync-switch.yaml
+++ b/workflows/argo-events/workflowtemplates/undersync-switch.yaml
@@ -16,7 +16,7 @@ spec:
         command:
           - undersync-switch
         args:
-          - --switch_uuids
+          - --vlan_group_uuid
           - "{{workflow.parameters.vlan_group_uuid}}"
           - --dry-run
           - "{{workflow.parameters.dry_run}}"


### PR DESCRIPTION
A long time ago this workflow used to take a switch ID argument.  This was changed to a Vlan Group ID argument, but I was lazy and failed to update identifiers and parameter strings to reflect the change in behaviour.  This PR cleans up the confusment.

closes PUC-732