### PR TITLE
feat(neutron-understack): add L3 router example plugins

### DIFF
--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -83,7 +83,12 @@ conf:
       # add 50 to the max MTU we want of 9000 to handle Neutron's -50 for VXLAN type
       global_physnet_mtu: 9050
     service_providers:
-      service_provider: "L3_ROUTER_NAT:cisco-asa:neutron_understack.l3_service_cisco_asa.CiscoAsa"
+      service_provider:
+        type: multistring
+        values:
+          - "L3_ROUTER_NAT:cisco-asa:neutron_understack.l3_router.cisco_asa.CiscoAsa"
+          - "L3_ROUTER_NAT:palo-alto:neutron_understack.l3_router.palo_alto.PaloAlto"
+          - "L3_ROUTER_NAT:vrf:neutron_understack.l3_router.vrf.Vrf"
     ovn:
       # the ovn-metadata-agent utilizes 'localport' on each hypervisor in OVS to work, since
       # we don't have an OVS that the baremetal nodes are plugged into we can't have this

--- a/python/neutron-understack/neutron_understack/l3_router/cisco_asa.py
+++ b/python/neutron-understack/neutron_understack/l3_router/cisco_asa.py
@@ -1,0 +1,5 @@
+from neutron.services.ovn_l3.service_providers.user_defined import UserDefined
+
+
+class CiscoAsa(UserDefined):
+    pass

--- a/python/neutron-understack/neutron_understack/l3_router/palo_alto.py
+++ b/python/neutron-understack/neutron_understack/l3_router/palo_alto.py
@@ -1,0 +1,5 @@
+from neutron.services.ovn_l3.service_providers.user_defined import UserDefined
+
+
+class PaloAlto(UserDefined):
+    pass

--- a/python/neutron-understack/neutron_understack/l3_router/vrf.py
+++ b/python/neutron-understack/neutron_understack/l3_router/vrf.py
@@ -1,0 +1,5 @@
+from neutron.services.ovn_l3.service_providers.user_defined import UserDefined
+
+
+class Vrf(UserDefined):
+    pass


### PR DESCRIPTION
These plugins serve the purpose of being able to be loaded and be used for conversations around different router backend implementations. The networking design doc references these plugins in its examples.