### PR TITLE
fix: the otel-collector should be in the understack project

### DIFF
--- a/apps/appsets/project-understack.yaml
+++ b/apps/appsets/project-understack.yaml
@@ -26,6 +26,8 @@ spec:
     server: '*'
   - namespace: 'monitoring'
     server: '*'
+  - namespace: 'otel-collector'
+    server: '*'
   - namespace: 'kube-system'
     server: '*'
   clusterResourceWhitelist:

--- a/apps/appsets/understack.yaml
+++ b/apps/appsets/understack.yaml
@@ -90,6 +90,8 @@ spec:
     server: '*'
   - namespace: 'monitoring'
     server: '*'
+  - namespace: 'otel-collector'
+    server: '*'
   - namespace: 'global-secrets-sync'
     server: '*'
   - namespace: 'kube-system'
@@ -509,6 +511,7 @@ spec:
                       targetRevision: '{{ .values.uc_deploy_ref }}'
                       ref: deploy
                 - component: otel-collector
+                  componentProject: understack
                   componentNamespace: otel-collector
                   skipComponent: '{{has "otel-collector" (.values.uc_skip_components | fromJson)}}'
                   sources:


### PR DESCRIPTION
The componentProject was not set for the otel-collector and it was trying to be installed under the nonexistent otel-collector project.