### PR TITLE
fix(glance): Increase memory limits due to errors uploading images

### DIFF
--- a/components/glance/values.yaml
+++ b/components/glance/values.yaml
@@ -73,6 +73,9 @@ pod:
         min_available: 0
   resources:
     enabled: true
+    api:
+      limits:
+        memory: 6144Mi
   probes:
     api:
       glance-api:


### PR DESCRIPTION
When attempting to upload a new image, glance-api crashes with this error:
``` text
2025-03-28 15:42:33.305 22 INFO glance.api.v2.image_data [None req-6e15a68a-b57c-48bb-8679-770e67eb16bd 7129b5909a1d44c394fc84d915aa1e8d 2ae532bb8a82466ebba66c7a9a806eb5 - - default default] Unable to create trust: no such option collect_timing in group [keystone_authtoken] Use the existing user token.
DAMN ! worker 2 (pid: 22) died, killed by signal 9 :( trying respawn ...
Respawned uWSGI worker 2 (new pid: 30)
```
