### PR TITLE
feat: modify anaconda deploy interface to support ESXi installs

### DIFF
--- a/apps/appsets/operators.yaml
+++ b/apps/appsets/operators.yaml
@@ -22,7 +22,7 @@ spec:
                   sources:
                     - repoURL: https://charts.rook.io/release
                       chart: rook-ceph
-                      targetRevision: v1.15.0
+                      targetRevision: v1.16.4
                       helm:
                         releaseName: rook-ceph
                         valueFiles:
@@ -31,7 +31,7 @@ spec:
                         ignoreMissingValueFiles: true
                     - repoURL: https://charts.rook.io/release
                       chart: rook-ceph-cluster
-                      targetRevision: v1.15.0
+                      targetRevision: v1.16.4
                       helm:
                         releaseName: rook-ceph-cluster
                         valueFiles:

--- a/components/images-openstack.yaml
+++ b/components/images-openstack.yaml
@@ -23,8 +23,8 @@ images:
     keystone_fernet_setup: "ghcr.io/rackerlabs/understack/keystone:2024.2-ubuntu_jammy"
 
     # ironic
-    ironic_api: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
-    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
+    ironic_api: "ghcr.io/rackerlabs/understack/ironic:pr-706"
+    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:pr-706"
     ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
     ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
     ironic_pxe_http: "docker.io/nginx:1.13.3"

--- a/components/ironic/esxi.ipxe_config.template
+++ b/components/ironic/esxi.ipxe_config.template
@@ -1,0 +1,68 @@
+#!ipxe
+
+set attempts:int32 10
+set i:int32 0
+
+goto deploy
+
+:deploy
+imgfree
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ pxe_options.deployment_aki_path }} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }} BOOTIF=${mac} initrd={{ pxe_options.initrd_filename|default("deploy_ramdisk", true) }} || goto retry
+
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ pxe_options.deployment_ari_path }} || goto retry
+boot
+
+:retry
+iseq ${i} ${attempts} && goto fail ||
+inc i
+echo No response, retrying in ${i} seconds.
+sleep ${i}
+goto deploy
+
+:fail
+echo Failed to get a response after ${attempts} attempts
+echo Powering off in 30 seconds.
+sleep 30
+poweroff
+
+:boot_anaconda
+imgfree
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ pxe_options.aki_path }} -c {{ pxe_options.ari_path|default("deploy_ramdisk", true) }} ignoreHeadless=TRUE ks={{ pxe_options.ks_cfg_url }} ip=${net0/ip} netmask=${net0/netmask} gateway=${net0/gateway} nameserver=${net0/dns} BOOTIF=01-${mac:hexhyp} || goto retry
+boot
+
+:boot_ramdisk
+imgfree
+{%- if pxe_options.boot_iso_url %}
+sanboot {{ pxe_options.boot_iso_url }}
+{%- else %}
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ pxe_options.aki_path }} root=/dev/ram0 text {{ pxe_options.pxe_append_params|default("", true) }} {{ pxe_options.ramdisk_opts|default('', true) }} initrd=ramdisk || goto boot_ramdisk
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ pxe_options.ari_path }} || goto boot_ramdisk
+boot
+{%- endif %}
+
+{%- if pxe_options.boot_from_volume %}
+
+:boot_iscsi
+imgfree
+{% if pxe_options.username %}set username {{ pxe_options.username }}{% endif %}
+{% if pxe_options.password %}set password {{ pxe_options.password }}{% endif %}
+{% if pxe_options.iscsi_initiator_iqn %}set initiator-iqn {{ pxe_options.iscsi_initiator_iqn }}{% endif %}
+sanhook --drive 0x80 {{ pxe_options.iscsi_boot_url }} || goto fail_iscsi_retry
+{%- if pxe_options.iscsi_volumes %}{% for i, volume in enumerate(pxe_options.iscsi_volumes) %}
+set username {{ volume.username }}
+set password {{ volume.password }}
+{%- set drive_id = 129 + i %}
+sanhook --drive {{ '0x%x' % drive_id }} {{ volume.url }} || goto fail_iscsi_retry
+{%- endfor %}{% endif %}
+{% if pxe_options.iscsi_volumes %}set username {{ pxe_options.username }}{% endif %}
+{% if pxe_options.iscsi_volumes %}set password {{ pxe_options.password }}{% endif %}
+sanboot --no-describe || goto fail_iscsi_retry
+
+:fail_iscsi_retry
+echo Failed to attach iSCSI volume(s), retrying in 10 seconds.
+sleep 10
+goto boot_iscsi
+{%- endif %}
+
+:boot_whole_disk
+sanboot --no-describe || exit 0

--- a/components/ironic/kustomization.yaml
+++ b/components/ironic/kustomization.yaml
@@ -10,3 +10,10 @@ resources:
   - dnsmasq-ss.yaml
   - understack-data-pvc.yaml
   - ironic-ks-user-baremetal.yaml
+
+configMapGenerator:
+  - name: ironic-ipxe-template
+    files:
+      - ipxe_config.template=esxi.ipxe_config.template
+    options:
+      disableNameSuffixHash: true

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -72,6 +72,7 @@ conf:
     pxe:
       images_path: /var/lib/understack/master_iso_images
       instance_master_path: /var/lib/understack/master_iso_images
+      ipxe_config_template: /var/lib/extracfg/ipxe_config.template
     inspector:
       extra_kernel_params: ipa-collect-lldp=1
       hooks: "$default_hooks,parse-lldp,local-link-connection,physical-network"
@@ -182,6 +183,9 @@ pod:
             mountPath: /var/lib/dnsmasq/
           - name: understack-data
             mountPath: /var/lib/understack
+          - name: extracfg
+            mountPath: /var/lib/extracfg
+            readOnly: true
         volumes:
           - name: dnsmasq-ironic
             persistentVolumeClaim:
@@ -192,6 +196,16 @@ pod:
           - name: understack-data
             persistentVolumeClaim:
               claimName: understack-data
+          - name: extracfg
+            projected:
+              sources:
+                - configMap:
+                    name: ironic-ipxe-template
+                    items:
+                      - key: ipxe_config.template
+                        path: ipxe_config.template
+
+
   lifecycle:
     disruption_budget:
       api:

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -37,7 +37,7 @@ conf:
       default_deploy_interface: direct
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo
       enabled_boot_interfaces: http-ipxe,ipxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-ipxe
-      enabled_deploy_interfaces: direct,ramdisk
+      enabled_deploy_interfaces: direct,ramdisk,anaconda
       enabled_firmware_interfaces: redfish,no-firmware
       enabled_hardware_types: redfish,idrac,ilo5,ilo
       enabled_inspect_interfaces: redfish,agent,idrac-redfish,ilo

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -52,6 +52,8 @@ conf:
       # service project
       # see: https://review.opendev.org/c/openstack/ironic/+/907148
       rbac_service_role_elevated_access: true
+    anaconda:
+      use_provisioning_network: true
     deploy:
       erase_devices_priority: 0
       erase_devices_metadata_priority: 0

--- a/containers/ironic/Dockerfile.ironic
+++ b/containers/ironic/Dockerfile.ironic
@@ -7,8 +7,16 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         genisoimage \
         isolinux \
+        patch \
+        quilt \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY python/ironic-understack /tmp/ironic-understack
 COPY python/understack-flavor-matcher /tmp/understack-flavor-matcher
 RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack /tmp/understack-flavor-matcher sushy-oem-idrac==6.0.0
+
+# copy in any patches we have
+COPY containers/ironic/patches /tmp/patches
+# change to our installed directory and use quilt to apply patches
+RUN cd $(/var/lib/openstack/bin/python -c "import site; print(site.getsitepackages()[0])") && \
+    QUILT_PATCHES=/tmp/patches quilt push -a

--- a/containers/ironic/patches/0001-fix-glance-metadata-layout.patch
+++ b/containers/ironic/patches/0001-fix-glance-metadata-layout.patch
@@ -1,0 +1,152 @@
+From 74fac79fcf1abdd2aa2145c3b475d5266996f73a Mon Sep 17 00:00:00 2001
+From: Doug Goldstein <cardoe@cardoe.com>
+Date: Sat, 22 Feb 2025 18:34:59 -0600
+Subject: [PATCH 1/3] fix glance metadata layout
+
+The code here builds a dictionary from a glance v2 image object that
+roughly resembles the glance v2 image object. The current behavior
+nests the 'properties' set on the image under it's own 'properties' key
+resulting in the image properties never being seen by the Ironic code.
+The breakage results from the change from glanceclient to the SDK which
+changed the shape of the returned object. The glanceclient object shape
+was that of FakeImage while the SDK returns a Resource based object
+which includes attributes for all possible fields which are defined at
+the top-level of the object. Since the tests run against a different
+value they did not cature the failure. Just changing to the SDK object
+results in us copying all these new values to the properties dict which
+is definitely not the intention. For maximum compatibility to backport
+this filters any value not set from being set into properties and sets
+the rest. The broken path is any user of get_image_properties()
+(both copies from common/images and deploy_utils) checking for user
+supplied properties.
+
+Closes-Bug: 2099953
+Change-Id: I1842e2651fd2bd8455646db9a3a80c3b9ece5c97
+Signed-off-by: Doug Goldstein <cardoe@cardoe.com>
+---
+ ironic/common/glance_service/service_utils.py | 18 ++++++++++---
+ .../tests/unit/common/test_glance_service.py  |  6 +++--
+ ironic/tests/unit/stubs.py                    | 27 -------------------
+ ...age-properties-check-2a11337c9e517a5c.yaml | 13 +++++++++
+ 4 files changed, 32 insertions(+), 32 deletions(-)
+ create mode 100644 releasenotes/notes/bug-2099275-glance-image-properties-check-2a11337c9e517a5c.yaml
+
+diff --git a/ironic/common/glance_service/service_utils.py b/ironic/common/glance_service/service_utils.py
+index 20cc21ffa..315395d97 100644
+--- a/ironic/common/glance_service/service_utils.py
++++ b/ironic/common/glance_service/service_utils.py
+@@ -34,14 +34,26 @@ _IMAGE_ATTRIBUTES = ['size', 'disk_format', 'owner',
+ 
+ def _extract_attributes(image):
+     output = {}
++    # copies attributes from the openstacksdk Image object
++    # to a dictionary
+     for attr in _IMAGE_ATTRIBUTES:
+         output[attr] = getattr(image, attr, None)
+ 
+-    output['properties'] = {}
++    # copy the properties over to start so that image properties
++    # are not nested in another properties key
++    output['properties'] = getattr(image, 'properties', {})
+     output['schema'] = image.schema
+ 
+-    for image_property in set(image) - set(_IMAGE_ATTRIBUTES):
+-        output['properties'][image_property] = image[image_property]
++    # attributes already copied so we copy the rest into properties
++    copied = set(_IMAGE_ATTRIBUTES)
++    copied.add('properties')
++
++    for image_property in set(image) - copied:
++        # previously with glanceclient only set things
++        # were on the object that came back but the SDK
++        # defines every possible attribute so we need to filter
++        if image[image_property]:
++            output['properties'][image_property] = image[image_property]
+ 
+     return output
+ 
+diff --git a/ironic/tests/unit/common/test_glance_service.py b/ironic/tests/unit/common/test_glance_service.py
+index e02156ae1..f997dea64 100644
+--- a/ironic/tests/unit/common/test_glance_service.py
++++ b/ironic/tests/unit/common/test_glance_service.py
+@@ -100,9 +100,11 @@ class TestGlanceImageService(base.TestCase):
+     @staticmethod
+     def _make_fixture(**kwargs):
+         fixture = {'name': None,
++                   'owner': None,
++                   'properties': {},
+                    'status': "active"}
+         fixture.update(kwargs)
+-        return stubs.FakeImage(fixture)
++        return openstack.image.v2.image.Image.new(**fixture)
+ 
+     @property
+     def endpoint(self):
+@@ -142,7 +144,7 @@ class TestGlanceImageService(base.TestCase):
+             'schema': None,
+             'size': None,
+             'status': "active",
+-            'tags': None,
++            'tags': [],
+             'updated_at': None,
+             'visibility': None,
+             'os_hash_algo': None,
+diff --git a/ironic/tests/unit/stubs.py b/ironic/tests/unit/stubs.py
+index 6927f38d2..a73c2ab37 100644
+--- a/ironic/tests/unit/stubs.py
++++ b/ironic/tests/unit/stubs.py
+@@ -51,33 +51,6 @@ class FakeImageDownload(object):
+         self.content = content
+ 
+ 
+-class FakeImage(dict):
+-    def __init__(self, metadata):
+-        IMAGE_ATTRIBUTES = ['size', 'disk_format', 'owner',
+-                            'container_format', 'checksum', 'id',
+-                            'name', 'deleted', 'status',
+-                            'min_disk', 'min_ram', 'tags', 'visibility',
+-                            'protected', 'file', 'schema', 'os_hash_algo',
+-                            'os_hash_value']
+-        raw = dict.fromkeys(IMAGE_ATTRIBUTES)
+-        raw.update(metadata)
+-        # raw['created_at'] = NOW_GLANCE_FORMAT
+-        # raw['updated_at'] = NOW_GLANCE_FORMAT
+-        super(FakeImage, self).__init__(raw)
+-
+-    def __getattr__(self, key):
+-        try:
+-            return self[key]
+-        except KeyError:
+-            raise AttributeError(key)
+-
+-    def __setattr__(self, key, value):
+-        if key in self:
+-            self[key] = value
+-        else:
+-            raise AttributeError(key)
+-
+-
+ class FakeNeutronPort(dict):
+     def __init__(self, **attrs):
+         PORT_ATTRS = ['admin_state_up',
+diff --git a/releasenotes/notes/bug-2099275-glance-image-properties-check-2a11337c9e517a5c.yaml b/releasenotes/notes/bug-2099275-glance-image-properties-check-2a11337c9e517a5c.yaml
+new file mode 100644
+index 000000000..ed1be77d1
+--- /dev/null
++++ b/releasenotes/notes/bug-2099275-glance-image-properties-check-2a11337c9e517a5c.yaml
+@@ -0,0 +1,13 @@
++---
++fixes:
++  - |
++    validate_image_properties() was unable to read the properties set on a
++    Glance  image due to an issue where the properties loaded being nested
++    under another properties key. This resulted in the Anaconda deploy
++    interface being unable to use Glance images due to the requirement of
++    the stage2_id field. Even when passing this the field would not be
++    read correctly. For other deploy interfaces the value for kernel and
++    ramdisk ended up coming from deploy_info instead of the image properties.
++    This fixes the data to come from image properties as is documented.
++    See `bug 2099275 <https://bugs.launchpad.net/ironic/+bug/2099953>`_ for
++    more details.
+-- 
+2.39.5 (Apple Git-154)

--- a/containers/ironic/patches/0002-deploy-allow-anaconda-to-use-the-provisioning-networ.patch
+++ b/containers/ironic/patches/0002-deploy-allow-anaconda-to-use-the-provisioning-networ.patch
@@ -1,0 +1,70 @@
+From 01982628cf83f2668961470f2cc249c421b3c108 Mon Sep 17 00:00:00 2001
+From: Doug Goldstein <cardoe@cardoe.com>
+Date: Fri, 21 Feb 2025 16:01:08 -0600
+Subject: [PATCH 2/3] deploy: allow anaconda to use the provisioning network
+
+Allow the anaconda deploy interface to use the provisioning network to
+deploy itself.
+<longer commit message to come>
+
+Change-Id: I4dea2855889d7699f09b545b341054e0fe1470f8
+---
+ ironic/conf/anaconda.py       |  9 +++++++++
+ ironic/drivers/modules/pxe.py | 15 +++++++++++++--
+ 2 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/ironic/conf/anaconda.py b/ironic/conf/anaconda.py
+index f478e49fe..c4144ab19 100644
+--- a/ironic/conf/anaconda.py
++++ b/ironic/conf/anaconda.py
+@@ -39,6 +39,15 @@ opts = [
+                        'heartbeat operations, depending on the contents of '
+                        'the utilized kickstart template, may not enforce TLS '
+                        'certificate verification.')),
++    cfg.BoolOpt('use_provisioning_network',
++                default=False,
++                help=_('Controls if the deployment will happen when connected '
++                       'to the provisioning network or to the tenant network '
++                       '(default). To use the provisioning network you must '
++                       'callback using the heartbeat_url and agent_token with '
++                       'status during your build to let Ironic know when the '
++                       'installation is done to switch it back to the tenant '
++                       'network.')),
+ ]
+ 
+ 
+diff --git a/ironic/drivers/modules/pxe.py b/ironic/drivers/modules/pxe.py
+index c3ea7093e..8a64e5296 100644
+--- a/ironic/drivers/modules/pxe.py
++++ b/ironic/drivers/modules/pxe.py
+@@ -70,8 +70,12 @@ class PXEAnacondaDeploy(agent_base.AgentBaseMixin, agent_base.HeartbeatMixin,
+     @task_manager.require_exclusive_lock
+     def deploy(self, task):
+         manager_utils.node_power_action(task, states.POWER_OFF)
+-        with manager_utils.power_state_for_network_configuration(task):
+-            task.driver.network.configure_tenant_networks(task)
++
++        # if the user is not using the provisioning network
++        # then setup the tenant network
++        if not CONF.anaconda.use_provisioning_network:
++            with manager_utils.power_state_for_network_configuration(task):
++                task.driver.network.configure_tenant_networks(task)
+ 
+         # calling boot.prepare_instance will also set the node
+         # to PXE boot, and update PXE templates accordingly
+@@ -97,6 +101,13 @@ class PXEAnacondaDeploy(agent_base.AgentBaseMixin, agent_base.HeartbeatMixin,
+             # NOTE(TheJulia): If this was any other interface, we would
+             # unconfigure tenant networks, add provisioning networks, etc.
+             task.driver.storage.attach_volumes(task)
++
++            # if the user has requested to use the provisioning network,
++            # set it up
++            if CONF.anaconda.use_provisioning_network:
++                task.driver.network.unconfigure_tenant_networks(task)
++                task.driver.network.add_provisioning_network(task)
++
+             node.instance_info = deploy_utils.build_instance_info_for_deploy(
+                 task)
+             node.save()
+-- 
+2.39.5 (Apple Git-154)

--- a/containers/ironic/patches/0003-anaconda-more-flexible-config_drive-in-kickstart.patch
+++ b/containers/ironic/patches/0003-anaconda-more-flexible-config_drive-in-kickstart.patch
@@ -1,0 +1,218 @@
+From e0b1f8b44963f1c8528970250991b89b385ce6b3 Mon Sep 17 00:00:00 2001
+From: Doug Goldstein <cardoe@cardoe.com>
+Date: Wed, 26 Feb 2025 12:29:18 -0600
+Subject: [PATCH 3/3] anaconda: more flexible config_drive in kickstart
+
+Provide a more flexible consumption of the config_drive data inside of
+kickstart. The existing templated variable hardcoded paths and binaries
+and operations. Some versions of kickstart don't support the %end tag as
+well (VMware's installer). Removed any hardcoded path in the generation
+of the data and shifted that to the kickstart template, which gives the
+user more flexibility to support more distros and kickstart versions.
+Updated the kickstart template file to use the new v2 format while
+behaving identical to the original version.
+
+Change-Id: I42e499437c92b09cc37983ee4a1d6d98f68dde6e
+Co-Authored-by: Marek Skrobacki <skrobul@skrobul.com>
+Signed-off-by: Doug Goldstein <cardoe@cardoe.com>
+---
+ .../admin/anaconda-deploy-interface.rst       | 31 ++++++++++++++++
+ ironic/common/kickstart_utils.py              | 36 +++++++++++++++----
+ ironic/common/pxe_utils.py                    |  8 ++++-
+ ironic/drivers/modules/ks.cfg.template        | 13 ++++++-
+ .../tests/unit/common/test_kickstart_utils.py | 31 +++++++++++++++-
+ ...nfig-drive-kickstart-d3edd17b745db314.yaml | 11 ++++++
+ 6 files changed, 120 insertions(+), 10 deletions(-)
+ create mode 100644 releasenotes/notes/anaconda-config-drive-kickstart-d3edd17b745db314.yaml
+
+diff --git a/ironic/common/kickstart_utils.py b/ironic/common/kickstart_utils.py
+index 4e02e2ea7..4a7533d54 100644
+--- a/ironic/common/kickstart_utils.py
++++ b/ironic/common/kickstart_utils.py
+@@ -28,15 +28,11 @@ from ironic.conf import CONF
+ LOG = logging.getLogger(__name__)
+
+
+-def _get_config_drive_dict_from_iso(
+-        iso_reader, drive_dict,
+-        target_path='/var/lib/cloud/seed/config_drive'):
++def _get_config_drive_dict_from_iso(iso_reader, drive_dict):
+     """Traverse the config drive iso and extract content and filenames
+
+     :param iso_reader: pycdlib.PyCdlib object representing ISO files.
+     :param drive_dict: Mutable dictionary to store path and contents.
+-    :param target_path: Path on the local disk in which the files in config
+-                        drive files has to be written.
+     """
+     for path, dirlist, filelist in iso_reader.walk(iso_path='/'):
+         for f in filelist:
+@@ -50,14 +46,13 @@ def _get_config_drive_dict_from_iso(
+             # Path to which the file in config drive to be written on the
+             # server.
+             posix_file_path = posix_file_path.lstrip('/')
+-            target_file_path = os.path.join(target_path, posix_file_path)
+             b_buf = io.BytesIO()
+             iso_reader.get_file_from_iso_fp(
+                 iso_path=iso_file_path, outfp=b_buf
+             )
+             b_buf.seek(0)
+             content = b"".join(b_buf.readlines()).decode('utf-8')
+-            drive_dict[target_file_path] = content
++            drive_dict[posix_file_path] = content
+
+
+ def read_iso9600_config_drive(config_drive):
+@@ -169,3 +164,30 @@ def prepare_config_drive(task,
+         )
+
+     return ks_config_drive
++
++
++def prepare_config_drive_v2(task):
++    """Prepare config_drive for writing to kickstart file"""
++    LOG.debug("Preparing config_drive (v2) to write to kickstart file")
++    node = task.node
++    config_drive = node.instance_info.get('configdrive')
++    if not config_drive:
++        return {}
++
++    if ironic_utils.is_http_url(config_drive):
++        config_drive = _fetch_config_drive_from_url(config_drive)
++
++    if not isinstance(config_drive, dict):
++        # The config drive is in iso6600 format, gzipped and base-64-encoded.
++        # Convert it to a dict.
++        config_drive_iso = decode_and_extract_config_drive_iso(config_drive)
++        config_drive = read_iso9600_config_drive(config_drive_iso)
++
++    # dictionary comprehension to create a dictionary with the
++    # filename as the key and the base64 encoded content as the
++    # value to allow the kickstart template to consume this in
++    # a more flexible fashion
++    return {
++        key: base64.b64encode(str.encode(data)).decode('ascii')
++        for key, data in config_drive.items()
++    }
+diff --git a/ironic/common/pxe_utils.py b/ironic/common/pxe_utils.py
+index c49607648..3b61f3f8c 100644
+--- a/ironic/common/pxe_utils.py
++++ b/ironic/common/pxe_utils.py
+@@ -1071,6 +1071,7 @@ def build_kickstart_config_options(task):
+     )
+     params['heartbeat_url'] = heartbeat_url
+     params['config_drive'] = ks_utils.prepare_config_drive(task)
++    params['config_drive_v2'] = ks_utils.prepare_config_drive_v2(task)
+     return {'ks_options': params}
+
+
+@@ -1159,6 +1160,7 @@ def validate_kickstart_template(ks_template):
+     ks_options = {'liveimg_url': 'fake_image_url',
+                   'agent_token': 'fake_token',
+                   'config_drive': '',
++                  'config_drive_v2': {},
+                   'heartbeat_url': 'fake_heartbeat_url'}
+     params = {'ks_options': ks_options}
+     try:
+@@ -1173,7 +1175,11 @@ def validate_kickstart_template(ks_template):
+
+     missing_required_options = []
+     for var, value in ks_options.items():
+-        if rendered_tmpl.find(value) == -1:
++        # this just searches the rendered template to see if the 'fake'
++        # data above did not appear in the template. this can only be
++        # done for string types and if they aren't empty
++        if (isinstance(value, str) and value
++            and (rendered_tmpl.find(value) == -1)):
+             missing_required_options.append(var)
+     if missing_required_options:
+         msg = (_("Following required kickstart option variables are missing "
+diff --git a/ironic/drivers/modules/ks.cfg.template b/ironic/drivers/modules/ks.cfg.template
+index 93788fdb8..4cb958360 100644
+--- a/ironic/drivers/modules/ks.cfg.template
++++ b/ironic/drivers/modules/ks.cfg.template
+@@ -44,7 +44,18 @@ liveimg --url {{ ks_options.liveimg_url }}
+ %end
+
+ # Config-drive information, if any.
+-{{ ks_options.config_drive }}
++{% if ks_options.config_drive_v2 %}
++{% for k, v in ks_options.config_drive_v2.items() %}
++%post
++DIRPATH=`/user/bin/dirname {{ k }}`
++mkdir -p /var/lib/cloud/seed/config_drive/{{ k }}
++CONTENT='{{ v }}'
++echo $CONTENT | /usr/bin/base64 --decode > /var/lib/cloud/seed/config_drive/{{ k }}
++/bin/chmod 600 /var/lib/cloud/seed/config_drive/{{ k }}
++%end
++
++{% endfor %}
++{% endif %}
+
+ # Sending callback after the installation is mandatory.
+ # This ought to be the last thing done; otherwise the
+diff --git a/ironic/tests/unit/common/test_kickstart_utils.py b/ironic/tests/unit/common/test_kickstart_utils.py
+index 52ea0324d..fa2b46de6 100644
+--- a/ironic/tests/unit/common/test_kickstart_utils.py
++++ b/ironic/tests/unit/common/test_kickstart_utils.py
+@@ -78,8 +78,13 @@ echo $CONTENT | /usr/bin/base64 --decode > {file_path}\n\
+             )
+         return config_drive_ks
+
+-    def test_prepare_config_drive(self):
++    def _get_expected_ks_config_drive_v2(self, config_drive_dict):
++        return {
++            key: base64.b64encode(str.encode(data)).decode('ascii')
++            for key, data in config_drive_dict.items()
++        }
+
++    def test_prepare_config_drive(self):
+         expected = self._get_expected_ks_config_drive(self.config_drive_dict)
+         with task_manager.acquire(self.context, self.node.uuid) as task:
+             i_info = task.node.instance_info
+@@ -100,3 +105,27 @@ echo $CONTENT | /usr/bin/base64 --decode > {file_path}\n\
+             self.assertEqual(expected, ks_utils.prepare_config_drive(task))
+             mock_get.assert_called_with('http://server/fake-configdrive-url',
+                                         timeout=60)
++
++    def test_prepare_config_drive_v2(self):
++        expected = self._get_expected_ks_config_drive_v2(
++            self.config_drive_dict)
++        with task_manager.acquire(self.context, self.node.uuid) as task:
++            i_info = task.node.instance_info
++            i_info['configdrive'] = CONFIG_DRIVE
++            task.node.instance_info = i_info
++            task.node.save()
++            self.assertEqual(expected, ks_utils.prepare_config_drive_v2(task))
++
++    @mock.patch('requests.get', autospec=True)
++    def test_prepare_config_drive_v2_in_swift(self, mock_get):
++        expected = self._get_expected_ks_config_drive_v2(
++            self.config_drive_dict)
++        mock_get.return_value = mock.MagicMock(content=CONFIG_DRIVE)
++        with task_manager.acquire(self.context, self.node.uuid) as task:
++            i_info = task.node.instance_info
++            i_info['configdrive'] = 'http://server/fake-configdrive-url'
++            task.node.instance_info = i_info
++            task.node.save()
++            self.assertEqual(expected, ks_utils.prepare_config_drive_v2(task))
++            mock_get.assert_called_with('http://server/fake-configdrive-url',
++                                        timeout=60)
+diff --git a/releasenotes/notes/anaconda-config-drive-kickstart-d3edd17b745db314.yaml b/releasenotes/notes/anaconda-config-drive-kickstart-d3edd17b745db314.yaml
+new file mode 100644
+index 000000000..51000e869
+--- /dev/null
++++ b/releasenotes/notes/anaconda-config-drive-kickstart-d3edd17b745db314.yaml
+@@ -0,0 +1,11 @@
++---
++features:
++  - |
++    Updated the kickstart template variables to include ``config_drive_v2``
++    which is a dictionary of data. The keys are the relative path of the
++    file while the value for those keys are the base64 encoded content. This
++    supersedes the ``config_drive`` kickstart template variable which included
++    the same data but with hardcoded paths and kickstart variables. This allows
++    users of the kickstart template to have more control over the config drive
++    data in their kickstart template. The default kickstart template has been
++    updated to utilize this new format.
+--
+2.39.5 (Apple Git-154)

--- a/containers/ironic/patches/series
+++ b/containers/ironic/patches/series
@@ -1,1 +1,2 @@
 0001-fix-glance-metadata-layout.patch
+0002-deploy-allow-anaconda-to-use-the-provisioning-networ.patch

--- a/containers/ironic/patches/series
+++ b/containers/ironic/patches/series
@@ -1,0 +1,1 @@
+0001-fix-glance-metadata-layout.patch

--- a/containers/ironic/patches/series
+++ b/containers/ironic/patches/series
@@ -1,2 +1,3 @@
 0001-fix-glance-metadata-layout.patch
 0002-deploy-allow-anaconda-to-use-the-provisioning-networ.patch
+0003-anaconda-more-flexible-config_drive-in-kickstart.patch

--- a/operators/rook/values-cluster.yaml
+++ b/operators/rook/values-cluster.yaml
@@ -72,29 +72,6 @@ cephBlockPools:
         # see  https://docs.ceph.com/en/latest/rbd/rbd-config-ref/ for things supported
         # in particular kernel version
         imageFeatures: layering
-  - name: ceph-block-unreplicated
-    spec:
-      failureDomain: host
-      replicated:
-        size: 1
-    storageClass:
-      enabled: true
-      name: ceph-block-unreplicated
-      isDefault: false
-      reclaimPolicy: Retain
-      allowVolumeExpansion: true
-      volumeBindingMode: "Immediate"
-      mountOptions: []
-      # see https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies
-      allowedTopologies: []
-      parameters:
-        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-        csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-        imageFeatures: layering
 
 # -- A list of CephFileSystem configurations to deploy
 # @default -- See [below](#ceph-file-systems)


### PR DESCRIPTION
This modifies Ironic so that we can utilize the anaconda deploy interface to install VMware ESXi. The changes are 3 patches, all of which have been submitted upstream:
- https://review.opendev.org/c/openstack/ironic/+/942496 to fix Ironic's handling of Glance image properties since switching to the OpenStackSDK from the glanceclient
- https://review.opendev.org/c/openstack/ironic/+/942590 to allow the anaconda deploy interface to use the provisioning network
- https://review.opendev.org/c/openstack/ironic/+/942849 to change how the config drive data is passed along so we can handle it within VMware's kickstart syntax

Lastly we ship a changed ipxe_config.template with iPXE kernel and module arguments and parameters which line up with what ESXi's multiboot loader needs.

This still requires you to craft a correct kickstart template, modify boot.cfg appropriately, and host the ESXi CD contents somewhere accessible.