### PR TITLE
fix(keystone): fix healthcheck endpoint and max fernet keys

### DIFF
--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -20,7 +20,7 @@ spec:
                   repoURL: https://tarballs.opendev.org/openstack/openstack-helm
                   openstackRelease: 2024.2
                   # renovate: datasource=custom.openstackhelm depName=keystone
-                  chartVersion: 0.3.17
+                  chartVersion: 2024.2.4+79d4b689-eb60e37c
                 - component: openvswitch
                   repoURL: https://tarballs.opendev.org/openstack/openstack-helm-infra
                   openstackRelease: 2024.2

--- a/components/keystone/aio-values.yaml
+++ b/components/keystone/aio-values.yaml
@@ -256,11 +256,6 @@ conf:
       backend_argument: memcached_expire_time:3600
     DEFAULT:
       max_token_size: 512
-    # (TODO) Need to follow up on this. There is a pending upstream change to
-    # add this to the openstack-helm values:
-    # https://review.opendev.org/c/openstack/openstack-helm/+/934703
-    fernet_tokens:
-      max_active_keys: 7
 
   wsgi_keystone: |
     {{- $portInt := tuple "identity" "service" "api" $ | include "helm-toolkit.endpoints.endpoint_port_lookup" }}


### PR DESCRIPTION
Bumped the chart to the latest version which includes upstream fixes: https://review.opendev.org/c/openstack/openstack-helm/+/934703 https://review.opendev.org/c/openstack/openstack-helm/+/937472