### PR TITLE
fix(understack-workflows): don't try to set nautobot status if it doesn't exist

### DIFF
--- a/python/understack-workflows/understack_workflows/main/sync_provision_state.py
+++ b/python/understack-workflows/understack_workflows/main/sync_provision_state.py
@@ -41,11 +41,11 @@ def do_action(
         "ironic_provision_state": provision_state,
         "resource_class": resource_class,
     }
-    nautobot.update_cf(
-        device_id=device_uuid, tenant_id=tenant_id, fields=custom_fields_to_update
-    )
 
     if new_status:
+        nautobot.update_cf(
+            device_id=device_uuid, tenant_id=tenant_id, fields=custom_fields_to_update
+        )
         nautobot.update_device_status(device_uuid, new_status)
 
 


### PR DESCRIPTION
The code doesn't have mappings for all the possible ironic states. If we hit an ironic state with no mapping, the result is an exception:
```
 kubectl logs -f ironic-node-update-28fgn
2025-02-19 14:23:54 +0000 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): nautobot-default.nautobot.svc.cluster.local:80
2025-02-19 14:23:54 +0000 - urllib3.connectionpool - DEBUG - http://nautobot-default.nautobot.svc.cluster.local:80 "GET /api/ HTTP/1.1" 200 977
2025-02-19 14:23:55 +0000 - urllib3.connectionpool - DEBUG - http://nautobot-default.nautobot.svc.cluster.local:80 "GET /api/dcim/devices/6cc75fc1-756a-4b19-bbab-fe8e63eee45b/ HTTP/1.1" 200 2243
2025-02-19 14:23:55 +0000 - urllib3.connectionpool - DEBUG - http://nautobot-default.nautobot.svc.cluster.local:80 "PATCH /api/dcim/devices/6cc75fc1-756a-4b19-bbab-fe8e63eee45b/ HTTP/1.1" 400 424
Traceback (most recent call last):
  File "/opt/venv/bin/sync-provision-state", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/main/sync_provision_state.py", line 60, in main
    do_action(
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/main/sync_provision_state.py", line 44, in do_action
    nautobot.update_cf(
  File "/opt/venv/lib/python3.11/site-packages/understack_workflows/nautobot.py", line 76, in update_cf
    response = device.save()
               ^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/pynautobot/core/response.py", line 421, in save
    if req.patch({i: serialized[i] for i in diff}):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/pynautobot/core/query.py", line 433, in patch
    return self._make_call(verb="patch", data=data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/pynautobot/core/query.py", line 294, in _make_call
    raise RequestError(req)
pynautobot.core.query.RequestError: The request failed with code 400 Bad Request: {'__all__': ["Invalid value for custom field 'ironic_provision_state': Invalid choice (clean failed). Available choices are: active, adopting, available, clean wait, cleaning, deleting, deploy failed, deploying, enroll, error, inspect failed, inspect wait, inspecting, manageable, rescue, rescue failed, rescue wait, rescuing, service failed, service wait, servicing, unrescue failed, unrescuing, verifying, wait call-back"]}
time="2025-02-19T14:23:56.116Z" level=info msg="sub-process exited" argo=true error="<nil>"
Error: exit status 1
```

The argo workflow fails and the argo workflow pod which ran this code goes in to Error due to above exception.  The error'd pod then triggers prometheus alerts. And we have to manually clean up the error pods.
