### PR TITLE
feat: Accept either name or UUID for switch interface in local_link_info

### DIFF
--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -330,7 +330,7 @@ class Nautobot:
     def create_vlan_and_associate_vlan_to_ucvni(self, vlan: VlanPayload):
         try:
             result = self.api.ipam.vlans.create(vlan.to_dict())
-        except pynautobot.core.query.RequestError as error:
+        except pynautobot.core.query.RequestError as error:  # type: ignore
             LOG.error("Nautobot error: %(error)s", {"error": error})
             raise NautobotRequestError(
                 code=error.req.status_code,

--- a/python/neutron-understack/neutron_understack/nautobot.py
+++ b/python/neutron-understack/neutron_understack/nautobot.py
@@ -342,6 +342,20 @@ class Nautobot:
         else:
             return result
 
+    def get_interface_uuid(self, device_name: str, interface_name: str) -> str:
+        device = self.api.dcim.devices.get(name=device_name)
+        if not device:
+            raise NautobotNotFoundError(obj="device", ref=device_name)
+
+        interface = self.api.dcim.interfaces.get(
+            name=interface_name,
+            device=device.id,  # type: ignore
+        )
+        if not interface:
+            raise NautobotNotFoundError(obj="interface", ref=interface_name)
+
+        return interface.id  # type: ignore
+
 
 def _vlan_payload(vlan_group_name: str, vlan_id: int) -> dict:
     return {

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -268,7 +268,7 @@ class UnderstackDriver(MechanismDriver):
         segment_id = context.original_top_bound_segment["id"]
         original_binding = context.original["binding:profile"]
         connected_interface_uuid = utils.fetch_connected_interface_uuid(
-            original_binding, LOG
+            original_binding, self.nb
         )
 
         if not utils.ports_bound_to_segment(segment_id):
@@ -342,7 +342,7 @@ class UnderstackDriver(MechanismDriver):
     def _bind_port_segment(self, context: PortContext, segment):
         network_id = context.current["network_id"]
         connected_interface_uuid = utils.fetch_connected_interface_uuid(
-            context.current["binding:profile"], LOG
+            context.current["binding:profile"], self.nb
         )
         vlan_group_name = self._vlan_group_name(context)
         if vlan_group_name is None:
@@ -473,7 +473,7 @@ class UnderstackDriver(MechanismDriver):
 
     def _set_nautobot_port_status(self, context: PortContext, status: str):
         profile = context.current["binding:profile"]
-        interface_uuid = utils.fetch_connected_interface_uuid(profile, LOG)
+        interface_uuid = utils.fetch_connected_interface_uuid(profile, self.nb)
         LOG.debug("Set interface %s to %s status", interface_uuid, status)
         self.nb.configure_port_status(interface_uuid, status=status)
 

--- a/python/neutron-understack/neutron_understack/tests/test_utils.py
+++ b/python/neutron-understack/neutron_understack/tests/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 from neutron.plugins.ml2.driver_context import portbindings
 
@@ -7,16 +9,25 @@ from neutron_understack import utils
 class TestFetchConnectedInterfaceUUID:
     def test_with_normal_uuid(self, port_context, port_id):
         result = utils.fetch_connected_interface_uuid(
-            port_context.current["binding:profile"]
+            binding_profile=port_context.current["binding:profile"], nautobot=Mock()
         )
         assert result == str(port_id)
 
     @pytest.mark.parametrize("binding_profile", [{"port_id": 11}], indirect=True)
     def test_with_integer(self, port_context):
-        with pytest.raises(ValueError):
-            utils.fetch_connected_interface_uuid(
-                port_context.current["binding:profile"]
-            )
+        fake_nautobot = Mock()
+        fake_nautobot.get_interface_uuid.return_value = "FAKE ID"
+
+        result = utils.fetch_connected_interface_uuid(
+            binding_profile=port_context.current["binding:profile"],
+            nautobot=fake_nautobot,
+        )
+        assert result == "FAKE ID"
+
+        fake_nautobot.get_interface_uuid.assert_called_once_with(
+            device_name="a1-1-1.iad3.rackspace.net",
+            interface_name=11,
+        )
 
 
 class TestParentPortIsBound:

--- a/python/neutron-understack/neutron_understack/trunk.py
+++ b/python/neutron-understack/neutron_understack/trunk.py
@@ -190,7 +190,7 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
         binding_profile = parent_port.bindings[0].profile
         binding_host = parent_port.bindings[0].host
         connected_interface_id = utils.fetch_connected_interface_uuid(
-            binding_profile, LOG
+            binding_profile, self.nb
         )
 
         vlan_group_name = utils.vlan_group_name_from_binding_profile(binding_profile)
@@ -269,7 +269,7 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
     ) -> None:
         vlan_group_name = utils.vlan_group_name_from_binding_profile(binding_profile)
         connected_interface_id = utils.fetch_connected_interface_uuid(
-            binding_profile, LOG
+            binding_profile, self.nb
         )
 
         vlan_ids_to_remove = self._handle_segment_deallocation(subports, binding_host)


### PR DESCRIPTION
We wanted this to become a name rather than a nautobot UUID.  To support the transition from UUID to interface name, we accept a value of either kind.  If the value is not a UUID, we look it up in nautobot.