### PR TITLE
fix(keystone): add job annotations for syncing

### DIFF
--- a/components/keystone/values.yaml
+++ b/components/keystone/values.yaml
@@ -393,3 +393,7 @@ annotations:
       argocd.argoproj.io/hook: Sync
       argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
       argocd.argoproj.io/sync-options: Replace=true
+    keystone_bootstrap:
+      argocd.argoproj.io/hook: Sync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+      argocd.argoproj.io/sync-options: Replace=true


### PR DESCRIPTION
The way OpenStack Helm does their job configuration is incompatible with how Kubernetes treats jobs. So we must set annotations to have ArgoCD delete the job before applying any updates to the job.