### PR TITLE
fix: understack-infra appset needs to install to kube-system

### DIFF
--- a/apps/appsets/understack.yaml
+++ b/apps/appsets/understack.yaml
@@ -13,6 +13,8 @@ spec:
     server: '*'
   - namespace: 'cilium'
     server: '*'
+  - namespace: 'kube-system'
+    server: '*'
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'


### PR DESCRIPTION
For cert-manager