### PR TITLE
feat(argocd): sync only out of sync objects and don't manipulate the openstack namespace everywhere

### DIFF
--- a/apps/appsets/appset-understack-global.yaml
+++ b/apps/appsets/appset-understack-global.yaml
@@ -75,9 +75,20 @@ spec:
         automated:
           selfHeal: true
         syncOptions:
+          # Create the namespace we are using if it doesn't already exist.
           - CreateNamespace=true
+          # Use the server side apply behavior of kubernetes for resources, we've got the
+          # compare option set above to support this.
           - ServerSideApply=true
+          # Resources might have mutated fields and we want to allow those to be set without
+          # ArgoCD coming back and smacking them back. The ignoreDifferences templatePatch
+          # uses this feature.
           - RespectIgnoreDifferences=true
+          # Enable selective sync so that resources that have a difference are applied
+          # instead of always applying all resources. This prevents us from always
+          # running jobs.
+          # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#selective-sync
+          - ApplyOutOfSyncOnly=true
         managedNamespaceMetadata:
           annotations:
             # ArgoCD can create our namespace but let's not delete it

--- a/apps/appsets/appset-understack-infra.yaml
+++ b/apps/appsets/appset-understack-infra.yaml
@@ -76,9 +76,20 @@ spec:
         automated:
           selfHeal: true
         syncOptions:
+          # Create the namespace we are using if it doesn't already exist.
           - CreateNamespace=true
+          # Use the server side apply behavior of kubernetes for resources, we've got the
+          # compare option set above to support this.
           - ServerSideApply=true
+          # Resources might have mutated fields and we want to allow those to be set without
+          # ArgoCD coming back and smacking them back. The ignoreDifferences templatePatch
+          # uses this feature.
           - RespectIgnoreDifferences=true
+          # Enable selective sync so that resources that have a difference are applied
+          # instead of always applying all resources. This prevents us from always
+          # running jobs.
+          # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#selective-sync
+          - ApplyOutOfSyncOnly=true
         managedNamespaceMetadata:
           annotations:
             # ArgoCD can create our namespace but let's not delete it

--- a/apps/appsets/appset-understack-openstack.yaml
+++ b/apps/appsets/appset-understack-openstack.yaml
@@ -104,8 +104,18 @@ spec:
         automated:
           selfHeal: true
         syncOptions:
+          # Use the server side apply behavior of kubernetes for resources, we've got the
+          # compare option set above to support this.
           - ServerSideApply=true
+          # Resources might have mutated fields and we want to allow those to be set without
+          # ArgoCD coming back and smacking them back. The ignoreDifferences templatePatch
+          # uses this feature.
           - RespectIgnoreDifferences=true
+          # Enable selective sync so that resources that have a difference are applied
+          # instead of always applying all resources. This prevents us from always
+          # running DB migrations and messing with keystone users and endpoints.
+          # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#selective-sync
+          - ApplyOutOfSyncOnly=true
   templatePatch: |
     spec:
       ignoreDifferences: {{ dig "ignoreDifferences" list . | toJson }}

--- a/apps/appsets/appset-understack-openstack.yaml
+++ b/apps/appsets/appset-understack-openstack.yaml
@@ -104,16 +104,8 @@ spec:
         automated:
           selfHeal: true
         syncOptions:
-          - CreateNamespace=true
           - ServerSideApply=true
           - RespectIgnoreDifferences=true
-        managedNamespaceMetadata:
-          annotations:
-            # ArgoCD can create our namespace but let's not delete it
-            argocd.argoproj.io/sync-options: Delete=false
-          labels:
-            kubernetes.io/metadata.name: openstack
-            name: openstack
   templatePatch: |
     spec:
       ignoreDifferences: {{ dig "ignoreDifferences" list . | toJson }}

--- a/apps/appsets/appset-understack-operators.yaml
+++ b/apps/appsets/appset-understack-operators.yaml
@@ -76,9 +76,20 @@ spec:
         automated:
           selfHeal: true
         syncOptions:
+          # Create the namespace we are using if it doesn't already exist.
           - CreateNamespace=true
+          # Use the server side apply behavior of kubernetes for resources, we've got the
+          # compare option set above to support this.
           - ServerSideApply=true
+          # Resources might have mutated fields and we want to allow those to be set without
+          # ArgoCD coming back and smacking them back. The ignoreDifferences templatePatch
+          # uses this feature.
           - RespectIgnoreDifferences=true
+          # Enable selective sync so that resources that have a difference are applied
+          # instead of always applying all resources. This prevents us from always
+          # running jobs.
+          # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#selective-sync
+          - ApplyOutOfSyncOnly=true
         managedNamespaceMetadata:
           annotations:
             # ArgoCD can create our namespace but let's not delete it

--- a/apps/appsets/appset-understack-site.yaml
+++ b/apps/appsets/appset-understack-site.yaml
@@ -75,9 +75,20 @@ spec:
         automated:
           selfHeal: true
         syncOptions:
+          # Create the namespace we are using if it doesn't already exist.
           - CreateNamespace=true
+          # Use the server side apply behavior of kubernetes for resources, we've got the
+          # compare option set above to support this.
           - ServerSideApply=true
+          # Resources might have mutated fields and we want to allow those to be set without
+          # ArgoCD coming back and smacking them back. The ignoreDifferences templatePatch
+          # uses this feature.
           - RespectIgnoreDifferences=true
+          # Enable selective sync so that resources that have a difference are applied
+          # instead of always applying all resources. This prevents us from always
+          # running jobs.
+          # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#selective-sync
+          - ApplyOutOfSyncOnly=true
         managedNamespaceMetadata:
           annotations:
             # ArgoCD can create our namespace but let's not delete it


### PR DESCRIPTION
Documented what all the sync options do. Enabled applying only the objects that are out of sync which will prevent certain things that are marked for re-creation from being run all the time like the OpenStack Helm db-sync and keystone user/endpoint jobs. Removed every OpenStack component from fighting over owning the openstack namespace since it's created and owned by the shared resources anyway.