### PR TITLE
fix: allow outside dir files in kustomization.yaml

### DIFF
--- a/bootstrap/argocd/values.yaml
+++ b/bootstrap/argocd/values.yaml
@@ -19,7 +19,7 @@ configs:
   params:
     server.insecure: true
   cm:
-    kustomize.buildOptions: --enable-helm
+    kustomize.buildOptions: --enable-helm --load-restrictor LoadRestrictionsNone
     resource.exclusions: |
         - apiGroups:
           - cilium.io


### PR DESCRIPTION
fix to bypass Kustomize security restriction that prevents from referencing files outside of the directory containing kustomization.yaml.

There are few places where we need this for example to include [ansible inventory](https://github.com/RSS-Engineering/undercloud-deploy/blob/5af4f74813fe4710d0251cd24f422da0cda527a4/bravo-uc-iad3-dev/manifests/openstack/kustomization.yaml#L12) as config map so that we can volume mount.