### PR TITLE
fix(argocd): correct the git generator referencing the cluster

### DIFF
--- a/apps/appsets/appset-understack-global.yaml
+++ b/apps/appsets/appset-understack-global.yaml
@@ -53,10 +53,8 @@ spec:
                     repoURL: '{{ .values.deploy_url }}'
                     revision: '{{ .values.deploy_ref }}'
                     files:
-                      # due to https://github.com/argoproj/argo-cd/issues/22051
-                      # we need to do this workaround. this reads the apps.yaml
-                      # for per cluster
-                      - path: '{{ "{{.name}}" }}/apps.yaml'
+                        # this reads the overrides per cluster
+                      - path: '{{ .name }}/apps.yaml'
       selector:
         matchExpressions:
           # if you set skip to any value for the component in apps.yaml, this will disable it

--- a/apps/appsets/appset-understack-infra.yaml
+++ b/apps/appsets/appset-understack-infra.yaml
@@ -54,10 +54,8 @@ spec:
                     repoURL: '{{ .values.deploy_url }}'
                     revision: '{{ .values.deploy_ref }}'
                     files:
-                      # due to https://github.com/argoproj/argo-cd/issues/22051
-                      # we need to do this workaround. this reads the apps.yaml
-                      # for per cluster
-                      - path: '{{ "{{.name}}" }}/apps.yaml'
+                        # this reads the overrides per cluster
+                      - path: '{{ .name }}/apps.yaml'
       selector:
         matchExpressions:
           # if you set skip to any value for the component in apps.yaml, this will disable it

--- a/apps/appsets/appset-understack-openstack.yaml
+++ b/apps/appsets/appset-understack-openstack.yaml
@@ -55,9 +55,8 @@ spec:
                     repoURL: '{{ .values.deploy_url }}'
                     revision: '{{ .values.deploy_ref }}'
                     files:
-                      # due to https://github.com/argoproj/argo-cd/issues/22051
-                      # we need to do this workaround
-                      - path: '{{ "{{.name}}" }}/apps.yaml'
+                        # this reads the overrides per cluster
+                      - path: '{{ .name }}/apps.yaml'
       selector:
         matchExpressions:
           # if you set skip to any value for the component in apps.yaml, this will disable it

--- a/apps/appsets/appset-understack-operators.yaml
+++ b/apps/appsets/appset-understack-operators.yaml
@@ -54,10 +54,8 @@ spec:
                     repoURL: '{{ .values.deploy_url }}'
                     revision: '{{ .values.deploy_ref }}'
                     files:
-                      # due to https://github.com/argoproj/argo-cd/issues/22051
-                      # we need to do this workaround. this reads the apps.yaml
-                      # for per cluster
-                      - path: '{{ "{{.name}}" }}/apps.yaml'
+                        # this reads the overrides per cluster
+                      - path: '{{ .name }}/apps.yaml'
       selector:
         matchExpressions:
           # if you set skip to any value for the component in apps.yaml, this will disable it

--- a/apps/appsets/appset-understack-site.yaml
+++ b/apps/appsets/appset-understack-site.yaml
@@ -53,10 +53,8 @@ spec:
                     repoURL: '{{ .values.deploy_url }}'
                     revision: '{{ .values.deploy_ref }}'
                     files:
-                      # due to https://github.com/argoproj/argo-cd/issues/22051
-                      # we need to do this workaround. this reads the apps.yaml
-                      # for per cluster
-                      - path: '{{ "{{.name}}" }}/apps.yaml'
+                        # this reads the overrides per cluster
+                      - path: '{{ .name }}/apps.yaml'
       selector:
         matchExpressions:
           # if you set skip to any value for the component in apps.yaml, this will disable it


### PR DESCRIPTION
I originally added this nested variable and referenced an upstream issue believing it was necessary but local testing showed this didn't work and in fact is not necessary so remove it.