### PR TITLE
fix: use openvswitch dpdk image which contains needed packages

### DIFF
--- a/components/images-openstack.yaml
+++ b/components/images-openstack.yaml
@@ -68,8 +68,8 @@ images:
     placement_db_sync: "docker.io/openstackhelm/placement:2024.2-ubuntu_jammy"
 
     # openvswitch
-    openvswitch_db_server: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-20250111"
-    openvswitch_vswitchd: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-20250111"
+    openvswitch_db_server: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-dpdk-20250111"
+    openvswitch_vswitchd: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-dpdk-20250111"
 
     # ovn
     ovn_ovsdb_nb: "docker.io/openstackhelm/ovn:ubuntu_jammy-20250111"


### PR DESCRIPTION
There are two similar openvswitch images being build upstream by openstack: https://opendev.org/openstack/openstack-helm-images/src/branch/master/openvswitch

The ubuntu-jammy image we were using only has the openvswitch-switch package, but the dpdk image includes some additional packages and useful tools, such as iproute2 which contains a required tool `ip` used by openstack-helm init containers and scripts.
