### PR TITLE
fix: Further updates to Nautobot api response logging

### DIFF
--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -65,6 +65,8 @@ class Nautobot:
             response_data = {"status_code": response.status_code, "body": ""}
 
         if response.status_code >= 300:
+            response_data = response_data.get("error", response_data)
+
             raise NautobotRequestError(
                 code=response.status_code, url=full_url, body=response_data
             )

--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -11,7 +11,7 @@ LOG = log.getLogger(__name__)
 
 
 class NautobotRequestError(exc.NeutronException):
-    message = "Nautobot API returned error %(code)s for %(url)s: %(body)s"
+    message = "Nautobot API ERROR %(code)s for %(url)s %(method)s %(payload)s: %(body)s"
 
 
 class NautobotOSError(exc.NeutronException):
@@ -68,7 +68,11 @@ class Nautobot:
             response_data = response_data.get("error", response_data)
 
             raise NautobotRequestError(
-                code=response.status_code, url=full_url, body=response_data
+                code=response.status_code,
+                url=full_url,
+                method=method,
+                payload=payload,
+                body=response_data,
             )
 
         caller_function = inspect.stack()[1].function

--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -26,6 +26,14 @@ class NautobotCustomFieldNotFoundError(exc.NeutronException):
     message = "Custom field with name %(cf_name)s not found for %(obj)s"
 
 
+def _truncated(message: str | bytes, maxlen=200) -> str:
+    input = str(message)
+    if len(input) <= maxlen:
+        return input
+
+    return f"{input[:maxlen]}...{len(input) - maxlen} more chars"
+
+
 class Nautobot:
     """Basic Nautobot wrapper because pynautobot doesn't expose plugin APIs."""
 
@@ -60,7 +68,8 @@ class Nautobot:
             try:
                 response_data = response.json()
             except requests.exceptions.JSONDecodeError:
-                response_data = {"body": response.content}
+                response_data = {"body": _truncated(response.content)}
+
         else:
             response_data = {"status_code": response.status_code, "body": ""}
 

--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -56,16 +56,18 @@ class Nautobot:
         except Exception as e:
             raise NautobotOSError(err=e) from e
 
+        if response.content:
+            try:
+                response_data = response.json()
+            except requests.exceptions.JSONDecodeError:
+                response_data = {"body": response.content}
+        else:
+            response_data = {"status_code": response.status_code}
+
         if response.status_code >= 300:
             raise NautobotRequestError(
-                code=response.status_code, url=full_url, body=response.content
+                code=response.status_code, url=full_url, body=response_data
             )
-        if not response.content:
-            response_data = {"status_code": response.status_code}
-        try:
-            response_data = response.json()
-        except requests.exceptions.JSONDecodeError:
-            response_data = {"body": response.content}
 
         caller_function = inspect.stack()[1].function
         LOG.debug(

--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -62,7 +62,7 @@ class Nautobot:
             except requests.exceptions.JSONDecodeError:
                 response_data = {"body": response.content}
         else:
-            response_data = {"status_code": response.status_code}
+            response_data = {"status_code": response.status_code, "body": ""}
 
         if response.status_code >= 300:
             raise NautobotRequestError(


### PR DESCRIPTION
Logs more information, but limits the size of any raw payloads we dump out to the logger.

Also extracts the "error" key instead of logging the whole json payload.

```
neutron_understack.nautobot.NautobotRequestError: Nautobot API ERROR 404 for https://nautobot.dev.undercloud.rackspace.net/testing-failures POST {'payload1': 123}: {'body': 'b\'\\n\\n\\n\\n<!DOCTYPE html>\\n<html lang="en">\\n<head>\\n    '
         '<title>Page Not Found - Nautobot</title>\\n    \\n\\n\\n\\n    <link '
         'rel="stylesheet" id="template-theme"\\n          '
         'href="/template.css">\\n    <lin...10971 more chars'}
```