### PR TITLE
feat: argocd: allow operators to control syncPolicy

### DIFF
--- a/apps/aio-app-of-apps.yaml
+++ b/apps/aio-app-of-apps.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   syncPolicy:
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/app-of-apps.yaml
+++ b/apps/app-of-apps.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   syncPolicy:
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-global.yaml
+++ b/apps/appsets/appset-understack-global.yaml
@@ -8,6 +8,11 @@ spec:
     applicationsSync: create-update
     # for infrastructure resources we don't want to delete things automatically
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-infra.yaml
+++ b/apps/appsets/appset-understack-infra.yaml
@@ -8,6 +8,11 @@ spec:
     applicationsSync: create-update
     # for infrastructure resources we don't want to delete things automatically
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-openstack.yaml
+++ b/apps/appsets/appset-understack-openstack.yaml
@@ -8,6 +8,11 @@ spec:
     applicationsSync: create-update
     # for infrastructure resources we don't want to delete things automatically
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-operators.yaml
+++ b/apps/appsets/appset-understack-operators.yaml
@@ -8,6 +8,11 @@ spec:
     applicationsSync: create-update
     # for infrastructure resources we don't want to delete things automatically
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-site.yaml
+++ b/apps/appsets/appset-understack-site.yaml
@@ -8,6 +8,11 @@ spec:
     applicationsSync: create-update
     # for infrastructure resources we don't want to delete things automatically
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/argocd/appset-argocd.yaml
+++ b/apps/appsets/argocd/appset-argocd.yaml
@@ -6,6 +6,11 @@ spec:
   syncPolicy:
     applicationsSync: create-update
     preserveResourcesOnDeletion: true
+  ignoreApplicationDifferences:
+    - jsonPointers:
+      # Allow temporarily disabling auto-sync for troubleshooting
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
+      - /spec/syncPolicy
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:


### PR DESCRIPTION
This is a followup to https://github.com/pvceng-sre/argocd-infra/pull/65

The aim is to allow operators to temporarily pause the automated synchronization for particular apps to facilitate debugging, migrations and similar.

ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync