### PR TITLE
fix(argocd): deploying cert-manager webhooks requires kube-system

### DIFF
--- a/apps/appsets/understack.yaml
+++ b/apps/appsets/understack.yaml
@@ -92,6 +92,8 @@ spec:
     server: '*'
   - namespace: 'global-secrets-sync'
     server: '*'
+  - namespace: 'kube-system'
+    server: '*'
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'


### PR DESCRIPTION
To deploy a cert-manager webhook we need to be able to create a rolebinding in kube-system so access must be granted here.