### PR TITLE
chore: fix up renovate rules for OpenStack Helm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
   "extends": [
     "github>rackerlabs/understack//.github/renovate/default",
     "github>rackerlabs/understack//.github/renovate/nautobot",
-    "github>rackerlabs/understack//.github/renovate/understackContainerMatch"
+    "github>rackerlabs/understack//.github/renovate/understackContainerMatch",
+    "github>rackerlabs/understack//.github/renovate/matchOpenStackHelm"
   ],
   "packageRules": [
     {
@@ -16,16 +17,6 @@
     }
   ],
   "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/apps/appsets/openstack.yaml$/"
-      ],
-      "matchStrings": [
-        "\\s- component: (?<depName>.+)\\n\\s+repoURL: (?<packageName>.+)\\n\\s+chartVersion: (?<currentValue>.+)\\s"
-      ],
-      "datasourceTemplate": "helm"
-    },
     {
       "customType": "regex",
       "managerFilePatterns": [

--- a/.github/renovate/matchOpenStackHelm.json
+++ b/.github/renovate/matchOpenStackHelm.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/apps/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "['\"]?component:\\s['\"]?(?<depName>)['\"]?\\s*(?:repoUrl:\\s['\"]?(?<repoUrl>.*?)?['\"]\\s*chartVersion:\\s['\"]?(?<currentValue>.*?)['\"]?"
+      ],
+      "datasourceTemplate": "helm",
+      "registryUrlTemplate": "{{#if repoUrl }}{{repoUrl}}{{else}}https://tarballs.opendev.org/openstack/openstack-helm{{/if}}",
+      "packageNameTemplate": "openstack-helm/{{depName}}",
+      "versioningTemplate": "helm"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["openstack-helm/**"],
+      "groupName": "openstack-helm"
+    }
+  ]
+}


### PR DESCRIPTION
Updated the renovate rules and moved them to their own file to detect the Helm chart changes in the OpenStack Helm project.