### PR TITLE
ci: pin argo workflows binary to not get broken by release process

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,15 @@
         "\\s- component: (?<depName>.+)\\n\\s+repoURL: (?<packageName>.+)\\n\\s+chartVersion: (?<currentValue>.+)\\s"
       ],
       "datasourceTemplate": "helm"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^.*\\.ya?ml$"],
+      "matchStrings": [
+        "(?<depName>[^/]+/[^/]+)/releases/download/v(?<currentValue>[^/]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
     }
   ],
   "devbox": {

--- a/.github/workflows/lint-workflow-templates.yaml
+++ b/.github/workflows/lint-workflow-templates.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Argo CLI
         run: |
-          curl -sLO https://github.com/argoproj/argo-workflows/releases/latest/download/argo-linux-amd64.gz
+          curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.6.6/argo-linux-amd64.gz
           gunzip argo-linux-amd64.gz
           chmod +x argo-linux-amd64
           sudo mv argo-linux-amd64 /usr/local/bin/argo


### PR DESCRIPTION
We've just pulled the latest argo workflows binary which has been working but their most recent release attempt ran up against Docker rate limits so it failed. The result is our CI is broken because the release binary is not available. To avoid this from happening in the future, pin the version but allow renovate to update it for us.