### PR TITLE
fix(prometheus): prevent constant sync cycling with ArgoCD

### DIFF
--- a/operators/monitoring/values.yaml
+++ b/operators/monitoring/values.yaml
@@ -54,18 +54,10 @@ prometheusOperator:
     enabled: true
 
     annotations:
-      argocd.argoproj.io/hook: PreSync
+      argocd.argoproj.io/hook: PostSync
       argocd.argoproj.io/hook-delete-policy: HookSucceeded
 
     patch:
       annotations:
-        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook: PostSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
-
-    mutatingWebhookConfiguration:
-      annotations:
-        argocd.argoproj.io/hook: PreSync
-
-    validatingWebhookConfiguration:
-      annotations:
-        argocd.argoproj.io/hook: PreSync


### PR DESCRIPTION
The comments in the default values.yaml are wrong for the helm chart for this and one of the maintainers pointed out the correct values at: https://github.com/prometheus-community/helm-charts/issues/4500#issuecomment-2724199565