### PR TITLE
feat: Adds prometheus monitoring for rabbitmq operator and clusters

### DIFF
--- a/operators/rabbitmq-system/kustomization.yaml
+++ b/operators/rabbitmq-system/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - cluster-operator/
 - messaging-topology/
+- monitoring/

--- a/operators/rabbitmq-system/monitoring/kustomization.yaml
+++ b/operators/rabbitmq-system/monitoring/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rabbitmq-system
+
+resources:
+  - rabbitmq-servicemonitor.yml
+  - rabbitmq-cluster-operator-podmonitor.yml
+  - ./rules/rabbitmq-per-object/queue-is-growing.yml
+  - ./rules/rabbitmq-per-object/queue-has-no-consumers.yml
+  - ./rules/rabbitmq/container-restarts.yml
+  - ./rules/rabbitmq/high-connection-churn.yml
+  - ./rules/rabbitmq/file-descriptors-near-limit.yml
+  - ./rules/rabbitmq/low-disk-watermark-predicted.yml
+  - ./rules/rabbitmq/unroutable-messages.yml
+  - ./rules/rabbitmq/recording-rules.yml
+  - ./rules/rabbitmq/no-majority-of-nodes-ready.yml
+  - ./rules/rabbitmq/cluster-alarms.yml
+  - ./rules/rabbitmq/insufficient-established-erlang-distribution-links.yml
+  - ./rules/rabbitmq/persistent-volume-missing.yml
+  - ./rules/rabbitmq/tcp-sockets-near-limit.yml
+  - ./rules/rabbitmq-cluster-operator/unavailable-replicas.yml

--- a/operators/rabbitmq-system/monitoring/rabbitmq-cluster-operator-podmonitor.yml
+++ b/operators/rabbitmq-system/monitoring/rabbitmq-cluster-operator-podmonitor.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: rabbitmq-cluster-operator
+  namespace: rabbitmq-system
+  # If labels are defined in spec.podMonitorSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rabbitmq-operator
+  namespaceSelector:
+    matchNames:
+    - rabbitmq-system

--- a/operators/rabbitmq-system/monitoring/rabbitmq-servicemonitor.yml
+++ b/operators/rabbitmq-system/monitoring/rabbitmq-servicemonitor.yml
@@ -1,0 +1,49 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rabbitmq
+  namespace: rabbitmq-system
+  # If labels are defined in spec.serviceMonitorSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+spec:
+  endpoints:
+  - port: prometheus
+    scheme: http
+    interval: 15s
+    scrapeTimeout: 14s
+  - port: prometheus-tls
+    scheme: https
+    interval: 15s
+    scrapeTimeout: 14s
+    tlsConfig:
+      insecureSkipVerify: true # set to false and uncomment lines below to enable tls verification
+        # ca:
+        #   secret:
+        #     key: ca.crt
+        #     name: tls-secret # name of the secret containing the CA cert which signed the RabbitMQ Prometheus TLS cert
+        # serverName: '*.RABBITMQ-INSTANCE-NAME.NAMESPACE.svc.cluster.local'
+  - port: prometheus
+    scheme: http
+    path: /metrics/detailed
+    params:
+      family:
+        - queue_coarse_metrics
+        - queue_metrics
+    interval: 15s
+    scrapeTimeout: 14s
+  - port: prometheus-tls
+    scheme: https
+    path: /metrics/detailed
+    params:
+      family:
+        - queue_coarse_metrics
+        - queue_metrics
+    interval: 15s
+    scrapeTimeout: 14s
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: rabbitmq
+  namespaceSelector:
+    any: true

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq-cluster-operator/unavailable-replicas.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq-cluster-operator/unavailable-replicas.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-cluster-operator-unavailable-replicas
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq-cluster-operator
+    rules:
+    - alert: RabbitMQClusterOperatorUnavailableReplicas
+      expr: |
+        kube_deployment_status_replicas_unavailable{deployment="rabbitmq-cluster-operator"}
+        >
+        0
+      for: 5m
+      annotations:
+        description: |
+          `{{ $value }}` replicas are unavailable in Deployment `rabbitmq-cluster-operator`
+          in namespace `{{ $labels.namespace }}`.
+        summary: |
+          There are pods that are either running but not yet available or pods that still have not been created.
+          Check the status of the deployment: `kubectl -n {{ $labels.namespace }} describe deployment rabbitmq-cluster-operator`
+          Check the status of the pod: `kubectl -n {{ $labels.namespace }} describe pod -l app.kubernetes.io/component=rabbitmq-cluster-operator`
+      labels:
+        rulesgroup: rabbitmq-operator
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq-per-object/queue-has-no-consumers.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq-per-object/queue-has-no-consumers.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-queue-has-no-consumers
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: QueueHasNoConsumers
+      expr: |
+          (
+            ((rabbitmq_detailed_queue_consumers{vhost="/", queue=~".*"} == 0) + rabbitmq_detailed_queue_messages) > 0
+          ) * on (instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info
+      for: 10m
+      annotations:
+        description: |
+          Over the last 10 minutes, non-empty queue `{{ $labels.queue }}` with {{ $value }} messages
+          in virtual host `{{ $labels.vhost }}` didn't have any consumers in
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` in namespace `{{ $labels.namespace }}`.
+        summary: |
+          Messages are sitting idle in the queue, without any processing.
+          This alert is highly application specific (and e.g. doesn't make sense for stream queues).
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq-per-object/queue-is-growing.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq-per-object/queue-is-growing.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-queue-is-growing
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: QueueIsGrowing
+      # `> 1` because of floating point rounding errors
+      expr: |
+          (
+              avg_over_time(rabbitmq_detailed_queue_messages[10m]) - avg_over_time(rabbitmq_detailed_queue_messages[10m] offset 1m) > 1
+          ) * on (instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info
+      for: 10m
+      annotations:
+        description: |
+          Over the last 10 minutes, queue `{{ $labels.queue }}` in virtual host `{{ $labels.vhost }}`
+          was growing. 10 minute moving average has grown by {{ $value }}.
+          This happens in RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` in namespace `{{ $labels.namespace }}`.
+        summary: |
+          Queue size is steadily growing over time.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/cluster-alarms.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/cluster-alarms.yml
@@ -1,0 +1,60 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-cluster-alarms
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: MemoryAlarm
+      expr: |
+        max by(rabbitmq_cluster) (
+          max_over_time(rabbitmq_alarms_memory_used_watermark[5m])
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
+        ) > 0
+      keep_firing_for: 5m
+      annotations:
+        description: |
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` memory alarm active. Publishers are blocked.
+        summary: |
+          A RabbitMQ node reached the `vm_memory_high_watermark` threshold.
+          See https://www.rabbitmq.com/docs/alarms#overview, https://www.rabbitmq.com/docs/memory.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning
+    - alert: RabbitmqDiskAlarm
+      expr: |
+        max by(rabbitmq_cluster) (
+          max_over_time(rabbitmq_alarms_free_disk_space_watermark[5m])
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
+        ) > 0
+      keep_firing_for: 5m
+      annotations:
+        description: |
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` disk alarm active. Publishers are blocked.
+        summary: |
+          A RabbitMQ node reached the `disk_free_limit` threshold.
+          See https://www.rabbitmq.com/docs/alarms#overview, https://www.rabbitmq.com/docs/disk-alarms.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning
+    - alert: RabbitmqFileDescriptorAlarm
+      expr: |
+        max by(rabbitmq_cluster) (
+          max_over_time(rabbitmq_alarms_file_descriptor_limit[5m])
+          * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
+        ) > 0
+      keep_firing_for: 5m
+      annotations:
+        description: |
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` file descriptor alarm active. Publishers are blocked.
+        summary: |
+          A RabbitMQ node ran out of file descriptors.
+          See https://www.rabbitmq.com/docs/alarms#file-descriptors.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/container-restarts.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/container-restarts.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-container-restarts
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: ContainerRestarts
+      expr: |
+        increase(kube_pod_container_status_restarts_total[10m]) * on(namespace, pod, container) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
+        >=
+        1
+      for: 5m
+      annotations:
+        description: |
+          Over the last 10 minutes, container `{{ $labels.container }}`
+          restarted `{{ $value | printf "%.0f" }}` times in pod `{{ $labels.pod }}` of RabbitMQ cluster
+          `{{ $labels.rabbitmq_cluster }}` in namespace `{{ $labels.namespace }}`.
+        summary: |
+          Investigate why the container got restarted.
+          Check the logs of the current container: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
+          Check the logs of the previous container: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }} --previous`
+          Check the last state of the container: `kubectl -n {{ $labels.namespace }} get pod {{ $labels.pod }} -o jsonpath='{.status.containerStatuses[].lastState}'`
+      labels:
+        rabbitmq_cluster: '{{ $labels.rabbitmq_cluster }}'
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/file-descriptors-near-limit.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/file-descriptors-near-limit.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-file-descriptors-near-limit
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: FileDescriptorsNearLimit
+      expr: |
+        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (max_over_time(rabbitmq_process_open_fds[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster))
+        /
+        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (rabbitmq_process_max_fds  * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster))
+        > 0.8
+      for: 10m
+      annotations:
+        description: |
+          `{{ $value | humanizePercentage }}` file descriptors of file
+          descriptor limit are used in RabbitMQ node `{{ $labels.rabbitmq_node }}`,
+          pod `{{ $labels.pod }}`, RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}`,
+          namespace `{{ $labels.namespace }}`.
+        summary: |
+          More than 80% of file descriptors are used on the RabbitMQ node.
+          When this value reaches 100%, new connections will not be accepted and disk write operations may fail.
+          Client libraries, peer nodes and CLI tools will not be able to connect when the node runs out of available file descriptors.
+          See https://www.rabbitmq.com/production-checklist.html#resource-limits-file-handle-limit.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/high-connection-churn.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/high-connection-churn.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-high-connection-churn
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: HighConnectionChurn
+      expr: |
+        (
+          sum(rate(rabbitmq_connections_closed_total[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by(namespace, rabbitmq_cluster)
+          +
+          sum(rate(rabbitmq_connections_opened_total[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by(namespace, rabbitmq_cluster)
+        )
+        /
+        sum (rabbitmq_connections * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by (namespace, rabbitmq_cluster)
+        > 0.1
+        unless
+        sum (rabbitmq_connections * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) by (namespace, rabbitmq_cluster)
+        < 100
+      for: 10m
+      annotations:
+        description: |
+          Over the last 5 minutes, `{{ $value | humanizePercentage }}`
+          of total connections are closed or opened per second in RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}`
+          in namespace `{{ $labels.namespace }}`.
+        summary: |
+          More than 10% of total connections are churning.
+          This means that client application connections are short-lived instead of long-lived.
+          Read https://www.rabbitmq.com/connections.html#high-connection-churn to understand why this is an anti-pattern.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/insufficient-established-erlang-distribution-links.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/insufficient-established-erlang-distribution-links.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-insufficient-established-erlang-distribution-links
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: InsufficientEstablishedErlangDistributionLinks
+      # erlang_vm_dist_node_state: 1=pending, 2=up_pending, 3=up
+      expr: |
+        count by (namespace, rabbitmq_cluster) (erlang_vm_dist_node_state * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster) == 3)
+        <
+         count by (namespace, rabbitmq_cluster) (rabbitmq_build_info * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster))
+         *
+        (count by (namespace, rabbitmq_cluster) (rabbitmq_build_info * on(instance) group_left(rabbitmq_cluster) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)) -1 )
+      for: 10m
+      annotations:
+        description: |
+          There are only `{{ $value }}` established Erlang distribution links
+          in RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` in namespace `{{ $labels.namespace }}`.
+        summary: |
+          RabbitMQ clusters have a full mesh topology.
+          All RabbitMQ nodes connect to all other RabbitMQ nodes in both directions.
+          The expected number of established Erlang distribution links is therefore `n*(n-1)` where `n` is the number of RabbitMQ nodes in the cluster.
+          Therefore, the expected number of distribution links are `0` for a 1-node cluster, `6` for a 3-node cluster, and `20` for a 5-node cluster.
+          This alert reports that the number of established distributions links is less than the expected number.
+          Some reasons for this alert include failed network links, network partitions, failed clustering (i.e. nodes can't join the cluster).
+          Check the panels `All distribution links`, `Established distribution links`, `Connecting distributions links`, `Waiting distribution links`, and `distribution links`
+          of the Grafana dashboard `Erlang-Distribution`.
+          Check the logs of the RabbitMQ nodes: `kubectl -n {{ $labels.namespace }} logs -l app.kubernetes.io/component=rabbitmq,app.kubernetes.io/name={{ $labels.rabbitmq_cluster }}`
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/low-disk-watermark-predicted.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/low-disk-watermark-predicted.yml
@@ -1,0 +1,45 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-low-disk-watermark-predicted
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: LowDiskWatermarkPredicted
+      # The 2nd condition ensures that data points are available until 24 hours ago such that no false positive alerts are triggered for newly created RabbitMQ clusters.
+      expr: |
+        (
+          predict_linear(rabbitmq_disk_space_available_bytes[24h], 60*60*24) * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
+          <
+          rabbitmq_disk_space_available_limit_bytes * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
+        )
+        and
+        (
+          count_over_time(rabbitmq_disk_space_available_limit_bytes[2h] offset 22h) * on (instance, pod) group_left(rabbitmq_cluster, rabbitmq_node) max(rabbitmq_identity_info) by (namespace, pod, container, rabbitmq_cluster)
+          >
+          0
+        )
+      for: 60m
+      annotations:
+        description: |
+          The predicted free disk space in 24 hours from now is `{{ $value | humanize1024 }}B`
+          in RabbitMQ node `{{ $labels.rabbitmq_node }}`, pod `{{ $labels.pod }}`,
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}`, namespace `{{ $labels.namespace }}`.
+        summary: |
+          Based on the trend of available disk space over the past 24 hours, it's predicted that, in 24 hours from now, a disk alarm will be triggered since the free disk space will drop below the free disk space limit.
+          This alert is reported for the partition where the RabbitMQ data directory is stored.
+          When the disk alarm will be triggered, all publishing connections across all cluster nodes will be blocked.
+          See
+          https://www.rabbitmq.com/alarms.html,
+          https://www.rabbitmq.com/disk-alarms.html,
+          https://www.rabbitmq.com/production-checklist.html#resource-limits-disk-space,
+          https://www.rabbitmq.com/persistence-conf.html,
+          https://www.rabbitmq.com/connection-blocked.html.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/no-majority-of-nodes-ready.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/no-majority-of-nodes-ready.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-no-majority-of-nodes-ready
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: NoMajorityOfNodesReady
+      expr: |
+        kube_statefulset_status_replicas_ready * on (namespace, statefulset) group_left(label_app_kubernetes_io_name) kube_statefulset_labels{label_app_kubernetes_io_component="rabbitmq"}
+        <=
+        kube_statefulset_replicas              * on (namespace, statefulset) group_left(label_app_kubernetes_io_name) kube_statefulset_labels{label_app_kubernetes_io_component="rabbitmq"}
+        / 2
+        unless
+        kube_statefulset_replicas              * on (namespace, statefulset) group_left(label_app_kubernetes_io_name) kube_statefulset_labels{label_app_kubernetes_io_component="rabbitmq"}
+        == 0
+      for: 5m
+      annotations:
+        description: |
+          Only `{{ $value }}` replicas are ready in StatefulSet `{{ $labels.statefulset }}`
+          of RabbitMQ cluster `{{ $labels.label_app_kubernetes_io_name }}` in namespace `{{ $labels.namespace }}`.
+        summary: |
+          No majority of nodes have been ready for the last 5 minutes.
+          Check the details of the pods:
+          `kubectl -n {{ $labels.namespace }} describe pods -l app.kubernetes.io/component=rabbitmq,app.kubernetes.io/name={{ $labels.label_app_kubernetes_io_name }}`
+      labels:
+        rabbitmq_cluster: '{{ $labels.label_app_kubernetes_io_name }}'
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/persistent-volume-missing.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/persistent-volume-missing.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-persistent-volume-missing
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: PersistentVolumeMissing
+      expr: |
+        kube_persistentvolumeclaim_status_phase{phase="Bound"} * on (namespace, persistentvolumeclaim) group_left(label_app_kubernetes_io_name) kube_persistentvolumeclaim_labels{label_app_kubernetes_io_component="rabbitmq"}
+        ==
+        0
+      for: 10m
+      annotations:
+        description: |
+          PersistentVolumeClaim `{{ $labels.persistentvolumeclaim }}` of
+          RabbitMQ cluster `{{ $labels.label_app_kubernetes_io_name }}` in namespace
+          `{{ $labels.namespace }}` is not bound.
+        summary: |
+          RabbitMQ needs a PersistentVolume for its data.
+          However, there is no PersistentVolume bound to the PersistentVolumeClaim.
+          This means the requested storage could not be provisioned.
+          Check the status of the PersistentVolumeClaim: `kubectl -n {{ $labels.namespace }} describe pvc {{ $labels.persistentvolumeclaim }}`.
+      labels:
+        rabbitmq_cluster: '{{ $labels.label_app_kubernetes_io_name }}'
+        rulesgroup: rabbitmq
+        severity: critical

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/recording-rules.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/recording-rules.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-recording-rules
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    # The following 3 rules are needed to plot the status map panel in the RabbitMQ-Alerts Grafana dashboard.
+    # To understand why, read https://medium.com/flant-com/statusmap-grafana-plugin-to-visualize-status-over-time-fe6ced391853
+    rules:
+    # The first 2 rules create a metric ALERTS:rabbitmq_alert_state_numeric which has value 1 for alertstate pending and value 2 for alertstate firing
+    - expr: |
+        ALERTS{rulesgroup="rabbitmq", alertstate="pending"} * 0 + 1
+      record: ALERTS:rabbitmq_alert_state_numeric
+    - expr: |
+        ALERTS{rulesgroup="rabbitmq", alertstate="firing"} * 0 + 2
+      record: ALERTS:rabbitmq_alert_state_numeric
+      # The 3rd rule creates a metric ALERTS:rabbitmq_alert_state_discrete with label alert_state_numeric.
+      # The label value is either 1 for pending or 2 for firing.
+      # The metric value is binary: 1 means the alert is active in that state (pending or firing), 0 means there is no such alert in that state.
+    - expr: |
+        count_values
+        by (namespace, rabbitmq_cluster, alertname, severity, instance, endpoint, pod, container, persistentvolumeclaim)
+        ("alert_state_numeric", ALERTS:rabbitmq_alert_state_numeric)
+      record: ALERTS:rabbitmq_alert_state_discrete

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/tcp-sockets-near-limit.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/tcp-sockets-near-limit.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-tcp-sockets-near-limit
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: TCPSocketsNearLimit
+      expr: |
+        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (max_over_time(rabbitmq_process_open_tcp_sockets[5m]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info)
+        /
+        sum by(namespace, rabbitmq_cluster, pod, rabbitmq_node) (rabbitmq_process_max_tcp_sockets  * on(instance) group_left(rabbitmq_cluster, rabbitmq_node, pod) rabbitmq_identity_info)
+        > 0.8
+      for: 10m
+      annotations:
+        description: |
+          `{{ $value | humanizePercentage }}` TCP sockets of TCP socket
+          limit are open in RabbitMQ node `{{ $labels.rabbitmq_node }}`, pod `{{ $labels.pod }}`,
+          RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}`, namespace `{{ $labels.namespace }}`.
+        summary: |
+          More than 80% of TCP sockets are open on the RabbitMQ node.
+          When this value reaches 100%, new connections will not be accepted.
+          Client libraries, peer nodes and CLI tools will not be able to connect when the node runs out of available TCP sockets.
+          See https://www.rabbitmq.com/networking.html.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning

--- a/operators/rabbitmq-system/monitoring/rules/rabbitmq/unroutable-messages.yml
+++ b/operators/rabbitmq-system/monitoring/rules/rabbitmq/unroutable-messages.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-unroutable-messages
+  # If labels are defined in spec.ruleSelector.matchLabels of your deployed Prometheus object, make sure to include them here.
+  labels:
+    role: alert-rules
+spec:
+  groups:
+  - name: rabbitmq
+    rules:
+    - alert: UnroutableMessages
+      expr: |
+        sum by(namespace, rabbitmq_cluster) (increase(rabbitmq_channel_messages_unroutable_dropped_total[5m]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info)
+        >= 1
+        or
+        sum by(namespace, rabbitmq_cluster) (increase(rabbitmq_channel_messages_unroutable_returned_total[5m]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info)
+        >= 1
+      annotations:
+        description: |
+          There were `{{ $value | printf "%.0f" }}` unroutable messages within the last
+          5 minutes in RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` in namespace
+          `{{ $labels.namespace }}`.
+        summary: |
+          There are messages published into an exchange which cannot be routed and are either dropped silently, or returned to publishers.
+          Is your routing topology set up correctly?
+          Check your application code and bindings between exchanges and queues.
+          See
+          https://www.rabbitmq.com/publishers.html#unroutable,
+          https://www.rabbitmq.com/confirms.html#when-publishes-are-confirmed.
+      labels:
+        rulesgroup: rabbitmq
+        severity: warning


### PR DESCRIPTION
We aren't using the rabbitmq-operator helm chart currently so I've copied the upstream rabbitmq monitoring manifests in from:

* https://www.rabbitmq.com/kubernetes/operator/operator-monitoring
* https://github.com/rabbitmq/cluster-operator/tree/main/observability/prometheus
