### PR TITLE
fix: secondary IP blocks on "external" subnets (SVIs)

### DIFF
--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -188,21 +188,21 @@ class Nautobot:
         }
         return self.make_api_request("POST", "/api/ipam/prefixes/", payload)
 
-    def associate_subnet_with_network(
-        self, network_uuid: str, subnet_uuid: str, role: str
-    ):
+    def set_svi_role_on_network(self, network_uuid: str, role: str):
         url = f"/api/plugins/undercloud-vni/ucvnis/{network_uuid}/"
-        payload = {
-            "role": {"name": role},
-            "relationships": {
-                "ucvni_prefixes": {
-                    "destination": {
-                        "objects": [subnet_uuid],
-                    },
-                },
-            },
-        }
+        payload = {"role": {"name": role}}
         self.make_api_request("PATCH", url, payload)
+
+    def associate_subnet_with_network(self, network_uuid: str, subnet_uuid: str):
+        url = "/api/extras/relationship-associations/"
+        payload = {
+            "relationship": {"key": "ucvni_prefixes"},
+            "source_type": "vni_custom_model.ucvni",
+            "source_id": network_uuid,
+            "destination_type": "ipam.prefix",
+            "destination_id": subnet_uuid,
+        }
+        self.make_api_request("POST", url, payload)
 
     def add_tenant_vlan_tag_to_ucvni(self, network_uuid: str, vlan_tag: int) -> dict:
         url = f"/api/plugins/undercloud-vni/ucvnis/{network_uuid}/"

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -176,9 +176,12 @@ class UnderstackDriver(MechanismDriver):
 
         if external:
             self.nb.associate_subnet_with_network(
-                role="svi_vxlan_anycast_gateway",
                 network_uuid=network_uuid,
                 subnet_uuid=subnet_uuid,
+            )
+            self.nb.set_svi_role_on_network(
+                role="svi_vxlan_anycast_gateway",
+                network_uuid=network_uuid,
             )
 
         LOG.info(

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -123,9 +123,12 @@ class TestCreateSubnetPostCommit:
             tenant_uuid=ANY,
         )
         understack_driver.nb.associate_subnet_with_network.assert_called_once_with(
-            role="svi_vxlan_anycast_gateway",
             network_uuid=subnet.network_id,
             subnet_uuid=subnet.id,
+        )
+        understack_driver.nb.set_svi_role_on_network.assert_called_once_with(
+            network_uuid=subnet.network_id,
+            role="svi_vxlan_anycast_gateway",
         )
 
 


### PR DESCRIPTION
The Nautobot update is supposed to be adding to the set of subnets that are associated with the UCVNI.  It was incorrectly replacing the entire set.

With these changes, the network/UCVNI gets correctly associated with both subnets/prefixes:

![image](https://github.com/user-attachments/assets/0d371114-b5a6-4c1c-bd2f-416cb65851ca)

and the correct configuration ends up on the switch:
```
interface Vlan1100
  description 1100_OUTSIDE___cccbb055
  no shutdown
  ip access-group customer-12200-CUSTOM in
  vrf member PUBLIC
  no ip redirects
  ip address 10.4.88.33/28 tag 50000
  ip address 10.4.88.49/28 secondary tag 50000
  no ipv6 redirects
  fabric forwarding mode anycast-gateway
```