### PR TITLE
fix: renovate rule for understack containers

### DIFF
--- a/.github/renovate/understackContainerMatch.json
+++ b/.github/renovate/understackContainerMatch.json
@@ -3,9 +3,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^.*\\.ya?ml$"],
+      "fileMatch": ["(^|/)images-openstack\\.ya?ml$"],
       "matchStrings": [
-        "ghcr\\.io/rackerlabs/understack/(?<depName>[\\w-]+):(?<currentValue>[\\w.-]+"
+        "ghcr\\.io/rackerlabs/understack/(?<depName>[\\w-]+):(?<currentValue>[\\w.-]+)"
       ],
       "datasourceTemplate": "docker",
       "packageNameTemplate": "ghcr.io/rackerlabs/understack/{{depName}}",


### PR DESCRIPTION
Fix the bad syntax in 50120fd4088d5 and narrow down the file match.