### PR TITLE
fix(ironic): do not override OpenStack Helm default paths

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -70,8 +70,6 @@ conf:
     oslo_messaging_rabbit:
       rabbit_ha_queues: true
     pxe:
-      images_path: /var/lib/understack/master_iso_images
-      instance_master_path: /var/lib/understack/master_iso_images
       loader_file_paths: "snponly.efi:/usr/lib/ipxe/snponly.efi"
     inspector:
       extra_kernel_params: ipa-collect-lldp=1

--- a/containers/dnsmasq/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq/dnsmasq.conf.j2
@@ -95,7 +95,7 @@ dhcp-allowed-srvids={{ dhcp_allowed_srvids_list|join(',') }}
 {% endif %}
 enable-tftp
 tftp-no-fail
-tftp-root={{ env['TFTP_DIR'] | default('/var/lib/understack/master_iso_images') }}
+tftp-root={{ env['TFTP_DIR'] | default('/var/lib/openstack-helm/tftpboot') }}
 
 # don't set to enable logging
 {% if env.LOG_DHCP_QUERIES | default(False, True) %}


### PR DESCRIPTION
These paths are defaulted within /var/lib/openstack-helm and should remain that way to avoid cross filesystem operations.