### PR TITLE
feat: Adds diffsync human-friendly summary to uc-diff output

### DIFF
--- a/python/diff-nautobot-understack/diff_nautobot_understack/cli.py
+++ b/python/diff-nautobot-understack/diff_nautobot_understack/cli.py
@@ -47,6 +47,9 @@ def display_output(
             diff_output_props.get("id_column_name"),
         )
     else:
+        print("Summary:\n")
+        print(diff_result.str())
+        print("\n")
         print(diff_result.dict())
 
 


### PR DESCRIPTION
Adds a more human-friendly output summary to the uc-diff output. Example:

``` text
Summary:

project
  project: 32e02632f4f04415bab5895d1e7247b7
    description    OpenstackProject()    Tenant(baremetal)
  project: 5cd5ec5f3c2f4b278920416234573570 MISSING in Tenant
  project: d3c2c85bdbf24ff5843f323524b63768
    description    OpenstackProject()    Tenant(Needs to go away)
  project: fe57b90d20084270a21a9e15ecf397bb MISSING in Tenant
  project: f4b27e2fe3d34d09989518b86199acef MISSING in OpenstackProject
  project: 08905eba31e24fce9353bf78c1e18c59 MISSING in OpenstackProject
  project: 22254735dcc44fea8aa0bd169da5234d MISSING in OpenstackProject
  project: 70f0955a1e7b41039addd8f90b93e786 MISSING in OpenstackProject
  project: 8095a0b147a74a16ab0c5f3e576ea6c3 MISSING in OpenstackProject
```
