### PR TITLE
feat(neutron): set some neutron defaults

### DIFF
--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -48,6 +48,11 @@ conf:
   plugins:
     ml2_conf:
       ml2:
+        # at this time due to physical switches not doing OpenFlow and enabling
+        # port security rules being different per model (or supported at all)
+        # disable it by default. this is necessary because openstack-helm enables
+        # it by default
+        extension_drivers: ''
         # set the default ml2 backend to our plugin, neutron_understack
         # we'll need to use the ovn ML2 plugin to hook the routers to our network
         mechanism_drivers: "understack,ovn"
@@ -75,6 +80,8 @@ conf:
       # we aren't using availability zones so having calls attempt to add things to
       # availability zones won't work.
       default_availability_zones: ""
+      # add 50 to the max MTU we want of 9000 to handle Neutron's -50 for VXLAN type
+      global_physnet_mtu: 9050
     service_providers:
       service_provider: "L3_ROUTER_NAT:cisco-asa:neutron_understack.l3_service_cisco_asa.CiscoAsa"
     ovn:

--- a/docs/component-networking-neutron.md
+++ b/docs/component-networking-neutron.md
@@ -1,0 +1,25 @@
+# Neutron
+
+OpenStack Neutron is used for the user facing API for networks. While
+much of the focus of Neutron is around virtual networks on top of
+physical networks for delivering cloud services. However controlling
+physical networks is supported and utilized by OpenStack Ironic for
+example with the [networking-generic-switch][ngs] ML2 mechanism.
+
+Given our focus on physical networks with physical switches, there
+are some features we are disabling by default that can be enabled
+in your specific deploy configs.
+
+MTU override
+:  Bare metal switch networks support using up to 9000 MTU. Neutron assumes
+   a 50 byte overhead with the VXLAN type for encapsulation so we need to
+   specify what the physical MTU is with the encapsulation overhead.
+: `global_physnet_mtu = 9050`
+
+Security Groups
+: Our focus is on bare metal switches and not OpenFlow based OVS so these
+  switches implement this differently or not at all. Disable this to not
+  have confusiona until we can enable it generically.
+: `extension_drivers` lacking `port_security`
+
+[ngs]: <https://opendev.org/openstack/networking-generic-switch>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,8 @@ nav:
       - networking.md
     - Components:
       - component-overview.md
+      - Networking:
+        - component-networking-neutron.md
       - component-argo-workflows.md
       - component-understack-workflows.md
   - 'Deployment Guide':


### PR DESCRIPTION
We're working with bare metal switches and not OpenFlow in OVS so we don't have the ability right now to use security groups universally without specific switch support. We're also wanting a maximum of 9000 MTU advertised so we need to set it to 9050 to account for Neutron's VXLAN math.