### PR TITLE
fix: adds 'clean failed' ironic provision state

### DIFF
--- a/python/understack-workflows/understack_workflows/ironic/provision_state_mapper.py
+++ b/python/understack-workflows/understack_workflows/ironic/provision_state_mapper.py
@@ -12,6 +12,7 @@ class ProvisionStateMapper:
         "inspecting": "Provisioning",
         "deploying": "Provisioning",
         "cleaning": "Quarantine",
+        "clean failed": "Quarantine",
         "deleting": "Decommissioning",
     }
     ALL_IRONIC_STATES = [
@@ -23,6 +24,7 @@ class ProvisionStateMapper:
         "inspect failed",
         "cleaning",
         "clean wait",
+        "clean failed",
         "available",
         "deploying",
         "wait call-back",


### PR DESCRIPTION
Fix for an ironic-node-update error I saw in argo workflows:

``` text
2025-02-06 20:27:27 +0000 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): nautobot-default.nautobot.svc.cluster.local:80
2025-02-06 20:27:27 +0000 - urllib3.connectionpool - DEBUG - http://nautobot-default.nautobot.svc.cluster.local:80 "GET /api/ HTTP/1.1" 200 977
Traceback (most recent call last):
  File "/opt/venv/bin/sync-provision-state", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/main/sync_provision_state.py", line 60, in main
    do_action(
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/main/sync_provision_state.py", line 38, in do_action
    new_status = ProvisionStateMapper.translate_to_nautobot(provision_state)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/ironic/provision_state_mapper.py", line 64, in translate_to_nautobot
    raise ValueError(f"Unknown {provision_state=}")
ValueError: Unknown provision_state='clean failed'
time="2025-02-06T20:27:28 UTC" level=info msg="sub-process exited" argo=true error="<nil>"
Error: exit status 1
```