### PR TITLE
chore(argocd): remove finalizer on openstack components

### DIFF
--- a/apps/appsets/openstack.yaml
+++ b/apps/appsets/openstack.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openstack
 spec:
   syncPolicy:
+    preserveResourcesOnDeletion: true
     applicationsSync: create-update
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]


### PR DESCRIPTION
This should have been part of 4a28a9163ab2. We are making changes to the deployment and have seen that not preserving the resources and letting ArgoCD set the finalizer causes it to delete the application and re-create it on changes. We really don't want that and just want to upgrade in place.