### PR TITLE
feat(neutron): make our VXLAN type driver unique

### DIFF
--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -52,7 +52,7 @@ conf:
         # we'll need to use the ovn ML2 plugin to hook the routers to our network
         mechanism_drivers: "understack,ovn"
         tenant_network_types: "vlan"
-        type_drivers: "vlan,understack_vxlan"
+        type_drivers: "vlan,vxlan"
       ml2_type_vxlan:
         # OSH sets a default range here but we want to use network_segment_range plugin
         # to configure this instead

--- a/components/ovn/values.yaml
+++ b/components/ovn/values.yaml
@@ -7,7 +7,7 @@ conf:
   ovn_cms_options: ""
   ovn_cms_options_gw_enabled: "enable-chassis-as-gw"
   # we are working with baremetal so we'll need VTEP support
-  ovn_encap_type: vxlan
+  ovn_encap_type: geneve
 
 volume:
   ovn_ovsdb_nb:

--- a/python/neutron-understack/neutron_understack/type_understack_vxlan.py
+++ b/python/neutron-understack/neutron_understack/type_understack_vxlan.py
@@ -1,45 +1,9 @@
+from neutron.plugins.ml2.drivers import type_vxlan
 from neutron_lib import constants as p_const
-from neutron_lib.plugins.ml2 import api
-from oslo_log import log
-
-LOG = log.getLogger(__name__)
 
 
-class UnderstackVxlanTypeDriver(api.ML2TypeDriver):
-    def __init__(self):
-        """Understack based type driver."""
-        super().__init__()
-        LOG.info("ML2 Understack VXLAN Type initialization complete")
+class UnderstackVxlanTypeDriver(type_vxlan.VxlanTypeDriver):
+    """Manage state for EVPN L2VNI networks with ML2."""
 
     def get_type(self):
         return p_const.TYPE_VXLAN
-
-    def initialize(self):
-        pass
-
-    def initialize_network_segment_range_support(self):
-        pass
-
-    def update_network_segment_range_allocations(self):
-        pass
-
-    def get_network_segment_ranges(self):
-        pass
-
-    def is_partial_segment(self, segment):
-        return False
-
-    def validate_provider_segment(self, segment):
-        pass
-
-    def reserve_provider_segment(self, context, segment, filters=None):
-        return segment
-
-    def allocate_tenant_segment(self, context, filters=None):
-        return {api.NETWORK_TYPE: p_const.TYPE_VXLAN}
-
-    def release_segment(self, context, segment):
-        pass
-
-    def get_mtu(self, physical_network=None):
-        pass


### PR DESCRIPTION
Instead of standing in for the VXLAN type driver directly, have it be its own thing that will be ignored by mechanisms that consume it. The reason is that the existing VXLAN type driver is treated and consumed as a L3VNI while we need L2VNI.