### PR TITLE
fix(nautobot): no superusers by default

### DIFF
--- a/components/nautobot/kustomization.yaml
+++ b/components/nautobot/kustomization.yaml
@@ -16,6 +16,8 @@ configMapGenerator:
       - NAUTOBOT_SSO_CLAIMS_GROUP="groups"
       # comma separated list to get these permissions
       - NAUTOBOT_SSO_STAFF_GROUPS="ucadmin"
-      - NAUTOBOT_SSO_SUPERUSER_GROUPS="ucadmin"
+      # superuser really ignores all permissions so probably not something
+      # which should have a default
+      - NAUTOBOT_SSO_SUPERUSER_GROUPS=""
     options:
       disableNameSuffixHash: true


### PR DESCRIPTION
superusers in Nautobot ignore permissions and have access to everything. This is likely not something you want on by default. But the staff group has the ability to make changes so this can be the escape hatch to let people elevate their permissions should they need.