### PR TITLE
feat: PUC-752: reading OIDCCryptoPassphrase from a file

### DIFF
--- a/components/keystone/values.yaml
+++ b/components/keystone/values.yaml
@@ -228,10 +228,18 @@ pod:
           - name: keystone-sso
             mountPath: /etc/keystone-sso
             readOnly: true
+          - name: oidc-secret
+            mountPath: /etc/oidc-secret
+            readOnly: true
         volumes:
           - name: keystone-sso
             secret:
               secretName: keystone-sso
+          - name: oidc-secret
+            secret:
+              secretName: sso-passphrase
+  replicas:
+    api: 2
   lifecycle:
     disruption_budget:
       api:
@@ -287,7 +295,9 @@ conf:
         OIDCProviderMetadataURL http://dex.dex.svc:5556/.well-known/openid-configuration
         OIDCClientID keystone
         OIDCClientSecret "exec:/bin/cat /etc/keystone-sso/client-secret"
-        OIDCCryptoPassphrase "exec:/bin/bash -c \"head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32\""
+        OIDCCryptoPassphrase "exec:/bin/cat /etc/oidc-secret/password"
+        OIDCCacheType memcache
+        OIDCMemCacheServers "memcached.openstack.svc.cluster.local:11211"
         OIDCClaimDelimiter ;
 
         # avoid redirect issues per the following

--- a/scripts/gitops-secrets-gen.sh
+++ b/scripts/gitops-secrets-gen.sh
@@ -261,10 +261,22 @@ convert_to_var_name() {
 convert_to_secret_name() {
     echo "$1" | tr '[:upper:]' '[:lower:]' | tr '_' '-'
 }
+# Default password generator using pwgen.sh
+# shellcheck disable=SC2317
+default_pwgen() {
+    "${SCRIPTS_DIR}/pwgen.sh" 2>/dev/null
+}
+
+# Custom password generator with only alphabets
+# shellcheck disable=SC2317
+alpha_only_pwgen() {
+    head /dev/urandom | tr -dc A-Za-z | head -c 32
+}
 
 load_or_gen_os_secret() {
     local data_var=$1
     local secret_var=$2
+    local gen_func=${3:-default_pwgen}
 
     if kubectl -n openstack get secret "${secret_var}" &>/dev/null; then
         data="$(kubectl -n openstack get secret "${secret_var}" -o jsonpath='{.data.password}' | base64 -d)"
@@ -274,7 +286,7 @@ load_or_gen_os_secret() {
         return 1
     else
         echo "Generating ${secret_var}"
-        data="$("${SCRIPTS_DIR}/pwgen.sh" 2>/dev/null)"
+        data="$(${gen_func})"
         # good ol' bash 3 compat for macOS
         eval "${data_var}=\"${data}\""
         # return 0 because we need to write this out
@@ -366,5 +378,19 @@ find "${DEST_DIR}" -maxdepth 1 -mindepth 1 -type d | while read -r component; do
         popd > /dev/null || exit 1
     fi
 done
+
+echo "Checking keystone oidc passphrase Sealed Secret"
+mkdir -p "${DEST_DIR}/keystone"
+
+# Generate or retrieve passphrase
+VARNAME_PASSPHRASE="OS_SSO_PASSPHRASE"
+SECRET_PASSPHRASE="sso-passphrase"
+
+load_or_gen_os_secret "${VARNAME_PASSPHRASE}" "${SECRET_PASSPHRASE}" alpha_only_pwgen && \
+    create_os_secret "PASSPHRASE" "keystone" "passphrase"
+
+# Export for Helm templating if needed
+export OS_SSO_PASSPHRASE
+
 
 exit 0

--- a/scripts/pwgen.sh
+++ b/scripts/pwgen.sh
@@ -1,5 +1,12 @@
 #!/bin/sh -e
 
 export LC_ALL=C
-dd bs=512 if=/dev/urandom count=1 | tr -dc _A-Z-a-z-0-9 | head -c${1:-32}
+
+# Default password length (32 characters)
+LENGTH="${1:-32}"
+
+# Default character set (alphanumeric + special characters)
+CHARSET="${2:-_A-Z-a-z-0-9}"
+
+dd bs=512 if=/dev/urandom count=1 2>/dev/null | tr -dc "$CHARSET" | head -c"$LENGTH"
 echo


### PR DESCRIPTION
Problem: 
Unable to authenticate when the user receives the initial state, it is encrypted with a key from pod A, then user is redirected to the identity provided and finally when they get back through redirect, they may land on pod B which is no longer able to decrypt the state.

Solution:

OIDCCryptoPassphrase is a password used for encryption of the state cookie and cache entries and it must be the same on all replicas.

Previously we were setting the OIDCCryptoPassphrase to a random value that is generated on pod startup and multiple pods have different value.
