### PR TITLE
fix: attempt to update understack container matching for renovate

### DIFF
--- a/.github/renovate/understackContainerMatch.json
+++ b/.github/renovate/understackContainerMatch.json
@@ -5,12 +5,10 @@
       "customType": "regex",
       "fileMatch": ["(^|/)images-openstack\\.ya?ml$"],
       "matchStrings": [
-        "ghcr\\.io/rackerlabs/understack/(?<depName>[\\w-]+):(?<currentValue>[\\w.-]+)"
+        "ghcr\\.io/rackerlabs/(?<depName>understack/[\\w\\-]+):(?<currentValue>v[\\d\\.]+)"
       ],
       "datasourceTemplate": "docker",
-      "packageNameTemplate": "ghcr.io/rackerlabs/understack/{{depName}}",
-      "versioningTemplate": "semver",
-      "extractVersionTemplate": "{{currentValue}}"
+      "packageNameTemplate": "ghcr.io/rackerlabs/{{depName}}"
     }
   ]
 }


### PR DESCRIPTION
Update to include understack/ in the depName match. Adjust the currentVersion to only take things prefixed with v followed by numbers. Drop the versioningTemplate since docker tags are not semver but renovate should use the correct default.