### PR TITLE
fix(argocd): deploy as early as possible and don't override upstream resource.exclusions

### DIFF
--- a/apps/appsets/argocd/appset-argocd.yaml
+++ b/apps/appsets/argocd/appset-argocd.yaml
@@ -17,6 +17,9 @@ spec:
   template:
     metadata:
       name: '{{.name}}-argocd'
+      annotations:
+        # we want ArgoCD itself to sync as early as possible
+        argocd.argoproj.io/sync-wave: "-1000"
     spec:
       project: default
       sources:

--- a/bootstrap/argocd/values.yaml
+++ b/bootstrap/argocd/values.yaml
@@ -20,13 +20,6 @@ configs:
     server.insecure: true
   cm:
     kustomize.buildOptions: --enable-helm --load-restrictor LoadRestrictionsNone
-    resource.exclusions: |
-        - apiGroups:
-          - cilium.io
-          kinds:
-          - CiliumIdentity
-          clusters:
-          - "*"
   rbac:
     policy.csv: |
       # role:ucadmin can sync applications


### PR DESCRIPTION
Upstream has created a broader list of resource.exclusions that should be included. It already includes the one we default along with some others which we currently don't so drop our override to use the upstream one. Set ArgoCD to deploy as early as possible.