### PR TITLE
fix(neutron): require nautobot auth and provide it by default

### DIFF
--- a/components/neutron/kustomization.yaml
+++ b/components/neutron/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - neutron-mariadb-db.yaml
   - neutron-rabbitmq-queue.yaml
+  - neutron-nautobot.yaml

--- a/components/neutron/neutron-nautobot.yaml
+++ b/components/neutron/neutron-nautobot.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: neutron-nautobot
+  namespace: openstack
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: nautobot
+  target:
+    name: neutron-nautobot
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      engineVersion: v2
+      data:
+        ml2_understack.conf: |
+          [ml2_understack]
+          nb_url = http://nautobot-default.nautobot.svc.cluster.local
+          nb_token = {{ .token }}
+  data:
+  - secretKey: token
+    remoteRef:
+      key: nautobot-superuser
+      property: apitoken

--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -95,32 +95,27 @@ pod:
     neutron_server:
       neutron_server:
         volumeMounts:
-          - mountPath: /etc/nb-token/
-            name: nb-token
+          - mountPath: /etc/neutron/neutron-server.conf.d/ml2_understack.conf
+            name: neutron-nautobot
+            subPath: ml2_understack.conf
             readOnly: true
           - mountPath: /etc/undersync/
             name: undersync-token
             readOnly: true
         volumes:
-          - name: nb-token
+          - name: neutron-nautobot
             secret:
-              secretName: nautobot-token
+              secretName: neutron-nautobot
           - name: undersync-token
             secret:
               secretName: undersync-token
     neutron_rpc_server:
       neutron_rpc_server:
         volumeMounts:
-          - mountPath: /etc/nb-token/
-            name: nb-token
-            readOnly: true
           - mountPath: /etc/undersync/
             name: undersync-token
             readOnly: true
         volumes:
-          - name: nb-token
-            secret:
-              secretName: nautobot-token
           - name: undersync-token
             secret:
               secretName: undersync-token

--- a/python/neutron-understack/neutron_understack/config.py
+++ b/python/neutron-understack/neutron_understack/config.py
@@ -12,10 +12,12 @@ mech_understack_opts = [
     cfg.StrOpt(
         "nb_url",
         help="Nautobot URL",
+        required=True,
     ),
     cfg.StrOpt(
         "nb_token",
         help="Nautobot API token",
+        required=True,
     ),
     cfg.StrOpt(
         "ucvni_group",


### PR DESCRIPTION
The config option parser was not requiring the nautobot auth info which was no longer defaulted or read from the existing location as of #666. This makes it required for the server to start up successfully. Lastly the auth information was actually being read from a location supplied by the workflows so create a new secret with the data populated. Create the secret in the syntax of a config snippet for oslo.config to automatically pick up for us and load in.