### PR TITLE
docs: make output easier to read and copy/paste

### DIFF
--- a/docs/operator-guide/rabbitmq.md
+++ b/docs/operator-guide/rabbitmq.md
@@ -4,9 +4,9 @@
 
 ```bash
 # Username
-kubectl -n openstack get secret rabbitmq-default-user -o jsonpath="{.data.username}" | base64 --decode
+kubectl -n openstack get secret rabbitmq-default-user -o jsonpath="{.data.username}" | base64 --decode && echo
 # Password
-kubectl -n openstack get secret rabbitmq-default-user -o jsonpath="{.data.password}" | base64 --decode
+kubectl -n openstack get secret rabbitmq-default-user -o jsonpath="{.data.password}" | base64 --decode && echo
 ```
 
 ## Opening the UI


### PR DESCRIPTION
The echo adds newlines to make it easier to see the output when copy/pasting from the docs.