### PR TITLE
fix: move logic from update_port_postcommit 

### DIFF
--- a/python/neutron-understack/neutron_understack/tests/conftest.py
+++ b/python/neutron-understack/neutron_understack/tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import uuid
 
 import pytest
+from neutron.db.models.segment import NetworkSegment
 from neutron.db.models_v2 import Network
 from neutron.db.models_v2 import Port
 from neutron.db.models_v2 import Subnet
@@ -73,12 +74,17 @@ def network_dict(ml2_plugin) -> dict:
 
 
 @pytest.fixture
-def network_context(ml2_plugin, network_dict) -> NetworkContext:
+def network_segment() -> NetworkSegment:
+    return NetworkSegment(network_type="vxlan")
+
+
+@pytest.fixture
+def network_context(ml2_plugin, network_dict, network_segment) -> NetworkContext:
     return NetworkContext(
         ml2_plugin,
         "plugin_context",
         network_dict,
-        segments=[],
+        segments=[network_segment],
     )
 
 


### PR DESCRIPTION
Currently, when any update is made to the neutron port where vif-type is "other", it triggers the whole logic in update_port_postcommit which is meant to be only on the bind port, so in other words, when baremetal port is attached to the server being kicked, we only need to trigger it once to setup switchport config. The best place for this logic therefor is bind_port.