### PR TITLE
chore(neutron): drop unused net types and use new config

### DIFF
--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -52,7 +52,7 @@ conf:
         # we'll need to use the ovn ML2 plugin to hook the routers to our network
         mechanism_drivers: "understack,ovn"
         tenant_network_types: "vlan"
-        type_drivers: "vlan,local,understack_vxlan"
+        type_drivers: "vlan,understack_vxlan"
       ml2_type_vxlan:
         # OSH sets a default range here but we want to use network_segment_range plugin
         # to configure this instead

--- a/python/neutron-understack/neutron_understack/config.py
+++ b/python/neutron-understack/neutron_understack/config.py
@@ -36,6 +36,11 @@ mech_understack_opts = [
         "undersync_dry_run", default=True, help="Call Undersync with dry-run mode"
     ),
     cfg.StrOpt(
+        "provisioning_network",
+        help="provisioning_network ID as configured in ironic.conf",
+        default="change_me",
+    ),
+    cfg.StrOpt(
         "shared_nautobot_namespace_name",
         default="Global",
         help=(

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -282,11 +282,8 @@ class UnderstackDriver(MechanismDriver):
         """
         network_type = segment[api.NETWORK_TYPE]
         return network_type in [
-            p_const.TYPE_LOCAL,
-            p_const.TYPE_GRE,
             p_const.TYPE_VXLAN,
             p_const.TYPE_VLAN,
-            p_const.TYPE_FLAT,
         ]
 
     def check_vlan_transparency(self, context):

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -229,9 +229,13 @@ class UnderstackDriver(MechanismDriver):
         pass
 
     def delete_port_postcommit(self, context):
-        network_id = context.current["network_id"]
+        provisioning_network = (
+            cfg.CONF.ml2_understack.provisioning_network
+            or cfg.CONF.ml2_type_understack.provisioning_network
+        )
 
-        if network_id == cfg.CONF.ml2_type_understack.provisioning_network:
+        network_id = context.current["network_id"]
+        if network_id == provisioning_network:
             connected_interface_uuid = self.fetch_connected_interface_uuid(
                 context.current
             )
@@ -323,7 +327,12 @@ class UnderstackDriver(MechanismDriver):
         :param connected_interface_uuid: The UUID of the connected interface.
         :return: The VLAN group UUID.
         """
-        if network_id == cfg.CONF.ml2_type_understack.provisioning_network:
+        provisioning_network = (
+            cfg.CONF.ml2_understack.provisioning_network
+            or cfg.CONF.ml2_type_understack.provisioning_network
+        )
+
+        if network_id == provisioning_network:
             port_status = "Provisioning-Interface"
             configure_port_status_data = self.nb.configure_port_status(
                 connected_interface_uuid, port_status

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -201,8 +201,6 @@ class UnderstackDriver(MechanismDriver):
         pass
 
     def update_port_postcommit(self, context):
-        pass
-
         self._delete_tenant_port_on_unbound(context)
 
         vif_type = context.current["binding:vif_type"]
@@ -231,8 +229,6 @@ class UnderstackDriver(MechanismDriver):
         pass
 
     def delete_port_postcommit(self, context):
-        pass
-
         network_id = context.current["network_id"]
 
         if network_id == cfg.CONF.ml2_type_understack.provisioning_network:


### PR DESCRIPTION
We won't ever support gre and flat networks so drop those out right. local is really for testing as a no-op so remove that as well but it might find its way back in for test purposes later. Fixed incorrect usage of pass. Handle old and new config file location.