### PR TITLE
feat(neutron): fix config paths for different startup case and drop rpc-server config

### DIFF
--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -95,7 +95,16 @@ pod:
     neutron_server:
       neutron_server:
         volumeMounts:
-          - mountPath: /etc/neutron/neutron-server.conf.d/ml2_understack.conf
+          # oslo.config autoloads certain paths in alphabetical order
+          # which gives us the opportunity to inject secrets and extra
+          # configs here. likely the best paths are:
+          # /etc/${project}/${prog}.conf.d/*.conf
+          # /etc/${project}/${project}.conf.d/*.conf
+          # the first would be best for per service separation but since each
+          # service is in its own pod they won't overlap. further more there
+          # is an issue with that see https://bugs.launchpad.net/oslo.config/+bug/2098514
+          # so we'll use the bottom one
+          - mountPath: /etc/neutron/neutron.conf.d/ml2_understack.conf
             name: neutron-nautobot
             subPath: ml2_understack.conf
             readOnly: true

--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -109,16 +109,6 @@ pod:
           - name: undersync-token
             secret:
               secretName: undersync-token
-    neutron_rpc_server:
-      neutron_rpc_server:
-        volumeMounts:
-          - mountPath: /etc/undersync/
-            name: undersync-token
-            readOnly: true
-        volumes:
-          - name: undersync-token
-            secret:
-              secretName: undersync-token
 # (nicholas.kuechler) updating the jobs list to remove the 'neutron-rabbit-init' job.
 dependencies:
   dynamic:

--- a/docs/deploy-guide/override-openstack-svc-config.md
+++ b/docs/deploy-guide/override-openstack-svc-config.md
@@ -1,0 +1,36 @@
+# Overriding OpenStack Services Config
+
+If you need to override any settings for any of the OpenStack services or add in
+additional configuration snippets, you can do so by defining additional mounts
+in your deploy repo.
+
+For example if you wanted to add the following into neutron-server:
+
+```ini
+[mysection]
+somevalue = 1
+```
+
+Firstly you would create either a `Secret` or a `ConfigMap` and ensure that it is
+being loaded by `${DEPLOY_NAME}/manifest/neutron/kustomize.yaml`
+
+Then you would edit `${DEPLOY_NAME}/helm-configs/neutron.yaml` and add something
+like:
+
+```yaml
+pod:
+  mounts:
+    neutron_server:
+      neutron_server:
+        volumeMounts:
+          - mountPath: /etc/neutron/neutron.conf.d/myfile.conf  # file which will be loaded
+            name: mysection  # volume name from below
+            subPath: myfile.conf  # key in the Secret or ConfigMap from the volume below
+            readOnly: true
+        volumes:
+          - name: mysection # volume name above
+            secret:
+              secretName: mysecret  # name of secret
+```
+
+See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for more details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
     - deploy-guide/extra-regions.md
     - deploy-guide/external-argocd.md
     - deploy-guide/add-remove-app.md
+    - deploy-guide/override-openstack-svc-config.md
   - 'Operator Guide':
     - operator-guide/index.md
     - 'OpenStack':


### PR DESCRIPTION
Due to https://bugs.launchpad.net/oslo.config/+bug/2098514 the path for the config file snippet that was originally used can change and we don't want that. So change paths and document why this is. Added a document explaining how you can provide further extensions for your deployment as well. Dropped the rpc-server section since we've got that disabled always now.