### PR TITLE
feat: add a renovatebot rule for matching our containers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "configMigration": true,
   "extends": [
     "github>rackerlabs/understack//.github/renovate/default",
-    "github>rackerlabs/understack//.github/renovate/nautobot"
+    "github>rackerlabs/understack//.github/renovate/nautobot",
+    "github>rackerlabs/understack//.github/renovate/understackContainerMatch"
   ],
   "packageRules": [
     {

--- a/.github/renovate/understackContainerMatch.json
+++ b/.github/renovate/understackContainerMatch.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^.*\\.ya?ml$"],
+      "matchStrings": [
+        "ghcr\\.io/rackerlabs/understack/(?<depName>[\\w-]+):(?<currentValue>[\\w.-]+"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "ghcr.io/rackerlabs/understack/{{depName}}",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "{{currentValue}}"
+    }
+  ]
+}


### PR DESCRIPTION
To make it easier for consumers of our containers to stay up to date, create a renovate bot rule which will find references to our containers in yaml files and update them.