### PR TITLE
fix(workflows): enrolling servers in Nautobot as Planned

### DIFF
--- a/python/understack-workflows/understack_workflows/nautobot_device.py
+++ b/python/understack-workflows/understack_workflows/nautobot_device.py
@@ -11,7 +11,7 @@ from understack_workflows.helpers import setup_logger
 
 logger = setup_logger(__name__)
 
-DEVICE_INITIAL_STATUS = "enroll"
+DEVICE_INITIAL_STATUS = "Planned"
 DEVICE_ROLE = "server"
 INTERFACE_TYPE = "25gbase-x-sfp28"
 BMC_INTERFACE_TYPE = "1000base-t"


### PR DESCRIPTION
Follow the Ironic/Nautobot state mapping by enrolling servers into Nautobot at the Planned state instead of creating a new state called "enroll" inside of Nautobot.