### PR TITLE
chore: updated external secrets to 0.16.2

### DIFF
--- a/operators/external-secrets/kustomization.yaml
+++ b/operators/external-secrets/kustomization.yaml
@@ -7,6 +7,6 @@ helmCharts:
   includeCRDs: true
   namespace: external-secrets
   releaseName: external-secrets
-  version: 0.16.1
+  version: 0.16.2
   repo: https://charts.external-secrets.io
   valuesFile: values.yaml


### PR DESCRIPTION
The external secrets upgrades its CRD versions.

We are currently on 0.16.1 that supports v1beta1 (what we currently use)

The 0.16.2 (what that PR updates to) adds support for v1.

Versions 0.17.0 and above support only v1.

We need to update to 0.16.2, then upgrade CRDs to v1 and then perform any further updates.

There is breaking change in 0.16.2 but I don't think it affects us:
https://github.com/external-secrets/external-secrets/releases/tag/v0.16.2