### PR TITLE
feat: further group understack containers together in updates

### DIFF
--- a/.github/renovate/understackContainerMatch.json
+++ b/.github/renovate/understackContainerMatch.json
@@ -10,5 +10,11 @@
       "datasourceTemplate": "docker",
       "packageNameTemplate": "ghcr.io/rackerlabs/{{depName}}"
     }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["ghcr.io/rackerlabs/understack/**"],
+      "groupName": "understack"
+    }
   ]
 }


### PR DESCRIPTION
Rather than treating each understack container separately in renovate, let's group them all together under the understack umbrella.