### PR TITLE
fix: fix keystone max active fernet keys

### DIFF
--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -255,6 +255,12 @@ conf:
       backend_argument: memcached_expire_time:3600
     DEFAULT:
       max_token_size: 512
+    # (TODO) Need to follow up on this. There is a pending upstream change to
+    # add this to the openstack-helm values:
+    # https://review.opendev.org/c/openstack/openstack-helm/+/934703
+    fernet_tokens:
+      max_active_keys: 7
+
   wsgi_keystone: |
     {{- $portInt := tuple "identity" "service" "api" $ | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
 


### PR DESCRIPTION
Pulls in the upstream change from: https://review.opendev.org/c/openstack/openstack-helm/+/934703 which is currently pending review process. Once that gets merged in to the upstream values, we can remove it from this override.