### PR TITLE
fix(openstack): bump open vswitch container for 45d55d30830

### DIFF
--- a/components/images-openstack.yaml
+++ b/components/images-openstack.yaml
@@ -68,8 +68,8 @@ images:
     placement_db_sync: "docker.io/openstackhelm/placement:2024.2-ubuntu_jammy"
 
     # openvswitch
-    openvswitch_db_server: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-dpdk-20250111"
-    openvswitch_vswitchd: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-dpdk-20250111"
+    openvswitch_db_server: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-dpdk-20250127"
+    openvswitch_vswitchd: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-dpdk-20250127"
 
     # ovn
     ovn_ovsdb_nb: "docker.io/openstackhelm/ovn:ubuntu_jammy-20250111"


### PR DESCRIPTION
In 45d55d30830 the chart was bumped but we needed to bump to a container with the user inside of it otherwise it fails to start up.

This fixes #1006 which needed a newer container. 