### PR TITLE
fix: update nova's ironic retry settings to allow for node cleaning time

### DIFF
--- a/components/nova/aio-values.yaml
+++ b/components/nova/aio-values.yaml
@@ -69,6 +69,15 @@ conf:
       cores: 512
       ram: 512000
 
+    # (TODO) This is to help with an upstream Nova bug:
+    # https://review.opendev.org/c/openstack/nova/+/883411
+    #
+    # This can be removed from when the upstream issue has been resolved.
+    # Cleaning can take around 5-10 minutes, so we need the value of
+    # (api_max_retries * api_retry_interval) > time to clean
+    ironic:
+      api_max_retries: 90  # number of times to retry. default is 60.
+      api_retry_interval: 10  # number of sesconds between retries. default is 2.
 
 console:
   # we are working with baremetal nodes and not QEMU so we don't need novnc or spice


### PR DESCRIPTION
We've hit an upstream OpenStack Nova bug with the ironic driver:

https://bugs.launchpad.net/nova/+bug/2019977
https://review.opendev.org/c/openstack/nova/+/883411

A work around is to increase the retries and retry interval for the ironic driver in order to get a longer timeout period, in order to wait until the ironic node cleaning has completed and ironic unlocks the node.
