### PR TITLE
fix: switch Cinder and Placement to quay.io images

### DIFF
--- a/components/images-openstack.yaml
+++ b/components/images-openstack.yaml
@@ -64,8 +64,8 @@ images:
     nova_service_cleaner: "docker.io/openstackhelm/ceph-config-helper:latest-ubuntu_jammy"
 
     # placement
-    placement: "docker.io/openstackhelm/placement:2024.2-ubuntu_jammy"
-    placement_db_sync: "docker.io/openstackhelm/placement:2024.2-ubuntu_jammy"
+    placement: "quay.io/airshipit/placement:2024.2-ubuntu_jammy"
+    placement_db_sync: "quay.io/airshipit/placement:2024.2-ubuntu_jammy"
 
     # openvswitch
     openvswitch_db_server: "docker.io/openstackhelm/openvswitch:ubuntu_jammy-dpdk-20250127"

--- a/containers/cinder/Dockerfile
+++ b/containers/cinder/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG OPENSTACK_VERSION="required_argument"
-FROM docker.io/openstackhelm/cinder:${OPENSTACK_VERSION}-ubuntu_jammy AS builder
+FROM quay.io/airshipit/cinder:${OPENSTACK_VERSION}-ubuntu_jammy AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd /tmp/cinder-understack && \
     uv build --wheel --out-dir /tmp/wheels/
 
-FROM docker.io/openstackhelm/cinder:${OPENSTACK_VERSION}-ubuntu_jammy AS final
+FROM quay.io/airshipit/cinder:${OPENSTACK_VERSION}-ubuntu_jammy AS final
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=from=builder,source=/tmp/wheels,target=/tmp/wheels \


### PR DESCRIPTION
The other OpenStack Helm images have already switched to using quay.io as the source of images.