### PR TITLE
chore: Bump ironic-python-agent-builder version to resolve missing hexdump issue

### DIFF
--- a/ironic-images/requirements.txt
+++ b/ironic-images/requirements.txt
@@ -1,4 +1,4 @@
 diskimage-builder==3.37.0
-ironic-python-agent-builder==5.4.0
+ironic-python-agent-builder==6.0.0
 python-keystoneclient==5.5.0
 python-swiftclient==4.6.0


### PR DESCRIPTION
Updates the ironic-python-agent-builder to the latest version which includes this fix: https://review.opendev.org/c/openstack/ironic-python-agent-builder/+/943334 for the missing hexdump command.
