### PR TITLE
feat: nautobot: allow configuring vni_custom_model through env

### DIFF
--- a/components/nautobot/nautobot_config.py
+++ b/components/nautobot/nautobot_config.py
@@ -423,6 +423,12 @@ INSTALLATION_METRICS_ENABLED = is_truthy(
 #         'buzz': 'bazz'
 #     }
 # }
+PLUGINS_CONFIG = {
+    "vni_custom_model": {
+        "FORCE_UNIQUE_VLANS": os.getenv("VNI_CUSTOM_MODEL_FORCE_UNIQUE_VLANS", None)
+        == "true"
+    }
+}
 
 # Prefer IPv6 addresses or IPv4 addresses in selecting a device's primary IP address?
 #


### PR DESCRIPTION
This change adds a way to configure the FORCE_UNIQUE_VLANS setting for the vni_custom_model plugin by passing the environment variable (defined on a per-environment basis in deploy repo).