### PR TITLE
fix: renovate: disable devbox package manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,5 +25,8 @@
       ],
       "datasourceTemplate": "helm"
     }
-  ]
+  ],
+  "devbox": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
This disables recently added renovate package manager. We generally don't want to have this automatically updated because whole point of creating an isolated dev environment is to have the ability to pin specific versions of the dependencies without affecting anyone else.


ref: 
https://github.com/renovatebot/renovate/issues/27543
https://github.com/jetify-com/devbox/pull/2508