### PR TITLE
fix: adds 'bsdextrautils' package to IPA image for hexdump command

### DIFF
--- a/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
+++ b/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
@@ -3,3 +3,4 @@ inetutils-telnet:
 mtr-tiny:
 tcpdump:
 bind9-dnsutils:
+bsdextrautils:


### PR DESCRIPTION
https://manpages.debian.org/bullseye/bsdextrautils/hexdump.1.en.html
