### PR TITLE
feat: allow Ironic patches and enable anaconda deploy interface

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -37,7 +37,7 @@ conf:
       default_deploy_interface: direct
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo
       enabled_boot_interfaces: http-ipxe,ipxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-ipxe
-      enabled_deploy_interfaces: direct,ramdisk
+      enabled_deploy_interfaces: direct,ramdisk,anaconda
       enabled_firmware_interfaces: redfish,no-firmware
       enabled_hardware_types: redfish,idrac,ilo5,ilo
       enabled_inspect_interfaces: redfish,agent,idrac-redfish,ilo

--- a/containers/ironic/Dockerfile.ironic
+++ b/containers/ironic/Dockerfile.ironic
@@ -7,8 +7,16 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         genisoimage \
         isolinux \
+        patch \
+        quilt \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY python/ironic-understack /tmp/ironic-understack
 COPY python/understack-flavor-matcher /tmp/understack-flavor-matcher
 RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack /tmp/understack-flavor-matcher sushy-oem-idrac==6.0.0
+
+# copy in any patches we have
+COPY containers/ironic/patches /tmp/patches
+# change to our installed directory and use quilt to apply patches
+RUN cd $(/var/lib/openstack/bin/python -c "import site; print(site.getsitepackages()[0])") && \
+    [ -s /tmp/patches/series ] && QUILT_PATCHES=/tmp/patches quilt push -a

--- a/containers/nova/Dockerfile.nova
+++ b/containers/nova/Dockerfile.nova
@@ -9,6 +9,8 @@ RUN apt-get update && \
         quilt \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY containers/nova/patches /tmp/patches/
-RUN cd /var/lib/openstack/lib/python3.10/site-packages && \
-    QUILT_PATCHES=/tmp/patches quilt push -a
+# copy in any patches we have
+COPY containers/ironic/patches /tmp/patches
+# change to our installed directory and use quilt to apply patches
+RUN cd $(/var/lib/openstack/bin/python -c "import site; print(site.getsitepackages()[0])") && \
+    [ -s /tmp/patches/series ] && QUILT_PATCHES=/tmp/patches quilt push -a


### PR DESCRIPTION
This allows for us to build the Ironic container with our own patches and enables the anaconda deploy interface for Ironic. This is the building blocks of getting VMware ESXi supported into the kick process.