### PR TITLE
feat: run inspection on enroll

### DIFF
--- a/components/images-openstack.yaml
+++ b/components/images-openstack.yaml
@@ -22,12 +22,12 @@ images:
     keystone_fernet_setup: "ghcr.io/rackerlabs/understack/keystone:2024.2-ubuntu_jammy"
 
     # ironic
-    ironic_api: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
-    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
-    ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
-    ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
+    ironic_api: "ghcr.io/rackerlabs/understack/ironic:pr-973"
+    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:pr-973"
+    ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:pr-973"
+    ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:pr-973"
     ironic_pxe_http: "docker.io/nginx:1.13.3"
-    ironic_db_sync: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
+    ironic_db_sync: "ghcr.io/rackerlabs/understack/ironic:pr-973"
     # these want curl which apparently is in the heat image
     ironic_manage_cleaning_network: "docker.io/openstackhelm/heat:2024.2-ubuntu_jammy"
     ironic_retrive_cleaning_network: "docker.io/openstackhelm/heat:2024.2-ubuntu_jammy"

--- a/components/images-openstack.yaml
+++ b/components/images-openstack.yaml
@@ -22,12 +22,12 @@ images:
     keystone_fernet_setup: "ghcr.io/rackerlabs/understack/keystone:2024.2-ubuntu_jammy"
 
     # ironic
-    ironic_api: "ghcr.io/rackerlabs/understack/ironic:pr-973"
-    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:pr-973"
-    ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:pr-973"
-    ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:pr-973"
+    ironic_api: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
+    ironic_conductor: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
+    ironic_pxe: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
+    ironic_pxe_init: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
     ironic_pxe_http: "docker.io/nginx:1.13.3"
-    ironic_db_sync: "ghcr.io/rackerlabs/understack/ironic:pr-973"
+    ironic_db_sync: "ghcr.io/rackerlabs/understack/ironic:2024.2-ubuntu_jammy"
     # these want curl which apparently is in the heat image
     ironic_manage_cleaning_network: "docker.io/openstackhelm/heat:2024.2-ubuntu_jammy"
     ironic_retrive_cleaning_network: "docker.io/openstackhelm/heat:2024.2-ubuntu_jammy"

--- a/containers/ironic/Dockerfile.ironic
+++ b/containers/ironic/Dockerfile.ironic
@@ -7,8 +7,13 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         genisoimage \
         isolinux \
+        patch \
+        quilt \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+COPY containers/ironic/patches /tmp/patches/
 COPY python/ironic-understack /tmp/ironic-understack
 COPY python/understack-flavor-matcher /tmp/understack-flavor-matcher
 RUN /var/lib/openstack/bin/python -m pip install --no-cache --no-cache-dir /tmp/ironic-understack /tmp/understack-flavor-matcher sushy-oem-idrac==6.0.0
+RUN cd /var/lib/openstack/lib/python3.10/site-packages && \
+    QUILT_PATCHES=/tmp/patches quilt push -a

--- a/containers/ironic/patches/0001_use_update_pxe_enabled_conf.patch
+++ b/containers/ironic/patches/0001_use_update_pxe_enabled_conf.patch
@@ -1,0 +1,82 @@
+From a13ed324b1e9bbd42715a6573a5797f7e08d2d61 Mon Sep 17 00:00:00 2001
+From: haseeb <syedhaseebahmed12@gmail.com>
+Date: Wed, 28 May 2025 10:51:18 +0000
+Subject: [PATCH] Control port updates with update_pxe_enabled flag
+
+The [inspector]update_pxe_enabled configuration option controls
+whether the pxe_enabled field of a Port is updated during node
+inspection. This patch adds logic to honor that setting.
+
+Change-Id: I3e28e439b386c9f73e377b62513346bcadbd56b2
+(cherry picked from commit 5a9efa070cf7fae80cd53c506e3b370a55b4a501)
+(cherry picked from commit b476c1bc27a4f3a66c7c1c8264c0ff9c77ddedf4)
+---
+
+diff --git a/ironic/drivers/modules/redfish/inspect.py b/ironic/drivers/modules/redfish/inspect.py
+index 9dd418c..754599a 100644
+--- a/ironic/drivers/modules/redfish/inspect.py
++++ b/ironic/drivers/modules/redfish/inspect.py
+@@ -22,6 +22,7 @@
+ from ironic.common.i18n import _
+ from ironic.common import states
+ from ironic.common import utils
++from ironic.conf import CONF
+ from ironic.drivers import base
+ from ironic.drivers.modules import inspect_utils
+ from ironic.drivers.modules.redfish import utils as redfish_utils
+@@ -183,7 +184,7 @@
+         if pxe_port_macs is None:
+             LOG.warning("No PXE enabled NIC was found for node "
+                         "%(node_uuid)s.", {'node_uuid': task.node.uuid})
+-        else:
++        elif CONF.inspector.update_pxe_enabled:
+             pxe_port_macs = [macs.lower() for macs in pxe_port_macs]
+ 
+             ports = objects.Port.list_by_node_id(task.context, task.node.id)
+diff --git a/ironic/tests/unit/drivers/modules/redfish/test_inspect.py b/ironic/tests/unit/drivers/modules/redfish/test_inspect.py
+index 68de7c0..d235ccb 100644
+--- a/ironic/tests/unit/drivers/modules/redfish/test_inspect.py
++++ b/ironic/tests/unit/drivers/modules/redfish/test_inspect.py
+@@ -475,6 +475,29 @@
+             port = mock_list_by_node_id.return_value
+             self.assertFalse(port[0].pxe_enabled)
+ 
++    @mock.patch.object(objects.Port, 'list_by_node_id') # noqa
++    @mock.patch.object(redfish_utils, 'get_system', autospec=True)
++    def test_inspect_hardware_with_conf_update_pxe_disabled_false(
++            self, mock_get_system, mock_list_by_node_id):
++        self.init_system_mock(mock_get_system.return_value)
++
++        pxe_enabled_port = obj_utils.create_test_port(
++            self.context, uuid=self.node.uuid,
++            node_id=self.node.id, address='24:6E:96:70:49:01',
++            pxe_enabled=True)
++        mock_list_by_node_id.return_value = [pxe_enabled_port]
++
++        self.config(update_pxe_enabled=False, group='inspector')
++
++        with task_manager.acquire(self.context, self.node.uuid,
++                                  shared=True) as task:
++            task.driver.inspect._get_pxe_port_macs = mock.Mock()
++            task.driver.inspect._get_pxe_port_macs.return_value = \
++                ['24:6E:96:70:49:00']
++            task.driver.inspect.inspect_hardware(task)
++            port = mock_list_by_node_id.return_value
++            self.assertTrue(port[0].pxe_enabled)
++
+     @mock.patch.object(redfish_utils, 'get_system', autospec=True)
+     def test_inspect_hardware_with_no_mac(self, mock_get_system):
+         self.init_system_mock(mock_get_system.return_value)
+diff --git a/releasenotes/notes/control-pxe-enabled-field-inspection-206f67c6638a0bdb.yaml b/releasenotes/notes/control-pxe-enabled-field-inspection-206f67c6638a0bdb.yaml
+new file mode 100644
+index 0000000..12eb499
+--- /dev/null
++++ b/releasenotes/notes/control-pxe-enabled-field-inspection-206f67c6638a0bdb.yaml
+@@ -0,0 +1,7 @@
++---
++fixes:
++  - |
++    In the redfish inspector, use condition to control whether the pxe_enabled field of a port is updated during inspection.
++    [inspector]update_pxe_enabled is used to control this so it behaves like all other inspection interfaces.
++    The default value for this configuration is True.
++

--- a/containers/ironic/patches/series
+++ b/containers/ironic/patches/series
@@ -1,0 +1,1 @@
+0001_use_update_pxe_enabled_conf.patch

--- a/workflows/argo-events/workflowtemplates/enroll-server.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-server.yaml
@@ -32,6 +32,20 @@ spec:
                 - name: device_id
                   value: "{{steps.enroll-server.outputs.result}}"
             when: "{{steps.server-enroll-state.outputs.result}} == enroll"
+        - - name: server-manage-state-for-inspect
+            template: openstack-state-cmd
+            arguments:
+              parameters:
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
+        - - name: redfish-inspect
+            template: openstack-wait-cmd
+            arguments:
+              parameters:
+                - name: operation
+                  value: "inspect"
+                - name: device_id
+                  value: "{{steps.enroll-server.outputs.result}}"
         - - name: openstack-set-baremetal-node-raid-config
             template: openstack-set-baremetal-node-raid-config
             arguments:


### PR DESCRIPTION
this fix also contains patch https://review.opendev.org/c/openstack/ironic/+/951716 for using update_pxe_enabled flag to enable/disable port updation while inspect. In our case we disable it which is done in [https://github.com/RSS-Engineering/undercloud-deploy/pull/350](https://github.com/RSS-Engineering/undercloud-deploy/pull/350)