### PR TITLE
fix: Create second rbac policy on OUTSIDE network to permit "shared" access

### DIFF
--- a/python/understack-workflows/understack_workflows/main/sync_keystone.py
+++ b/python/understack-workflows/understack_workflows/main/sync_keystone.py
@@ -96,6 +96,12 @@ def _create_outside_network(conn: Connection, project_id: uuid.UUID):
             action="access_as_external",
             target_project_id=project_id.hex,
         )
+        conn.network.create_rbac_policy(  # type: ignore
+            object_type="network",
+            object_id=network.id,
+            action="access_as_shared",
+            target_project_id=project_id.hex,
+        )
 
 
 def _delete_outside_network(conn: Connection, project_id: uuid.UUID):


### PR DESCRIPTION
Without this "shared" rule, the instance failed to build with:

nova.exception.ExternalNetworkAttachForbidden: It is not allowed to create an interface on external network <uuid>

We make the network shared, but only to this single project, so it remains invisible to other tenants.