### PR TITLE
fix(argocd): remove finalizer that should by controlled by policy

### DIFF
--- a/apps/appsets/appset-understack-infra.yaml
+++ b/apps/appsets/appset-understack-infra.yaml
@@ -81,8 +81,7 @@ spec:
   template:
     metadata:
       name: '{{.name}}-{{.component}}'
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
+      # we should never set the finalizer here as the applicationsSync policy will handle it
       annotations:
         argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:

--- a/apps/appsets/appset-understack-operators.yaml
+++ b/apps/appsets/appset-understack-operators.yaml
@@ -139,8 +139,7 @@ spec:
   template:
     metadata:
       name: '{{.name}}-{{.component}}'
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
+      # we should never set the finalizer here as the applicationsSync policy will handle it
       annotations:
         argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:

--- a/apps/appsets/components.yaml
+++ b/apps/appsets/components.yaml
@@ -232,8 +232,7 @@ spec:
   template:
     metadata:
       name: '{{.name}}-{{.component}}'
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
+      # we should never set the finalizer here as the applicationsSync policy will handle it
       annotations:
         argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:

--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -46,8 +46,7 @@ spec:
   template:
     metadata:
       name: '{{.name}}-{{.component}}'
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
+      # we should never set the finalizer here as the applicationsSync policy will handle it
       annotations:
         argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:

--- a/apps/appsets/understack.yaml
+++ b/apps/appsets/understack.yaml
@@ -828,8 +828,7 @@ spec:
   template:
     metadata:
       name: '{{.name}}-{{.component}}'
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
+      # we should never set the finalizer here as the applicationsSync policy will handle it
     spec:
       project: '{{coalesce (get . "componentProject") .component}}'
       destination:


### PR DESCRIPTION
We should not be setting this finalizer on our Applications since it should be set there by the AppSet applicationsSync. See https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/ for more context.