### PR TITLE
chore: protect resources from automated deletion

### DIFF
--- a/components/nautobot/cloudnative-postgres-nautobot.yaml
+++ b/components/nautobot/cloudnative-postgres-nautobot.yaml
@@ -3,6 +3,9 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: nautobot-cluster
+  annotations:
+    # do not allow ArgoCD to delete our DB
+    argocd.argoproj.io/sync-options: Delete=false
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:15.5
   instances: 3

--- a/components/nautobot/values.yaml
+++ b/components/nautobot/values.yaml
@@ -76,6 +76,9 @@ redis:
   auth:
     existingSecret: nautobot-redis
     existingSecretPasswordKey: NAUTOBOT_REDIS_PASSWORD
+  commonAnnotations:
+    # do not allow ArgoCD to delete our redis
+    argocd.argoproj.io/sync-options: Delete=false
 
 ingress:
   enabled: true

--- a/components/openstack/mariadb-instance.yaml
+++ b/components/openstack/mariadb-instance.yaml
@@ -3,6 +3,9 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: MariaDB
 metadata:
   name: mariadb  # this name is referenced by other resource kinds
+  annotations:
+    # do not allow ArgoCD to delete our DB
+    argocd.argoproj.io/sync-options: Delete=false
 spec:
   rootPasswordSecretKeyRef:
     name: mariadb

--- a/components/openstack/memcached-values.yaml
+++ b/components/openstack/memcached-values.yaml
@@ -1,2 +1,8 @@
+---
+
+commonAnnotations:
+  # do not allow ArgoCD to delete our memcached
+  argocd.argoproj.io/sync-options: Delete=false
+
 metrics:
   enabled: true

--- a/components/openstack/openstack-cluster.yaml
+++ b/components/openstack/openstack-cluster.yaml
@@ -2,3 +2,6 @@ apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: rabbitmq
+  annotations:
+    # do not allow ArgoCD to delete our cluster
+    argocd.argoproj.io/sync-options: Delete=false


### PR DESCRIPTION
This ensures that these resources are not deleted automatically through a sync operation. This should really be an intentional operation to delete them.