### PR TITLE
chore: we are making deploy changes so remove the finalizers

### DIFF
--- a/apps/appsets/appset-understack-infra.yaml
+++ b/apps/appsets/appset-understack-infra.yaml
@@ -3,9 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: understack-infra
-  finalizers:
-    # ensure applicationset is not deleted until its unreferenced
-    - resources-finalizer.argocd.argoproj.io
 spec:
   syncPolicy:
     applicationsSync: create-update

--- a/apps/appsets/appset-understack-operators.yaml
+++ b/apps/appsets/appset-understack-operators.yaml
@@ -3,9 +3,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: understack-operators
-  finalizers:
-    # ensure applicationset is not deleted until its unreferenced
-    - resources-finalizer.argocd.argoproj.io
 spec:
   syncPolicy:
     applicationsSync: create-update

--- a/apps/appsets/understack.yaml
+++ b/apps/appsets/understack.yaml
@@ -105,9 +105,6 @@ kind: ApplicationSet
 metadata:
   name: understack
   namespace: argocd
-  finalizers:
-    # ensure applicationset is not deleted until its unreferenced
-    - resources-finalizer.argocd.argoproj.io
 spec:
   syncPolicy:
     applicationsSync: create-update


### PR DESCRIPTION
These finalizers will delete Applications which isn't what we want as we move things around for deployment changes.