### PR TITLE
feat: PUC-765: use segmentation_id generated by neutron as ucvni_id in nautobot

### DIFF
--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -128,7 +128,7 @@ class Nautobot:
         project_id: str,
         ucvni_group: str,
         network_name: str,
-        segment_id: int | None = None,
+        segmentation_id: int,
     ) -> dict:
         payload = {
             "id": network_id,
@@ -136,14 +136,13 @@ class Nautobot:
             "name": network_name,
             "ucvni_group": ucvni_group,
             "status": {"name": "Active"},
+            "ucvni_id": segmentation_id,
         }
 
-        if segment_id:
-            payload["ucvni_id"] = segment_id
-            payload["ucvni_type"] = "INFRA"
-
-        url = "/api/plugins/undercloud-vni/ucvnis/"
-        return self.make_api_request("POST", url, payload)
+        ucvni: pynautobot.core.response.Record = (
+            self.api.plugins.undercloud_vni.ucvnis.create(payload)
+        )
+        return dict(ucvni)
 
     def ucvni_delete(self, network_id):
         url = f"/api/plugins/undercloud-vni/ucvnis/{network_id}/"

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -80,6 +80,7 @@ class UnderstackDriver(MechanismDriver):
             project_id=project_id,
             ucvni_group=ucvni_group,
             network_name=network_name,
+            segmentation_id=segmentation_id,
         )
         LOG.info(
             "network %(net_id)s has been added on ucvni_group %(ucvni_group)s, "

--- a/python/neutron-understack/neutron_understack/tests/conftest.py
+++ b/python/neutron-understack/neutron_understack/tests/conftest.py
@@ -111,7 +111,7 @@ def network_dict(ml2_plugin, network, network_segment) -> dict:
 
 @pytest.fixture
 def network_segment(network) -> NetworkSegment:
-    return NetworkSegment(network_type="vxlan", network=network)
+    return NetworkSegment(network_type="vxlan", network=network, segmentation_id=100)
 
 
 @pytest.fixture

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -202,6 +202,7 @@ class TestCreateNetworkPostCommit:
             network_id=str(network_id),
             project_id=str(project_id),
             ucvni_group=str(ucvni_group_id),
+            segmentation_id=network_context.current["provider:segmentation_id"],
             network_name=network_context.current["name"],
         )
         understack_driver._create_nautobot_namespace.assert_called_once_with(


### PR DESCRIPTION
Reason for code clean up related to VLAN type networks is,  we were experimenting with VLAN type networks but we switched back to VXLAN networks and in future also we want to use VXLAN type networks only.