### PR TITLE
feat: understack trunk

### DIFF
--- a/python/neutron-understack/neutron_understack/tests/test_trunk.py
+++ b/python/neutron-understack/neutron_understack/tests/test_trunk.py
@@ -4,10 +4,9 @@ from unittest.mock import patch
 import pytest
 
 from neutron_understack.nautobot import Nautobot
+from neutron_understack.neutron_understack_mech import UnderstackDriver
 from neutron_understack.trunk import SubportSegmentationIDError
 from neutron_understack.trunk import UnderStackTrunkDriver
-
-trunk_driver = UnderStackTrunkDriver.create("plugin_driver")
 
 
 @pytest.fixture
@@ -33,6 +32,11 @@ def payload(payload_metadata, trunk) -> MagicMock:
 @pytest.fixture
 def nautobot_client() -> Nautobot:
     return MagicMock(spec_set=Nautobot)
+
+
+driver = UnderstackDriver()
+driver.nb = Nautobot("", "")
+trunk_driver = UnderStackTrunkDriver.create(driver)
 
 
 @patch("neutron_understack.utils.fetch_subport_network_id", return_value="112233")

--- a/python/neutron-understack/neutron_understack/tests/test_trunk.py
+++ b/python/neutron-understack/neutron_understack/tests/test_trunk.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from neutron_understack.nautobot import Nautobot
+from neutron_understack.trunk import SubportSegmentationIDError
+from neutron_understack.trunk import UnderStackTrunkDriver
+
+trunk_driver = UnderStackTrunkDriver.create("plugin_driver")
+
+
+@pytest.fixture
+def subport() -> MagicMock:
+    return MagicMock(port_id="portUUID", segmentation_id=555)
+
+
+@pytest.fixture
+def trunk(subport) -> MagicMock:
+    return MagicMock(sub_ports=[subport])
+
+
+@pytest.fixture
+def payload_metadata(subport) -> dict:
+    return {"subports": [subport]}
+
+
+@pytest.fixture
+def payload(payload_metadata, trunk) -> MagicMock:
+    return MagicMock(metadata=payload_metadata, states=[trunk])
+
+
+@pytest.fixture
+def nautobot_client() -> Nautobot:
+    return MagicMock(spec_set=Nautobot)
+
+
+@patch("neutron_understack.utils.fetch_subport_network_id", return_value="112233")
+def test_subports_added_when_ucvni_tenan_vlan_id_is_not_set_yet(
+    nautobot_client, payload
+):
+    trunk_driver.nb = nautobot_client
+    attrs = {"fetch_ucvni_tenant_vlan_id.return_value": None}
+    nautobot_client.configure_mock(**attrs)
+    trunk_driver.subports_added("", "", "", payload)
+
+    nautobot_client.add_tenant_vlan_tag_to_ucvni.assert_called_once_with(
+        network_uuid="112233", vlan_tag=555
+    )
+
+
+@patch("neutron_understack.utils.fetch_subport_network_id", return_value="223344")
+def test_subports_added_when_segmentation_id_is_different_to_tenant_vlan_id(
+    nautobot_client, payload
+):
+    trunk_driver.nb = nautobot_client
+    attrs = {"fetch_ucvni_tenant_vlan_id.return_value": 123}
+    nautobot_client.configure_mock(**attrs)
+    with pytest.raises(SubportSegmentationIDError):
+        trunk_driver.subports_added("", "", "", payload)
+
+
+@patch("neutron_understack.utils.fetch_subport_network_id", return_value="112233")
+def test_trunk_created_when_ucvni_tenan_vlan_id_is_not_set_yet(
+    nautobot_client, payload
+):
+    trunk_driver.nb = nautobot_client
+    attrs = {"fetch_ucvni_tenant_vlan_id.return_value": None}
+    nautobot_client.configure_mock(**attrs)
+    trunk_driver.trunk_created("", "", "", payload)
+
+    nautobot_client.add_tenant_vlan_tag_to_ucvni.assert_called_once_with(
+        network_uuid="112233", vlan_tag=555
+    )
+
+
+@patch("neutron_understack.utils.fetch_subport_network_id", return_value="223344")
+def test_trunk_created_when_segmentation_id_is_different_to_tenant_vlan_id(
+    nautobot_client, payload
+):
+    trunk_driver.nb = nautobot_client
+    attrs = {"fetch_ucvni_tenant_vlan_id.return_value": 123}
+    nautobot_client.configure_mock(**attrs)
+    with pytest.raises(SubportSegmentationIDError):
+        trunk_driver.trunk_created("", "", "", payload)

--- a/python/neutron-understack/neutron_understack/trunk.py
+++ b/python/neutron-understack/neutron_understack/trunk.py
@@ -1,14 +1,56 @@
+from neutron.objects.trunk import SubPort
 from neutron.services.trunk.drivers import base as trunk_base
+from neutron_lib import exceptions as exc
 from neutron_lib.api.definitions import portbindings
+from neutron_lib.callbacks import events
+from neutron_lib.callbacks import registry
+from neutron_lib.callbacks import resources
 from neutron_lib.services.trunk import constants as trunk_consts
 from oslo_config import cfg
+from oslo_log import log
+
+from neutron_understack import config
+from neutron_understack import utils
+from neutron_understack.nautobot import Nautobot
+
+config.register_ml2_understack_opts(cfg.CONF)
+
+LOG = log.getLogger(__name__)
 
 SUPPORTED_INTERFACES = (portbindings.VIF_TYPE_OTHER,)
 
 SUPPORTED_SEGMENTATION_TYPES = (trunk_consts.SEGMENTATION_TYPE_VLAN,)
 
 
+class SubportSegmentationIDError(exc.NeutronException):
+    message = (
+        "Segmentation ID: %(seg_id)s cannot be set to the Subport: "
+        "%(subport_id)s as there is already another Segmentation ID: "
+        "%(nb_seg_id)s in use by the Network: %(net_id)s that is "
+        "attached to the Subport. Please use %(nb_seg_id)s as "
+        "segmentation_id for this subport."
+    )
+
+
 class UnderStackTrunkDriver(trunk_base.DriverBase):
+    def __init__(
+        self,
+        name,
+        interfaces,
+        segmentation_types,
+        agent_type=None,
+        can_trunk_bound_port=False,
+    ):
+        super().__init__(
+            name,
+            interfaces,
+            segmentation_types,
+            agent_type=agent_type,
+            can_trunk_bound_port=can_trunk_bound_port,
+        )
+        conf = cfg.CONF.ml2_understack
+        self.nb = Nautobot(conf.nb_url, conf.nb_token)
+
     @property
     def is_loaded(self):
         try:
@@ -26,3 +68,63 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
             None,
             can_trunk_bound_port=True,
         )
+
+    @registry.receives(resources.TRUNK_PLUGIN, [events.AFTER_INIT])
+    def register(self, resource, event, trigger, payload=None):
+        super().register(resource, event, trigger, payload=payload)
+
+        registry.subscribe(
+            self.subports_added,
+            resources.SUBPORTS,
+            events.AFTER_CREATE,
+            cancellable=True,
+        )
+        registry.subscribe(
+            self.trunk_created, resources.TRUNK, events.AFTER_CREATE, cancellable=True
+        )
+
+    def _configure_tenant_vlan_id(
+        self, tenant_vlan_id: int | None, ucvni_uuid: str, subport: SubPort
+    ) -> None:
+        subport_seg_id = subport.segmentation_id
+        if not tenant_vlan_id:
+            self.nb.add_tenant_vlan_tag_to_ucvni(
+                network_uuid=ucvni_uuid, vlan_tag=subport_seg_id
+            )
+            LOG.info(
+                "Segmentation ID: %(seg_id)s is now set on Nautobot's UCVNI "
+                "UUID: %(ucvni_uuid)s in the tenant_vlan_id custom field",
+                {"seg_id": subport_seg_id, "ucvni_uuid": ucvni_uuid},
+            )
+        elif tenant_vlan_id != subport_seg_id:
+            subport.delete()
+            raise SubportSegmentationIDError(
+                seg_id=subport_seg_id,
+                net_id=ucvni_uuid,
+                nb_seg_id=tenant_vlan_id,
+                subport_id=subport.port_id,
+            )
+
+    def _subports_added(self, subports: list[SubPort]) -> None:
+        for subport in subports:
+            subport_id = subport.port_id
+            subport_network_id = utils.fetch_subport_network_id(subport_id=subport_id)
+            ucvni_tenant_vlan_id = self.nb.fetch_ucvni_tenant_vlan_id(
+                network_id=subport_network_id
+            )
+
+            self._configure_tenant_vlan_id(
+                tenant_vlan_id=ucvni_tenant_vlan_id,
+                ucvni_uuid=subport_network_id,
+                subport=subport,
+            )
+
+    def subports_added(self, resource, event, trunk_plugin, payload):
+        subports = payload.metadata["subports"]
+        self._subports_added(subports)
+
+    def trunk_created(self, resource, event, trunk_plugin, payload):
+        trunk = payload.states[0]
+        subports = trunk.sub_ports
+        if subports:
+            self._subports_added(subports)

--- a/python/neutron-understack/neutron_understack/utils.py
+++ b/python/neutron-understack/neutron_understack/utils.py
@@ -1,0 +1,8 @@
+from neutron.objects import ports as port_obj
+from neutron_lib import context as n_context
+
+
+def fetch_subport_network_id(subport_id):
+    context = n_context.get_admin_context()
+    neutron_port = port_obj.Port.get_object(context, id=subport_id)
+    return neutron_port.network_id


### PR DESCRIPTION
This PR will enable us to set "tenant_vlan_id" on UCVNI in Nautobot when first subport is added to neutron trunk and user specifies the "segmentation_id" when adding the subport. The idea is that we will use the "tenant_vlan_id" as mapped VLAN that is local to the switchport during server provisioning. 
This PR covers only the trunk driver part and there will be another one where we will adjust the understack mechanism driver, so when server will go through provisioning, we will detect the trunk_details on the port attached and do the needful to configure our network.