### PR TITLE
feat: Adds 'uc-diff projects' to diff all projects

### DIFF
--- a/python/diff-nautobot-understack/diff_nautobot_understack/cli.py
+++ b/python/diff-nautobot-understack/diff_nautobot_understack/cli.py
@@ -11,6 +11,9 @@ from diff_nautobot_understack.network.main import (
     openstack_network_diff_from_ucvni_network,
 )
 from diff_nautobot_understack.project.main import (
+    openstack_all_projects_diff_from_nautobot_tenant,
+)
+from diff_nautobot_understack.project.main import (
     openstack_project_diff_from_nautobot_tenant,
 )
 from diff_nautobot_understack.settings import app_settings as settings
@@ -63,6 +66,19 @@ def tabular_output(diffs, title, id_column_name):
 
 
 @app.command()
+def projects(
+    debug: bool = typer.Option(False, "--debug", "-v", help="Enable debug mode"),
+    output_format: str = typer.Option(
+        "json", "--format", help="Available formats json, table"
+    ),
+):
+    """OpenStack projects ⟹ Nautobot tenants"""
+    settings.debug = debug
+    diff_result = openstack_all_projects_diff_from_nautobot_tenant()
+    display_output(diff_result, "project", output_format)
+
+
+@app.command()
 def project(
     name: str,
     debug: bool = typer.Option(False, "--debug", "-v", help="Enable debug mode"),
@@ -70,7 +86,7 @@ def project(
         "json", "--format", help="Available formats json, table"
     ),
 ):
-    """Nautobot tenants ⟹ Openstack projects"""
+    """OpenStack projects ⟹ Nautobot tenants"""
     settings.debug = debug
     diff_result = openstack_project_diff_from_nautobot_tenant(os_project=name)
     display_output(diff_result, "project", output_format)
@@ -83,7 +99,7 @@ def network(
         "json", "--format", help="Available formats json, table"
     ),
 ):
-    """Nautobot ucvnis ⟹ Openstack networks"""
+    """OpenStack networks ⟹ Nautobot UCVNIs"""
     settings.debug = debug
     diff_result = openstack_network_diff_from_ucvni_network()
     display_output(diff_result, "network", output_format)

--- a/python/diff-nautobot-understack/diff_nautobot_understack/project/adapters/nautobot_tenant.py
+++ b/python/diff-nautobot-understack/diff_nautobot_understack/project/adapters/nautobot_tenant.py
@@ -35,3 +35,29 @@ class Tenant(Adapter):
                     description=tenant.get("description"),
                 )
             )
+
+
+class Tenants(Adapter):
+    """All tenants."""
+
+    project = models.ProjectModel
+
+    top_level = ["project"]
+    type = "Tenant"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.api_client = API()
+
+    def load(self):
+        url = "/api/tenancy/tenants/?include=relationships"
+        tenants_response = self.api_client.make_api_request(url, paginated=True)
+
+        for tenant in tenants_response:
+            self.add(
+                self.project(
+                    id=_remove_hyphens(tenant.get("id")),
+                    name=tenant.get("name"),
+                    description=tenant.get("description"),
+                )
+            )

--- a/python/diff-nautobot-understack/diff_nautobot_understack/project/adapters/openstack_project.py
+++ b/python/diff-nautobot-understack/diff_nautobot_understack/project/adapters/openstack_project.py
@@ -32,3 +32,25 @@ class Project(Adapter):
                 description=os_project.description,
             )
         )
+
+
+class Projects(Adapter):
+    project = models.ProjectModel
+
+    top_level = ["project"]
+    type = "OpenstackProject"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        openstack_api = API()
+        self.cloud = openstack_api.cloud_connection
+
+    def load(self):
+        for os_project in self.cloud.identity.projects():
+            self.add(
+                self.project(
+                    id=os_project.id,
+                    name=os_project.name,
+                    description=os_project.description,
+                )
+            )

--- a/python/diff-nautobot-understack/diff_nautobot_understack/project/main.py
+++ b/python/diff-nautobot-understack/diff_nautobot_understack/project/main.py
@@ -2,7 +2,9 @@ from diffsync.diff import Diff
 from diffsync.enum import DiffSyncFlags
 
 from diff_nautobot_understack.project.adapters.nautobot_tenant import Tenant
+from diff_nautobot_understack.project.adapters.nautobot_tenant import Tenants
 from diff_nautobot_understack.project.adapters.openstack_project import Project
+from diff_nautobot_understack.project.adapters.openstack_project import Projects
 from diff_nautobot_understack.settings import app_settings as settings
 
 
@@ -12,6 +14,18 @@ def openstack_project_diff_from_nautobot_tenant(os_project=None) -> Diff:
     openstack_project.load()
 
     nautobot_tenant = Tenant(name=project_name)
+    nautobot_tenant.load()
+    tenant_destination_openstack_project_source = nautobot_tenant.diff_from(
+        openstack_project, flags=DiffSyncFlags.CONTINUE_ON_FAILURE
+    )
+    return tenant_destination_openstack_project_source
+
+
+def openstack_all_projects_diff_from_nautobot_tenant() -> Diff:
+    openstack_project = Projects()
+    openstack_project.load()
+
+    nautobot_tenant = Tenants()
     nautobot_tenant.load()
     tenant_destination_openstack_project_source = nautobot_tenant.diff_from(
         openstack_project, flags=DiffSyncFlags.CONTINUE_ON_FAILURE


### PR DESCRIPTION
Adds a new command: `uc-diff projects` to show the differences for all the OpenStack projects versus Nautobot tenants.