### PR TITLE
chore: upgrade OpenStack Helm's Open vSwitch chart to 2025.1.0

### DIFF
--- a/apps/openstack/openvswitch.yaml
+++ b/apps/openstack/openvswitch.yaml
@@ -1,4 +1,4 @@
 ---
 component: openvswitch
-repoURL: https://tarballs.opendev.org/openstack/openstack-helm-infra
-chartVersion: 2024.2.0
+repoURL: https://tarballs.opendev.org/openstack/openstack-helm
+chartVersion: 2025.1.0


### PR DESCRIPTION
OpenStack Helm moved this chart to their main repo so we need to update the repoURL when moving to the new version which is why renovate bot didn't see it.