### PR TITLE
docs: adds --progress option when creating an OpenStack image

### DIFF
--- a/docs/user-guide/openstack-image.md
+++ b/docs/user-guide/openstack-image.md
@@ -68,6 +68,7 @@ openstack image create 'My-Ubuntu-24.04' \
   --disk-format qcow2 \
   --property os_distro=ubuntu \
   --property os_version=24.04 \
+  --progress \
   --file=/path/to/image.qcow2
 ```
 


### PR DESCRIPTION
So that we can see the progress of the image upload since large images can take a while to complete.