### PR TITLE
chore: Rook upgrade to 16.4

### DIFF
--- a/apps/appsets/operators.yaml
+++ b/apps/appsets/operators.yaml
@@ -22,7 +22,7 @@ spec:
                   sources:
                     - repoURL: https://charts.rook.io/release
                       chart: rook-ceph
-                      targetRevision: v1.15.0
+                      targetRevision: v1.16.4
                       helm:
                         releaseName: rook-ceph
                         valueFiles:
@@ -31,7 +31,7 @@ spec:
                         ignoreMissingValueFiles: true
                     - repoURL: https://charts.rook.io/release
                       chart: rook-ceph-cluster
-                      targetRevision: v1.15.0
+                      targetRevision: v1.16.4
                       helm:
                         releaseName: rook-ceph-cluster
                         valueFiles:

--- a/operators/rook/values-cluster.yaml
+++ b/operators/rook/values-cluster.yaml
@@ -72,29 +72,6 @@ cephBlockPools:
         # see  https://docs.ceph.com/en/latest/rbd/rbd-config-ref/ for things supported
         # in particular kernel version
         imageFeatures: layering
-  - name: ceph-block-unreplicated
-    spec:
-      failureDomain: host
-      replicated:
-        size: 1
-    storageClass:
-      enabled: true
-      name: ceph-block-unreplicated
-      isDefault: false
-      reclaimPolicy: Retain
-      allowVolumeExpansion: true
-      volumeBindingMode: "Immediate"
-      mountOptions: []
-      # see https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies
-      allowedTopologies: []
-      parameters:
-        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-        csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-        imageFeatures: layering
 
 # -- A list of CephFileSystem configurations to deploy
 # @default -- See [below](#ceph-file-systems)


### PR DESCRIPTION
This fixes https://github.com/rook/rook/issues/13904 which is needed for @haseebsyed12's [work on PUC-523](https://github.com/rackerlabs/understack/tree/puc-523_glance-ceph-radosgw-backend).

Bravo cluster has been updated to 16.4 now.