### PR TITLE
chore(nova): we never use the OSH hardcoded flavors so disable them

### DIFF
--- a/components/nova/values.yaml
+++ b/components/nova/values.yaml
@@ -84,6 +84,12 @@ console:
   # connected to QEMU
   console_kind: none
 
+bootstrap:
+  structured:
+    flavors:
+      # this script adds hardcoded flavors which we never use so disable it
+      enabled: false
+
 # (nicholas.kuechler) Using custom dependencies in order to
 # prevent the nova-db-init and nova-rabbit-init jobs from running
 dependencies:


### PR DESCRIPTION
OpenStack Helm contains a list of hardcoded flavors, which can be further extended but is limited in that properties cannot be set which is a must for Ironic support so this is not useful to us so disable it entirely.