### PR TITLE
feat(argocd): set some less privileged RBAC rules

### DIFF
--- a/bootstrap/argocd/values.yaml
+++ b/bootstrap/argocd/values.yaml
@@ -25,5 +25,12 @@ configs:
     kustomize.buildOptions: --enable-helm
   rbac:
     policy.csv: |
-      g, ucadmin, role:admin
+      # role:ucadmin can sync applications
+      p, role:ucadmin, applications, sync, */*, allow
+      # role:ucadmin can update clusters so that they can set branch info
+      p, role:ucadmin, clusters, update, *, allow
+      # role:ucadmin inherits role:readonly
+      g, role:ucadmin, role:readonly
+      # members of the ucadmin group get role:ucadmin
+      g, ucadmin, role:ucadmin
     policy.default: role:readonly


### PR DESCRIPTION
Instead of giving the blanket admin permissions to the ucadmin, dial back to a more limited default.