### PR TITLE
fix: trunk_created payload parsing

### DIFF
--- a/python/neutron-understack/neutron_understack/trunk.py
+++ b/python/neutron-understack/neutron_understack/trunk.py
@@ -292,7 +292,7 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
         self._clean_parent_port_switchport_config(trunk, subports)
 
     def trunk_created(self, resource, event, trunk_plugin, payload):
-        trunk = payload.states[0]
+        trunk = payload.latest_state
         subports = trunk.sub_ports
         if subports:
             self._handle_tenant_vlan_id_and_switchport_config(subports, trunk)


### PR DESCRIPTION
Previously we changed the trunk_created and subports_added subscription event from AFTER_CREATE to PRECOMMIT_CREATE,  while that was not a problem for subports, it created a bug for trunk as DBEventPayload is constructed differently for trunk, hence we need this change.
code ref for trunk DBEventPayload on precommit:
https://github.com/openstack/neutron/blob/stable/2024.2/neutron/services/trunk/plugin.py#L263

As we see there, the "desired_state" is used instead of just "state".

If we call payload.latest_state, it will return desired if present, else it will return latest from state. code ref.
https://github.com/openstack/neutron-lib/blob/950f0f3a8a722da115c03f2abb756a732a3ec4c1/neutron_lib/callbacks/events.py#L142