### PR TITLE
feat: Neutron: consistent vlan assignments 

### DIFF
--- a/python/neutron-understack/neutron_understack/config.py
+++ b/python/neutron-understack/neutron_understack/config.py
@@ -50,6 +50,16 @@ mech_understack_opts = [
             "is used to trunk all vlans used by a neutron router."
         ),
     ),
+    cfg.BoolOpt(
+        "enforce_unique_vlans_in_fabric",
+        default=True,
+        help=(
+            "When enabled, Neutron performs an extra check during the creation of a"
+            "new VLAN network. This check ensures that the VLAN ID being assigned is"
+            "not already in use within a fabric. The verification is handled by "
+            "Nautobot."
+        ),
+    ),
 ]
 
 l3_svc_cisco_asa_opts = [

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -16,6 +16,7 @@ from neutron_understack import config
 from neutron_understack.nautobot import Nautobot
 from neutron_understack.trunk import UnderStackTrunkDriver
 from neutron_understack.undersync import Undersync
+from neutron_understack.vlan_manager import VlanManager
 
 LOG = logging.getLogger(__name__)
 
@@ -112,9 +113,11 @@ class UnderstackDriver(MechanismDriver):
         self.nb = Nautobot(conf.nb_url, conf.nb_token)
         self.undersync = Undersync(conf.undersync_token, conf.undersync_url)
         self.trunk_driver = UnderStackTrunkDriver.create(self)
+        self.vlan_manager = VlanManager(self.nb, conf)
 
-    def create_network_precommit(self, context):
+    def create_network_precommit(self, context: NetworkContext):
         log_call("create_network_precommit", context)
+        self.vlan_manager.create_vlan_for_network(context)
 
     def create_network_postcommit(self, context):
         log_call("create_network_postcommit", context)

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -117,7 +117,8 @@ class UnderstackDriver(MechanismDriver):
 
     def create_network_precommit(self, context: NetworkContext):
         log_call("create_network_precommit", context)
-        self.vlan_manager.create_vlan_for_network(context)
+        if cfg.CONF.ml2_understack.enforce_unique_vlans_in_fabric:
+            self.vlan_manager.create_vlan_for_network(context)
 
     def create_network_postcommit(self, context):
         log_call("create_network_postcommit", context)

--- a/python/neutron-understack/neutron_understack/vlan_manager.py
+++ b/python/neutron-understack/neutron_understack/vlan_manager.py
@@ -1,0 +1,111 @@
+import logging
+
+from neutron.db.models.plugins.ml2.vlanallocation import VlanAllocation
+from neutron.db.models.segment import NetworkSegment
+from neutron_lib import constants as p_const
+from neutron_lib import context as neutron_context
+from neutron_lib.plugins.ml2.api import NetworkContext
+from sqlalchemy import update
+
+LOG = logging.getLogger(__name__)
+MAX_VLAN_ATTEMPTS = 4096
+
+
+class VlanManager:
+    def __init__(self, nb, conf):
+        self.nb = nb
+        self.conf = conf
+
+    def create_vlan_for_network(self, context: NetworkContext):
+        """Ensures that Vlan ID for a newly created network is available.
+
+        This method checks if the VLAN is available across the whole fabric,
+        and in case where it isn't, it will attempt to allocate new one
+        and repeat the checks until successful or we run out of vlans..
+        """
+        if not context.current:
+            raise RuntimeError("no current context provided.")
+
+        vlan_tag = context.current["provider:segmentation_id"]
+        allocated = self._allocate_vlan(context, vlan_tag)
+
+        if allocated:
+            self._update_segmentation_id(context, vlan_tag)
+            self._new_vlan_mark_allocated(context, allocated)
+
+    def _allocate_vlan(
+        self, context: NetworkContext, vlan_tag: int
+    ) -> VlanAllocation | None:
+        """Attempts to allocate a VLAN ID, trying multiple times if necessary.
+
+        Returns:
+            allocation when new segment was assigned
+            None when the original segment was free
+        """
+        alloc = None
+        attempts = 0
+        while attempts < MAX_VLAN_ATTEMPTS:
+            if self._is_vlan_available(
+                self.conf.network_node_switchport_uuid,
+                vlan_tag,
+            ):
+                LOG.debug(f"Vlan {vlan_tag} is available for all VLANGroups.")
+                return alloc
+
+            LOG.info(
+                f"Vlan {vlan_tag} is reported to be used in fabric associated with "
+                "this VlanGroup. Trying next one..."
+            )
+            alloc = self._find_next_available_vlan(context)
+            vlan_tag = alloc.vlan_id
+            attempts += 1
+        raise RuntimeError("No available VLANs found after multiple attempts.")
+
+    def _is_vlan_available(self, interface_id: str, vlan_tag: int) -> bool:
+        """Checks if VLAN ID is available in Nautobot."""
+        return self.nb.check_vlan_availability(
+            interface_id=interface_id, vlan_tag=vlan_tag
+        )
+
+    def _find_next_available_vlan(self, context):
+        """Figures out what the next available VLAN ID for a given network is."""
+        if len(context.network_segments) != 1:
+            raise ValueError("Multi-segment networks are not supported.")
+
+        vlan_type_driver = context._plugin.type_manager.drivers.get("vlan", {}).obj
+        if vlan_type_driver is None:
+            raise RuntimeError("no VlanTypeDriver available.")
+
+        admin_context = neutron_context.get_admin_context()
+        physical_network = context.current["provider:physical_network"]
+        segment_record = vlan_type_driver.allocate_partially_specified_segment(
+            context=admin_context, physical_network=physical_network
+        )
+        return segment_record
+
+    def _update_segmentation_id(self, context, vlan_tag):
+        """Updates segmentation ID for the provider and all network segments."""
+        context.current["provider:segmentation_id"] = vlan_tag
+
+        # Update all segments' segmentation_id
+        session = context.plugin_context.session
+        results = []
+        for segment in context.network_segments:
+            if segment["network_type"] == p_const.TYPE_VLAN:
+                results.append(self._update_id_on_segment(session, segment, vlan_tag))
+        return results
+
+    def _update_id_on_segment(self, session, segment, vlan_tag):
+        """Updates segmentation_id on a single network segment."""
+        update_segment_statement = (
+            update(NetworkSegment)
+            .where(NetworkSegment.id == segment["id"])
+            .values(segmentation_id=vlan_tag)
+        )
+
+        return session.execute(update_segment_statement)
+
+    def _new_vlan_mark_allocated(self, context, alloc):
+        session = context.plugin_context.session
+        alloc.allocated = True
+        return alloc.save(session)


### PR DESCRIPTION
This PR modifies the Understack mechanism driver by hooking `create_network_precommit` event to verify if the selected VLAN ID is available in particular fabric before assigning it.

That feature heavily relies on the Nautobot data being correct. The concept of availability is abstracted away through custom API plugin in Nautobot which returns simple 'true/false'.

For the input, we take the `interface_id` which is configured statically in Neutron's configuration as `network_node_switchport_uuid`. This refers to an interface of a "network node" which presumably is always the first interface to be hooked into the network.

The second input is a `vlan_tag` as chosen by the Neutron.

If Nautobot considers the vlan to be available, the hook returns and the allocation proceeds as normal. If it happens to be taken, the Neutron is asked to allocate new segment (and thus new VLAN ID) and the check is repeated.

In addition to this, for extra safety, the same check is also executed during prep_switch_interface but that's out of scope for this commit because it's implemented in the Nautobot plugin change.

Goes together with https://github.com/RSS-Engineering/undercloud-rackspace/pull/338

Related: https://rackspace.atlassian.net/browse/PUC-736
