### PR TITLE
feat: enable Golangci linting

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -27,20 +27,42 @@ env:
   GOLANGCI_LINT_VERSION: v2.1.2
 
 jobs:
-  golangci-lint:
+  # Initial Setup Job
+  setup:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        apps:
-          - dexop
-          - deploy-cli
     steps:
       - uses: actions/checkout@v4
+
+      # List directories and set as output
+      - name: List Applications
+        id: list_dirs
+        run: |
+          apps=$(ls -d go/* | xargs -n1 basename)
+          app_array=$(printf '%s\n' $apps | jq -R . | jq -cs .)
+          echo "apps=${app_array}"
+          printf "apps=%s\n" "${app_array}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      # Set up Go environment
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: golangci-lint ${{ matrix.apps }}
+    outputs:
+      apps: ${{ steps.list_dirs.outputs.apps }}
+
+  golangci-lint:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix:
+        app: ${{ fromJson(needs.setup.outputs.apps) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: golangci-lint ${{ matrix.app }}
         uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          working-directory: go/${{ matrix.apps }}
+          working-directory: go/${{ matrix.app }}

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -1,0 +1,46 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "go/**"
+      - .github/workflows/go-lint.yaml
+  pull_request:
+    paths:
+      - "go/**"
+      - .github/workflows/go-lint.yaml
+  workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
+    paths:
+      - "go/**"
+      - .github/workflows/go-lint.yaml
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+env:
+  GO_VERSION: 1.23
+  GOLANGCI_LINT_VERSION: v2.1.2
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        apps:
+          - dexop
+          - deploy-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint ${{ matrix.apps }}
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: go/${{ matrix.apps }}

--- a/go/deploy-cli/cmd/helmConfig/helmConfig.go
+++ b/go/deploy-cli/cmd/helmConfig/helmConfig.go
@@ -25,10 +25,18 @@ var HelmConfig = &cobra.Command{
 }
 
 func helmConfigGen(cmd *cobra.Command, args []string) {
-	dex()
-	glance()
-	ironic()
-	rook()
+  functions := []func() error{
+    dex,
+    glance,
+    ironic,
+    rook,
+  }
+  for _, fn := range functions {
+    if err := fn(); err != nil {
+      fmt.Printf("Error helmConfigGen: %v\n", err)
+      os.Exit(1)
+    }
+  }
 }
 
 func dex() error {

--- a/go/deploy-cli/cmd/other/other.go
+++ b/go/deploy-cli/cmd/other/other.go
@@ -59,7 +59,9 @@ func generateOtherSecrets(_ *cobra.Command, _ []string) {
 	// Create Empty Dirs
 	emptyDirs := []string{"argo-events", "ovn", "metallb", "undersync", "cilium"}
 	for _, service := range emptyDirs {
-		fsutil.WriteFile(helpers.GetManifestPathToService(service)+"/.keep", "", os.ModePerm)
+    if err := fsutil.WriteFile(helpers.GetManifestPathToService(service)+"/.keep", "", os.ModePerm); err != nil {
+      log.Errorf("Failed creating .keep file for %s: %v", service, err)
+    }
 	}
 }
 

--- a/go/deploy-cli/cmd/root.go
+++ b/go/deploy-cli/cmd/root.go
@@ -4,11 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// Viper config location
-	cfgFile string
-)
-
 var RootCmd = &cobra.Command{
 	Use:   "",
 	Short: "",

--- a/go/deploy-cli/helpers/kubeseal.go
+++ b/go/deploy-cli/helpers/kubeseal.go
@@ -16,7 +16,7 @@ func KubeSeal(inputData []byte, outputPath string) error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpFile.Name())
+	defer removeTempFile(tmpFile)
 
 	if _, err := tmpFile.Write([]byte(inputData)); err != nil {
 		return err
@@ -52,4 +52,10 @@ func KubeSeal(inputData []byte, outputPath string) error {
 		log.Fatal("error in kustomization.yaml file", "err", err)
 	}
 	return nil
+}
+
+func removeTempFile(file *os.File) {
+    if err := os.Remove(file.Name()); err != nil {
+        log.Printf("Failed to remove temporary file: %v", err)
+    }
 }

--- a/go/deploy-cli/helpers/kustomization.go
+++ b/go/deploy-cli/helpers/kustomization.go
@@ -39,12 +39,15 @@ func UpdateKustomizeFile(dir string) {
 func scanYamlFiles(dir string) ([]string, error) {
 	fileSet := make(map[string]bool)
 
-	fsutil.FindInDir(dir, func(filePath string, de fs.DirEntry) error {
+  err := fsutil.FindInDir(dir, func(filePath string, de fs.DirEntry) error {
 		fileSet[de.Name()] = true
 		return nil
 	}, fsutil.IncludeSuffix(".yaml", ".yml"),
 		fsutil.ExcludeDotFile,
 		fsutil.ExcludeNames(kustomizationFile))
+  if err != nil {
+    return nil, err
+  }
 
 	var uniqueFiles []string
 	for f := range fileSet {

--- a/go/deploy-cli/main.go
+++ b/go/deploy-cli/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/rackerlabs/understack/go/deploy-cli/cmd"
 	_ "github.com/rackerlabs/understack/go/deploy-cli/cmd/argocd"
 	_ "github.com/rackerlabs/understack/go/deploy-cli/cmd/certManager"
@@ -13,5 +15,8 @@ import (
 )
 
 func main() {
-	cmd.Execute()
+  err := cmd.Execute()
+  if err != nil {
+    os.Exit(1)
+  }
 }


### PR DESCRIPTION
This PR enables golang linting as well as bunch of fixes for `deploy-cli`. The fixes for `dexop` are contained in #876 