### PR TITLE
chore(workflows): distinct users for argo events

### DIFF
--- a/workflows/openstack/eventsources/eventsource-openstack-ironic.yaml
+++ b/workflows/openstack/eventsources/eventsource-openstack-ironic.yaml
@@ -29,8 +29,8 @@ spec:
       # use secret selectors
       auth:
         username:
-          name: argo-user-credentials
+          name: argo-ironic-user-credentials
           key: username
         password:
-          name: argo-user-credentials
+          name: argo-ironic-user-credentials
           key: password

--- a/workflows/openstack/eventsources/eventsource-openstack-keystone.yaml
+++ b/workflows/openstack/eventsources/eventsource-openstack-keystone.yaml
@@ -30,8 +30,8 @@ spec:
       # use secret selectors
       auth:
         username:
-          name: argo-user-credentials
+          name: argo-keystone-user-credentials
           key: username
         password:
-          name: argo-user-credentials
+          name: argo-keystone-user-credentials
           key: password

--- a/workflows/openstack/eventsources/rabbitmq-user-argo-ironic.yaml
+++ b/workflows/openstack/eventsources/rabbitmq-user-argo-ironic.yaml
@@ -1,10 +1,19 @@
 ---
 apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: argo-ironic
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
-  name: argo-to-keystone-permission
+  name: argo-ironic
 spec:
-  vhost: "keystone"
+  vhost: "ironic"
   userReference:
     name: "argo"  # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
   permissions:

--- a/workflows/openstack/eventsources/rabbitmq-user-argo-keystone.yaml
+++ b/workflows/openstack/eventsources/rabbitmq-user-argo-keystone.yaml
@@ -1,10 +1,19 @@
 ---
 apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: argo-keystone
+spec:
+  rabbitmqClusterReference:
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
-  name: argo-to-ironic-permission
+  name: argo-keystone
 spec:
-  vhost: "ironic"
+  vhost: "keystone"
   userReference:
     name: "argo"  # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
   permissions:

--- a/workflows/openstack/eventsources/rabbitmq-user-argo.yaml
+++ b/workflows/openstack/eventsources/rabbitmq-user-argo.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: rabbitmq.com/v1beta1
-kind: User
-metadata:
-  name: argo
-spec:
-  rabbitmqClusterReference:
-    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
-    namespace: openstack

--- a/workflows/openstack/kustomization.yaml
+++ b/workflows/openstack/kustomization.yaml
@@ -8,9 +8,8 @@ resources:
   - eventbus/poddisruptionbudget-eventbus-default-pdb.yaml
   - eventsources/eventsource-openstack-ironic.yaml
   - eventsources/eventsource-openstack-keystone.yaml
-  - eventsources/rabbitmq-user-argo.yaml
-  - eventsources/rabbitmq-permission-argo-to-ironic-permission.yaml
-  - eventsources/rabbitmq-permission-argo-to-keystone-permission.yaml
+  - eventsources/rabbitmq-user-argo-ironic.yaml
+  - eventsources/rabbitmq-user-argo-keystone.yaml
   - eventsources/eventsource-openstack-neutron.yaml
   - serviceaccounts/serviceaccount-sensor-submit-workflow.yaml
   - serviceaccounts/serviceaccount-openstack-events.yaml


### PR DESCRIPTION
Added two distinct users for argo events to connect to two rabbitmq vhosts since we've seen an issue with the operator not ensuring the same user has access to both vhosts before.