### PR TITLE
feat: PUC-662: adding Ironic redfish inspection to enroll workflow

### DIFF
--- a/workflows/argo-events/workflowtemplates/enroll-server.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-server.yaml
@@ -32,6 +32,21 @@ spec:
                 - name: device_id
                   value: "{{steps.enroll-server.outputs.result}}"
             when: "{{steps.server-enroll-state.outputs.result}} == enroll"
+        - - name: server-manage-state-for-inspect
+            template: openstack-state-cmd
+            arguments:
+              parameters:
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
+        - - name: redfish-inspect
+            template: openstack-wait-cmd
+            arguments:
+              parameters:
+                - name: operation
+                  value: "inspect"
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
+            when: "{{steps.server-manage-state-for-inspect.outputs.result}} == manageable"
         - - name: openstack-set-baremetal-node-raid-config
             template: openstack-set-baremetal-node-raid-config
             arguments:


### PR DESCRIPTION
will not merge this PR until we figure out reason for `pxe_enabled` setting to `false` on port during inspection.

[https://opendev.org/openstack/ironic/src/commit/c525a16b06266b6b474c99b13301d5b4409e92a0/ironic/drivers/modules/drac/inspect.py#L94](https://opendev.org/openstack/ironic/src/commit/c525a16b06266b6b474c99b13301d5b4409e92a0/ironic/drivers/modules/drac/inspect.py#L94)
[https://opendev.org/openstack/ironic/src/commit/c525a16b06266b6b474c99b13301d5b4409e92a0/ironic/drivers/modules/redfish/inspect.py#L194](https://opendev.org/openstack/ironic/src/commit/c525a16b06266b6b474c99b13301d5b4409e92a0/ironic/drivers/modules/drac/inspect.py#L94)
 