### PR TITLE
fix(argocd): revert finalizer on appproject

### DIFF
--- a/apps/appsets/project-understack-infra.yaml
+++ b/apps/appsets/project-understack-infra.yaml
@@ -3,9 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: understack-infra
-  # Finalizer that ensures that project is not deleted until it is not referenced by any application
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
+  # we do not want the finalizer here as it deletes all resources as
+  # they move between AppProject's
 spec:
   sourceRepos:
   - '*'

--- a/apps/appsets/project-understack-operators.yaml
+++ b/apps/appsets/project-understack-operators.yaml
@@ -3,9 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: understack-operators
-  # Finalizer that ensures that project is not deleted until it is not referenced by any application
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
+  # we do not want the finalizer here as it deletes all resources as
+  # they move between AppProject's
 spec:
   sourceRepos:
   - '*'

--- a/apps/appsets/project-understack.yaml
+++ b/apps/appsets/project-understack.yaml
@@ -3,9 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: understack
-  # Finalizer that ensures that project is not deleted until it is not referenced by any application
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
+  # we do not want the finalizer here as it deletes all resources as
+  # they move between AppProject's
 spec:
   sourceRepos:
   - '*'


### PR DESCRIPTION
Reverts the finalizer added on AppProjects in 04d352154effaa as this causes all resources to be deleted when they transition between AppProjects despite any other settings.