### PR TITLE
fix: keystone SSO group mappings were too broad

### DIFF
--- a/ansible/roles/keystone_bootstrap/defaults/main.yml
+++ b/ansible/roles/keystone_bootstrap/defaults/main.yml
@@ -4,18 +4,44 @@ keystone_bootstrap_dex_url: "{{ dex_url | default('https://dex.' + lookup('ansib
 keystone_bootstrap_groups:
   - name: ucadmin
     desc: 'Users Federated with Admin'
-    roles:
-      - member
-      - admin
+    domain_roles:
+      # grants admin role to the infra domain and child projects like baremetal
+      # this is for full access in ironic
+      - domain: infra
+        role: admin
+        inherited: true
+      # grants member role to the infra domain and child projects like baremetal
+      # this allows manipulating resources like images and networks for ironic usage
+      - domain: infra
+        role: member
+        inherited: true
+      # grants manager role to the default domain so that projects can be created
+      - domain: default
+        role: manager
+      # grants member role to the default domain and child projects where normal tenants live
+      # TODO: remove this because admins might not be the same people touching tenants
+      - domain: default
+        role: member
+        inherited: true
   - name: ucuser
     desc: 'Regular Federated Users'
-    roles:
-      - member
+    domain_roles:
+      # grants member role to the default domain and child projects where normal tenants live
+      - domain: default
+        role: member
+        inherited: true
   - name: ucneteng
     desc: 'Federated Network Engineers'
-    roles:
-      - member
+    domain_roles:
+      # grants member role to the default domain and child projects where normal tenants live
+      - domain: default
+        role: member
+        inherited: true
   - name: ucdctech
     desc: 'Federated DC Technicians'
-    roles:
-      - member
+    domain_roles:
+      # grants member role to the infra domain and child projects like baremetal
+      # this allows manipulating resources like images and networks for ironic usage
+      - domain: infra
+        role: member
+        inherited: true

--- a/ansible/roles/keystone_bootstrap/tasks/sso.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/sso.yml
@@ -57,10 +57,7 @@
     mapping: sso_mapping
 
 - name: Create federated group mappings
-  ansible.builtin.include_tasks: sso_member_groups.yml
+  ansible.builtin.include_tasks: sso_groups.yml
   loop: "{{ keystone_bootstrap_groups }}"
-
-- name: Grant admin for groups
-  ansible.builtin.include_tasks: sso_role_admin.yml
-  loop:
-    - ucadmin
+  loop_control:
+    loop_var: group_item

--- a/ansible/roles/keystone_bootstrap/tasks/sso_domain_role.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/sso_domain_role.yml
@@ -12,17 +12,16 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
-- name: Create group
-  openstack.cloud.identity_group:
-    name: "{{ item.name }}"
-    domain_id: "{{ _domain_sso.domain.id }}"
-    description: "{{ item.desc }}"
-    state: present
-  register: _group
+#
 
 # role assignment module is lacking inherited and cross domain assignments
-- name: Assign member access
-  ansible.builtin.command: openstack role add --group "{{ _group.group.id }}" --domain default --inherited member
+# so need to do this manually
+- name: Assign role to group for domain
+  ansible.builtin.command: >
+    openstack role add --group "{{ group_id }}" --domain "{{ role_item.domain }}"
+    {% if role_item.inherited | default(false) | bool %}
+    --inherited
+    {% endif %}
+    "{{ role_item.role }}"
   when: dont_set_roles is not defined
   changed_when: false

--- a/ansible/roles/keystone_bootstrap/tasks/sso_groups.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/sso_groups.yml
@@ -12,20 +12,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-#
-- name: Find group
-  openstack.cloud.identity_group_info:
-    name: "{{ item }}"
-    domain: "{{ _domain_sso.domain.id }}"
+
+- name: Create group
+  openstack.cloud.identity_group:
+    name: "{{ group_item.name }}"
+    domain_id: "{{ _domain_sso.domain.id }}"
+    description: "{{ group_item.desc }}"
+    state: present
+  register: _group
 
 # role assignment module is lacking inherited and cross domain assignments
-- name: Assign member access
-  ansible.builtin.command: openstack role add --group "{{ _group.group.id }}" --domain default --inherited admin
-  when: dont_set_roles is not defined
-  changed_when: false
-
-# role assignment module is lacking inherited and cross domain assignments
-- name: Assign member access
-  ansible.builtin.command: openstack role add --group "{{ _group.group.id }}" --domain infra --inherited admin
-  when: dont_set_roles is not defined
-  changed_when: false
+# so need to do this manually done
+- name: Assign role to group for domain
+  ansible.builtin.include_tasks: sso_domain_role.yml
+  loop: "{{ group_item.domain_roles }}"
+  loop_control:
+    loop_var: role_item
+  vars:
+    group_id: "{{ _group.group.id }}"


### PR DESCRIPTION
The group mappings to permission roles inside of keystone were too broad and too much admin was applied. This scales it back to more of the permissions that are necessary. This also changes it so that a variable is used and can be defined to override these defaults in different deployment scenarios.