### PR TITLE
fix(ironic): ensure that UEFI boot works by having snponly.efi

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -72,6 +72,7 @@ conf:
     pxe:
       images_path: /var/lib/understack/master_iso_images
       instance_master_path: /var/lib/understack/master_iso_images
+      loader_file_paths: "snponly.efi:/usr/lib/ipxe/snponly.efi"
     inspector:
       extra_kernel_params: ipa-collect-lldp=1
       hooks: "$default_hooks,parse-lldp,local-link-connection,physical-network"


### PR DESCRIPTION
Since we are still using iPXE with our UEFI boot, we need to have snponly.efi available to our servers to fetch. Utilize the ironic.conf config that causes the conductor to copy the file from the host OS, which is located at /usr/lib/ipxe/snponly.efi in our containers, to the path where it will serve it up from. fixes PUC-649.