### PR TITLE
fix(ironic): allow lessee to see the last error in a build

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -24,6 +24,10 @@ labels:
     node_selector_value: conductor
 
 conf:
+  # Update policies for better integration with OpenStack services
+  # https://docs.openstack.org/ironic/latest/configuration/sample-policy.html
+  policy:
+    "baremetal:node:get:last_error": "role:service or role:admin or (project_id:%(node.owner)s or project_id:%(node.lessee)s)"
   ironic:
     DEFAULT:
       # We only want to default to direct, otherwise defaults interfere with hardware


### PR DESCRIPTION
Issues we're seeing:

``` text
{'code': 500, 'created': '2025-01-23T15:24:50Z', 'message': 'Build of instance
953691fd-1dde-4b01-9010-e0d45d1a9dfa aborted: Failed to provision instance
953691fd-1dde-4b01-9010-e0d45d1a9dfa: ** Value Redacted - Requires
baremetal:node:get:last_error permission. **'}
```