### PR TITLE
fix: router iface removal: switch to PRECOMMIT_DELETE 

### DIFF
--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -64,7 +64,7 @@ class UnderstackDriver(MechanismDriver):
         registry.subscribe(
             routers.handle_router_interface_removal,
             resources.PORT,
-            events.BEFORE_DELETE,
+            events.PRECOMMIT_DELETE,
             cancellable=True,
         )
 

--- a/python/neutron-understack/neutron_understack/routers.py
+++ b/python/neutron-understack/neutron_understack/routers.py
@@ -219,10 +219,13 @@ def handle_router_interface_removal(_resource, _event, trigger, payload) -> None
     In situation 2, we don't have to do anything. Router-specific port gets
     deleted by Neutron and segment-shared port stays around.
     """
-    port = payload.metadata["port"]
-    network_id = port["network_id"]
+    LOG.debug(
+        "handle_router_interface_removal received %(payload)s", {"payload": payload}
+    )
+    port = payload.metadata["port_db"]
+    network_id = payload.metadata["network"]["id"]
 
-    if port["device_owner"] not in ROUTER_INTERFACE_AND_GW:
+    if port.device_owner not in ROUTER_INTERFACE_AND_GW:
         return
 
     if not is_only_router_port_on_network(network_id):

--- a/python/neutron-understack/neutron_understack/tests/conftest.py
+++ b/python/neutron-understack/neutron_understack/tests/conftest.py
@@ -339,6 +339,15 @@ def port_payload(network_id) -> DBEventPayload:
 
 
 @pytest.fixture
+def port_db_payload(network) -> DBEventPayload:
+    metadata = {
+        "port_db": PortModel(device_owner=p_const.DEVICE_OWNER_ROUTER_GW),
+        "network": network,
+    }
+    return DBEventPayload("context", metadata=metadata)
+
+
+@pytest.fixture
 def ml2_understack_conf(mocker, ucvni_group_id) -> None:
     mocker.patch(
         "neutron_understack.neutron_understack_mech.cfg.CONF.ml2_understack.ucvni_group",

--- a/python/neutron-understack/neutron_understack/tests/test_routers.py
+++ b/python/neutron-understack/neutron_understack/tests/test_routers.py
@@ -79,7 +79,7 @@ class TestHandleSubportRemoval:
 
 
 class TestHandleRouterInterfaceRemoval:
-    def test_case_for_non_router(self, mocker, port_payload):
+    def test_case_for_non_router(self, mocker, port_db_payload):
         mock_sb_removal = mocker.patch(
             "neutron_understack.routers.handle_subport_removal"
         )
@@ -87,13 +87,14 @@ class TestHandleRouterInterfaceRemoval:
             "neutron_understack.routers.delete_uplink_port"
         )
 
-        port_payload.metadata["port"]["device_owner"] = "not_a_router"
-        handle_router_interface_removal(None, None, None, port_payload)
+        port_db_payload.metadata["port_db"].device_owner = "not_a_router"
+
+        handle_router_interface_removal(None, None, None, port_db_payload)
 
         mock_sb_removal.assert_not_called()
         mock_localnet_removal.assert_not_called()
 
-    def test_when_network_in_use(self, mocker, port_payload):
+    def test_when_network_in_use(self, mocker, port_db_payload):
         mock_sb_removal = mocker.patch(
             "neutron_understack.routers.handle_subport_removal"
         )
@@ -105,12 +106,14 @@ class TestHandleRouterInterfaceRemoval:
             return_value=False,
         )
 
-        handle_router_interface_removal(None, None, None, port_payload)
+        handle_router_interface_removal(None, None, None, port_db_payload)
 
         mock_sb_removal.assert_not_called()
         mock_localnet_removal.assert_not_called()
 
-    def test_last_port_on_network(self, mocker, port_object, port_payload, network_id):
+    def test_last_port_on_network(
+        self, mocker, port_object, port_db_payload, network_id
+    ):
         mock_sb_removal = mocker.patch(
             "neutron_understack.routers.handle_subport_removal"
         )
@@ -133,7 +136,7 @@ class TestHandleRouterInterfaceRemoval:
         )
         delete_shared_port = mocker.patch.object(port_object, "delete")
 
-        handle_router_interface_removal(None, None, None, port_payload)
+        handle_router_interface_removal(None, None, None, port_db_payload)
 
         mock_sb_removal.assert_called_once_with(port_object)
         mock_localnet_removal.assert_called_once_with(fake_segment, str(network_id))


### PR DESCRIPTION
This code must be executed after Neutron's core validations but before the delete transaction is committed so we would still have enough information to perform full cleanup.

Prior version had a bug where user could accidentally delete the data related to a router's port (OVN router port, uplink neutron port, etc) while attempting to detach router's interface that was still in use for floating IP.

More details at https://rackspace.atlassian.net/browse/PUC-980

Closes PUC-890