### PR TITLE
feat(horizon): Set default instance launch settings to include config drive

### DIFF
--- a/components/horizon/values.yaml
+++ b/components/horizon/values.yaml
@@ -13,6 +13,24 @@ conf:
         session_cookie_httponly: "True"
         allowed_hosts:
           - '*'
+    local_settings_d:
+      # Set default options when creating a server from the
+      # horizon UI for a more friendly and efficient user experience.
+      # https://docs.openstack.org/horizon/latest/configuration/settings.html#launch-instance-defaults
+      _40_launch_instance_settings: |
+        LAUNCH_INSTANCE_DEFAULTS = {
+            "config_drive": True,
+            "create_volume": False,
+            "hide_create_volume": False,
+            "disable_image": False,
+            "disable_instance_snapshot": False,
+            "disable_volume": False,
+            "disable_volume_snapshot": False,
+            "enable_scheduler_hints": True,
+            "enable_metadata": True,
+            "enable_net_ports": True,
+            "default_availability_zone": "Any",
+        }
 
 endpoints:
   dashboard:


### PR DESCRIPTION
Set config drive option to enabled by default when building a new server in the Horizon dashboard.

<img width="964" alt="Screenshot 2025-02-17 at 11 34 25 AM" src="https://github.com/user-attachments/assets/86845a06-b43a-4087-bf98-85583b5ce322" />
