### PR TITLE
fix(rabbitmq): set TTL to prevent notifications queues from growing indefinitely

### DIFF
--- a/components/glance/glance-rabbitmq-queue.yaml
+++ b/components/glance/glance-rabbitmq-queue.yaml
@@ -57,3 +57,20 @@ spec:
   rabbitmqClusterReference:
     name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: glance-notifications-ttl
+  namespace: openstack
+spec:
+  name: glance-notifications-ttl  # name of the policy
+  vhost: "glance"  # default to '/' if not provided
+  pattern: "^notifications.*"  # regex used to match queues and exchanges
+  applyTo: "queues"  # set to 'queues', 'exchanges', or 'all'
+  priority: 1  # defaults to 0
+  definition:  # policy definition
+    message-ttl: 86400000
+  rabbitmqClusterReference:
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack

--- a/components/ironic/ironic-rabbitmq-queue.yaml
+++ b/components/ironic/ironic-rabbitmq-queue.yaml
@@ -57,3 +57,20 @@ spec:
   rabbitmqClusterReference:
     name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: ironic-notifications-ttl
+  namespace: openstack
+spec:
+  name: ironic-notifications-ttl  # name of the policy
+  vhost: "ironic"  # default to '/' if not provided
+  pattern: "^notifications.*"  # regex used to match queues and exchanges
+  applyTo: "queues"  # set to 'queues', 'exchanges', or 'all'
+  priority: 1  # defaults to 0
+  definition:  # policy definition
+    message-ttl: 86400000
+  rabbitmqClusterReference:
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack

--- a/components/keystone/keystone-rabbitmq-queue.yaml
+++ b/components/keystone/keystone-rabbitmq-queue.yaml
@@ -57,3 +57,20 @@ spec:
   rabbitmqClusterReference:
     name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: keystone-notifications-ttl
+  namespace: openstack
+spec:
+  name: keystone-notifications-ttl  # name of the policy
+  vhost: "keystone"  # default to '/' if not provided
+  pattern: "^notifications.*"  # regex used to match queues and exchanges
+  applyTo: "queues"  # set to 'queues', 'exchanges', or 'all'
+  priority: 1  # defaults to 0
+  definition:  # policy definition
+    message-ttl: 86400000
+  rabbitmqClusterReference:
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack

--- a/components/neutron/neutron-rabbitmq-queue.yaml
+++ b/components/neutron/neutron-rabbitmq-queue.yaml
@@ -57,3 +57,20 @@ spec:
   rabbitmqClusterReference:
     name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: neutron-notifications-ttl
+  namespace: openstack
+spec:
+  name: neutron-notifications-ttl  # name of the policy
+  vhost: "neutron"  # default to '/' if not provided
+  pattern: "^notifications.*"  # regex used to match queues and exchanges
+  applyTo: "queues"  # set to 'queues', 'exchanges', or 'all'
+  priority: 1  # defaults to 0
+  definition:  # policy definition
+    message-ttl: 86400000
+  rabbitmqClusterReference:
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack

--- a/components/nova/nova-rabbitmq-queue.yaml
+++ b/components/nova/nova-rabbitmq-queue.yaml
@@ -57,3 +57,20 @@ spec:
   rabbitmqClusterReference:
     name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: nova-notifications-ttl
+  namespace: openstack
+spec:
+  name: nova-notifications-ttl  # name of the policy
+  vhost: "nova"  # default to '/' if not provided
+  pattern: "^notifications.*"  # regex used to match queues and exchanges
+  applyTo: "queues"  # set to 'queues', 'exchanges', or 'all'
+  priority: 1  # defaults to 0
+  definition:  # policy definition
+    message-ttl: 86400000
+  rabbitmqClusterReference:
+    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack


### PR DESCRIPTION
References:
* https://www.rabbitmq.com/docs/ttl
* https://www.rabbitmq.com/kubernetes/operator/using-operator#override
* https://github.com/rabbitmq/cluster-operator/tree/main/docs/examples/import-definitions

