### PR TITLE
fix: ArgoCD -  exclude CiliumIdentity from sync

### DIFF
--- a/bootstrap/argocd/values.yaml
+++ b/bootstrap/argocd/values.yaml
@@ -23,6 +23,13 @@ configs:
     server.insecure: true
   cm:
     kustomize.buildOptions: --enable-helm
+    resource.exclusions: |
+        - apiGroups:
+          - cilium.io
+          kinds:
+          - CiliumIdentity
+          clusters:
+          - "*"
   rbac:
     policy.csv: |
       # role:ucadmin can sync applications


### PR DESCRIPTION
This configures ArgoCD to exclude the CiliumIdentity objects from sync process. Without this, we have a false reports on applications being out of sync. Moreover, we suspect that if ArgoCD forces removal of those objects it may impact the network connections from affected namespaces.

![image](https://github.com/user-attachments/assets/96072657-ded4-4738-96de-f17be1c0bef7)
