### PR TITLE
chore: only set the tls secretName as needed

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -117,6 +117,14 @@ endpoints:
             name: understack-cluster-issuer
             kind: ClusterIssuer
 
+secrets:
+  tls:
+    baremetal:
+      api:
+        # needs to be kept in sync with secretName in the host_fqdn_override
+        # because helm-toolkit checks one field but then uses the other
+        public: ironic-tls-public
+
 network:
   api:
     ingress:

--- a/components/openstack-secrets.tpl.yaml
+++ b/components/openstack-secrets.tpl.yaml
@@ -137,29 +137,4 @@ endpoints:
     host_fqdn_override:
       public:
         host: horizon.${DNS_ZONE}
-
-# necessary cause the ingress definition in openstack-helm-infra helm-toolkit hardcodes this
-secrets:
-  tls:
-    baremetal:
-      api:
-        public: ironic-tls-public
-    image:
-      api:
-        public: glance-tls-public
-    identity:
-      api:
-        public: keystone-tls-public
-    network:
-      server:
-        public: neutron-tls-public
-    compute:
-      osapi:
-        public: nova-tls-public
-    placement:
-      api:
-        public: placement-tls-public
-    dashboard:
-      dashboard:
-        public: horizon-tls-public
 ...

--- a/go/understackctl/cmd/other/openstack.go
+++ b/go/understackctl/cmd/other/openstack.go
@@ -138,29 +138,4 @@ endpoints:
     host_fqdn_override:
       public:
         host: horizon.{{ .DNS_ZONE }}
-
-# necessary cause the ingress definition in openstack-helm-infra helm-toolkit hardcodes this
-secrets:
-  tls:
-    baremetal:
-      api:
-        public: ironic-tls-public
-    image:
-      api:
-        public: glance-tls-public
-    identity:
-      api:
-        public: keystone-tls-public
-    network:
-      server:
-        public: neutron-tls-public
-    compute:
-      osapi:
-        public: nova-tls-public
-    placement:
-      api:
-        public: placement-tls-public
-    dashboard:
-      dashboard:
-        public: horizon-tls-public
 `


### PR DESCRIPTION
All charts have the proper values and default them to keep them in sync except for the Ironic chart. We can drop this configuration in the deploy repos and just default it in Ironic until upstream fixes the issue.