### PR TITLE
fix(neutron): revert OpenStack Helm chart version

### DIFF
--- a/apps/openstack/neutron.yaml
+++ b/apps/openstack/neutron.yaml
@@ -1,4 +1,4 @@
 ---
 component: neutron
 repoURL: https://tarballs.opendev.org/openstack/openstack-helm
-chartVersion: 2025.1.8+062261562
+chartVersion: 2025.1.1+1fa537cf1


### PR DESCRIPTION
https://review.opendev.org/c/openstack/openstack-helm/+/949058 contained an invalid volumes spec for the neutron-ironic-agent preventing it from starting up. So revert back to before that landed. https://review.opendev.org/c/openstack/openstack-helm/+/952611 has been submitted to fix this.