### PR TITLE
feat:PUC-314: set default boot-interface to http-ipxe

### DIFF
--- a/python/understack-workflows/understack_workflows/ironic_node.py
+++ b/python/understack-workflows/understack_workflows/ironic_node.py
@@ -59,6 +59,7 @@ def update_ironic_node(client, node_meta, bmc):
         f"driver_info/redfish_username={bmc.username}",
         f"driver_info/redfish_password={bmc.password}",
         f"resource_class={node_meta.resource_class}",
+        "boot_interface=http-ipxe",
     ]
 
     patches = args_array_to_patch("add", updates)
@@ -85,5 +86,6 @@ def create_ironic_node(
                 "redfish_password": bmc.password,
             },
             "resource_class": node_meta.resource_class,
+            "boot_interface": "http-ipxe",
         }
     )


### PR DESCRIPTION
Use HTTP with our UEFI boot. So we need to switch to http-ipxe over ipxe.