### PR TITLE
chore: Rename Ubuntu 24.04 image

### DIFF
--- a/examples/tf-multi-node-build/variables.tf
+++ b/examples/tf-multi-node-build/variables.tf
@@ -7,7 +7,7 @@ variable "server_count" {
 variable "server_image" {
   description = "The OS image to use for the servers"
   type        = string
-  default     = "Ubuntu-24.04"
+  default     = "Ubuntu 24.04"
 }
 
 variable "server_flavor" {

--- a/examples/tf-multi-node-router/variables.tf
+++ b/examples/tf-multi-node-router/variables.tf
@@ -7,7 +7,7 @@ variable "server_count" {
 variable "server_image" {
   description = "The OS image to use for the servers"
   type        = string
-  default     = "Ubuntu-24.04"
+  default     = "Ubuntu 24.04"
 }
 
 variable "server_flavor" {


### PR DESCRIPTION
Renames the default Ubuntu 24.04 image name to the more common naming convention used by Ubuntu and other cloud providers.