### PR TITLE
fix(glance): add job annotations to fix sync issues

### DIFF
--- a/components/glance/values.yaml
+++ b/components/glance/values.yaml
@@ -140,3 +140,15 @@ annotations:
       argocd.argoproj.io/hook: Sync
       argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
       argocd.argoproj.io/sync-options: Replace=true
+    glance_metadefs_load:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+      argocd.argoproj.io/sync-options: Replace=true
+    glance_storage_init:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+      argocd.argoproj.io/sync-options: Replace=true
+    glance_bootstrap:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+      argocd.argoproj.io/sync-options: Replace=true


### PR DESCRIPTION
Due to the way OpenStack Helm loads their jobs and requires jobs to exist forever and that jobs are immutable, we need to have ArgoCD delete the existing or replace them when it runs a sync to apply any changes otherwise we hit immutable errors.