### PR TITLE
fix: avoid prometheus operator fighting ArgoCD

### DIFF
--- a/apps/appsets/operators.yaml
+++ b/apps/appsets/operators.yaml
@@ -74,7 +74,7 @@ spec:
                   sources:
                     - repoURL: https://prometheus-community.github.io/helm-charts
                       chart: kube-prometheus-stack
-                      targetRevision: 62.6.0
+                      targetRevision: 69.7.0
                       helm:
                         releaseName: kube-prometheus-stack
                         valueFiles:

--- a/operators/monitoring/values.yaml
+++ b/operators/monitoring/values.yaml
@@ -46,3 +46,26 @@ grafana:
         gnetId: 14057
         revision: 1
         datasource: Prometheus
+
+# prevent ArgoCD from getting hung up on the webhook jobs
+# https://github.com/prometheus-community/helm-charts/issues/4500#issuecomment-2693911587
+prometheusOperator:
+  admissionWebhooks:
+    enabled: true
+
+    annotations:
+      argocd.argoproj.io/hook: PreSync
+      argocd.argoproj.io/hook-delete-policy: HookSucceeded
+
+    patch:
+      annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded
+
+    mutatingWebhookConfiguration:
+      annotations:
+        argocd.argoproj.io/hook: PreSync
+
+    validatingWebhookConfiguration:
+      annotations:
+        argocd.argoproj.io/hook: PreSync


### PR DESCRIPTION
ArgoCD is fighting the prometheus operator and needs to have the correct annotations set on it to avoid this.
see: https://github.com/prometheus-community/helm-charts/issues/4500#issuecomment-2693911587