### PR TITLE
fix(neutron): don't default VNIs

### DIFF
--- a/components/neutron/aio-values.yaml
+++ b/components/neutron/aio-values.yaml
@@ -53,6 +53,10 @@ conf:
         mechanism_drivers: "understack,ovn"
         tenant_network_types: "vlan"
         type_drivers: "vlan,local,understack_vxlan"
+      ml2_type_vxlan:
+        # OSH sets a default range here but we want to use network_segment_range plugin
+        # to configure this instead
+        vni_ranges: ""
   neutron:
     DEFAULT:
       # the 'trunk' plugin allows for us to create and configure trunk ports to allow


### PR DESCRIPTION
OpenStack Helm hardcodes a default VNI range of 1:1000 which causes that range to always be available. We're using the network-segment-range service plugin and want to always configure our ranges with that.