### PR TITLE
fix: finish working around ArgoCD ServerSideApply

### DIFF
--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -222,6 +222,10 @@ spec:
   template:
     metadata:
       name: '{{.name}}-{{.component}}'
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: default
       destination:

--- a/apps/appsets/infra.yaml
+++ b/apps/appsets/infra.yaml
@@ -109,6 +109,8 @@ spec:
       name: '{{.name}}-{{.component}}'
       finalizers:
         - resources-finalizer.argocd.argoproj.io
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: default
       destination:

--- a/apps/appsets/operators.yaml
+++ b/apps/appsets/operators.yaml
@@ -99,6 +99,10 @@ spec:
   template:
     metadata:
       name: '{{.name}}-{{.component}}'
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: operators
       destination:


### PR DESCRIPTION
In e22cccdba9c3557 we made the change only for OpenStack components but this brings it to the rest.

See:
https://argo-cd.readthedocs.io/en/stable/user-guide/diff-strategies/ https://github.com/argoproj/argo-cd/issues/11143