### PR TITLE
fix: change bios settings for enroll, and add more LLDP details on missing neighbors

### DIFF
--- a/python/understack-workflows/understack_workflows/bmc_bios.py
+++ b/python/understack-workflows/understack_workflows/bmc_bios.py
@@ -11,7 +11,6 @@ def required_bios_settings(pxe_interface: str) -> dict:
     return {
         "PxeDev1EnDis": "Enabled",
         "PxeDev1Interface": pxe_interface,
-        "HttpDev1Interface": pxe_interface,
         "TimeZone": "UTC",
     }
 

--- a/python/understack-workflows/understack_workflows/discover.py
+++ b/python/understack-workflows/understack_workflows/discover.py
@@ -29,11 +29,15 @@ def discover_chassis_info(bmc: Bmc) -> ChassisInfo:
 
     attempts_remaining = LLDP_DISCOVERY_ATTEMPTS
     while len(device_info.neighbors) < MIN_REQUIRED_NEIGHBOR_COUNT:
+        lldp_table = {
+            i.name: f"{i.remote_switch_mac_address}/{i.remote_switch_port_name}"
+            for i in device_info.interfaces
+        }
         logger.info(
-            "%s does not have enough LLDP neighbors (saw %d), need at least %d. ",
+            "%s does not have enough LLDP neighbors, need %d or more, got %s",
             bmc,
-            len(device_info.neighbors),
             MIN_REQUIRED_NEIGHBOR_COUNT,
+            lldp_table,
         )
         if not attempts_remaining:
             raise Exception(


### PR DESCRIPTION
This makes enroll work on the prod node iDRACs