### PR TITLE
device_type data provided as volume mount

### DIFF
--- a/ansible/roles/device_types/tasks/console_ports.yml
+++ b/ansible/roles/device_types/tasks/console_ports.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Create device type console port templates
+  networktocode.nautobot.console_port_template:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    device_type: "{{ device_type_item.model }}"
+    name: "{{ console_port_item.name }}"
+    type: "{{ console_port_item.type }}"
+    state: present

--- a/ansible/roles/device_types/tasks/device_types.yml
+++ b/ansible/roles/device_types/tasks/device_types.yml
@@ -1,0 +1,37 @@
+---
+- name: Create default device types
+  networktocode.nautobot.device_type:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    model: "{{ device_type_item.model }}"
+    manufacturer: "{{ device_type_item.manufacturer }}"
+    u_height: "{{ device_type_item.u_height }}"
+    is_full_depth: "{{ device_type_item.is_full_depth }}"
+    part_number: "{{ device_type_item.part_number | default('') }}"
+    comments: "{{ device_type_item.comments | default('') }}"
+    subdevice_role: "parent"  # need to set subdevice_role=parent to allow device bays to be attached
+    state: present
+
+- name: Loop through interfaces and add them
+  ansible.builtin.include_tasks: interfaces.yml
+  loop: "{{ device_type_item.interfaces | default('[]') }}"
+  loop_control:
+    loop_var: interface_item
+
+- name: Loop through console ports and add them
+  ansible.builtin.include_tasks: console_ports.yml
+  loop: "{{ device_type_item['console-ports'] | default('[]') }}"
+  loop_control:
+    loop_var: console_port_item
+
+- name: Loop through module bays and add them
+  ansible.builtin.include_tasks: module_bays.yml
+  loop: "{{ device_type_item['module-bays'] | default('[]') }}"
+  loop_control:
+    loop_var: module_bay_item
+
+- name: Loop through power ports and add them
+  ansible.builtin.include_tasks: power_ports.yml
+  loop: "{{ device_type_item['power-ports'] | default('[]') }}"
+  loop_control:
+    loop_var: power_port_item

--- a/ansible/roles/device_types/tasks/interfaces.yml
+++ b/ansible/roles/device_types/tasks/interfaces.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Create device type interface templates
+  networktocode.nautobot.device_interface_template:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    device_type: "{{ device_type_item.model }}"
+    name: "{{ interface_item.name }}"
+    type: "{{ interface_item.type }}"
+    mgmt_only: "{{ interface_item.mgmt_only | default('false') }}"
+    state: present

--- a/ansible/roles/device_types/tasks/main.yml
+++ b/ansible/roles/device_types/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# Device Types repo: https://github.com/RSS-Engineering/undercloud-nautobot-device-types
+
+- name: Collect device types from undercloud-nautobot-device-types repo
+  ansible.builtin.set_fact:
+    device_types_data: "{{ device_types_data | d([]) + [lookup('file', item.src) | from_yaml] }}"
+  with_community.general.filetree: "/repo/device-types/"
+  when: item.state == "file"
+  check_mode: false
+
+- name: Sync manufacturers
+  networktocode.nautobot.manufacturer:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    name: "{{ item }}"
+    description: "{{ item }}"
+    state: present
+  loop: "{{ device_types_data | community.general.json_query('[*].manufacturer') | unique }}"
+
+- name: Loop through device types
+  ansible.builtin.include_tasks: device_types.yml
+  loop: "{{ device_types_data }}"
+  loop_control:
+    loop_var: device_type_item

--- a/ansible/roles/device_types/tasks/module_bays.yml
+++ b/ansible/roles/device_types/tasks/module_bays.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Create device type module bay templates
+  networktocode.nautobot.device_bay_template:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    device_type: "{{ device_type_item.model }}"
+    name: "{{ module_bay_item.name }}"
+    state: present

--- a/ansible/roles/device_types/tasks/power_ports.yml
+++ b/ansible/roles/device_types/tasks/power_ports.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Create device type power port templates
+  networktocode.nautobot.power_port_template:
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    device_type: "{{ device_type_item.model }}"
+    name: "{{ power_port_item.name }}"
+    allocated_draw: "{{ power_port_item.allocated_draw | default(1) }}"
+    maximum_draw: "{{ power_port_item.maximum_draw | default(1) }}"
+    type: "{{ power_port_item.type }}"
+    state: present

--- a/components/nautobot/kustomization.yaml
+++ b/components/nautobot/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - cloudnative-postgres-nautobot.yaml
   - secretstore-nautobot.yaml
   - external-secret-nautobot-sso.yaml
+  - device-sync-job.yaml
 
 configMapGenerator:
   - name: nautobot-sso


### PR DESCRIPTION
Providing [nautobot-device-types-repo](https://github.com/RSS-Engineering/undercloud-nautobot-device-types) as volume.

Previously we were doing this way https://github.com/RSS-Engineering/undercloud-rackspace/blob/main/ansible/roles/device_types/tasks/main.yml#L4-L45
