### PR TITLE
fix: Revert "feat: Only create SVIs for Prefixes of service_type "network:understack_svi""

### DIFF
--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -138,11 +138,10 @@ class UnderstackDriver(MechanismDriver):
            Don't have an SVI, which means we don't associate them with a VNI in
            nautobot.
         """
-        subnet_uuid: str = context.current["id"]
-        network_uuid: str = context.current["network_id"]
-        prefix: str = context.current["cidr"]
-        external: bool = context.current["router:external"]
-        service_types: list[str] = context.current["service_types"]
+        subnet_uuid = context.current["id"]
+        network_uuid = context.current["network_id"]
+        prefix = context.current["cidr"]
+        external = context.current["router:external"]
 
         if external:
             namespace = cfg.CONF.ml2_understack.shared_nautobot_namespace_name
@@ -155,7 +154,7 @@ class UnderstackDriver(MechanismDriver):
             namespace_name=namespace,
         )
 
-        if external and "network:understack_svi" in service_types:
+        if external:
             self.nb.associate_subnet_with_network(
                 role="svi_vxlan_anycast_gateway",
                 network_uuid=network_uuid,

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -170,7 +170,6 @@ def test_create_subnet_postcommit_private(nautobot_client):
             "network_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
             "cidr": "1.0.0.0/24",
             "router:external": False,
-            "service_types": [],
         }
     )
 
@@ -184,14 +183,13 @@ def test_create_subnet_postcommit_private(nautobot_client):
     )
 
 
-def test_create_subnet_postcommit_public_svi(nautobot_client, undersync_client):
+def test_create_subnet_postcommit_public(nautobot_client, undersync_client):
     context = MagicMock(
         current={
             "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             "network_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
             "cidr": "1.0.0.0/24",
             "router:external": True,
-            "service_types": ["network:understack_svi"],
         }
     )
 
@@ -205,27 +203,6 @@ def test_create_subnet_postcommit_public_svi(nautobot_client, undersync_client):
         prefix="1.0.0.0/24",
         namespace_name="Global",
     )
-    nautobot_client.associate_subnet_with_network.assert_called_once()
-
-
-def test_create_subnet_postcommit_public_non_svi(nautobot_client, undersync_client):
-    context = MagicMock(
-        current={
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "network_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-            "cidr": "1.0.0.0/24",
-            "router:external": True,
-            "service_types": ["not_an_svi_type"],
-        }
-    )
-
-    driver.nb = nautobot_client
-    driver.undersync = undersync_client
-
-    driver.create_subnet_postcommit(context)
-
-    nautobot_client.subnet_create.assert_called_once()
-    nautobot_client.associate_subnet_with_network.assert_not_called()
 
 
 def test_delete_subnet_postcommit_public(nautobot_client, undersync_client):


### PR DESCRIPTION
Reverts rackerlabs/understack#721 because we cannot build servers on a Subnet that has a service_type set:

    neutronclient.common.exceptions.Conflict: No valid service subnet for the given device owner, network 1499b961-2f5a-494a-b35a-bad9d727b74f, service type .

The [docs](https://docs.openstack.org/neutron/latest/admin/config-service-subnets.html) say that  the service type should be "matching the port device owner" which suggests to me that maybe we should not be using that field at all for this purpose, since we don't control the port device owner?