### PR TITLE
fix(nova): make ram quota a string so that openstack-helm doesn't convert it to scientific notation

### DIFF
--- a/components/nova/values.yaml
+++ b/components/nova/values.yaml
@@ -67,7 +67,7 @@ conf:
     quota:
       # adjust default quotas to make it possible to use baremetal
       cores: 512
-      ram: 1024000
+      ram: "1024000"
 
     # (TODO) This is to help with an upstream Nova bug:
     # https://review.opendev.org/c/openstack/nova/+/883411


### PR DESCRIPTION
```
2025-07-09 20:26:53.557 7 CRITICAL nova [-] Unhandled error: oslo_config.cfg.ConfigFileValueError: Value for option ram from LocationInfo(location=<Locations.user: (4, True)>, detail='/etc/nova/nova.conf') is not valid: invalid literal for int() with base 10: '1.024e+06'
2025-07-09 20:26:53.557 7 ERROR nova Traceback (most recent call last):
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2933, in _do_get
2025-07-09 20:26:53.557 7 ERROR nova     return (convert(val), alt_loc)
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2902, in convert
2025-07-09 20:26:53.557 7 ERROR nova     return self._convert_value(
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 3030, in _convert_value
2025-07-09 20:26:53.557 7 ERROR nova     return opt.type(value)
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/types.py", line 311, in __call__
2025-07-09 20:26:53.557 7 ERROR nova     value = self.num_type(value)
2025-07-09 20:26:53.557 7 ERROR nova ValueError: invalid literal for int() with base 10: '1.024e+06'
2025-07-09 20:26:53.557 7 ERROR nova
2025-07-09 20:26:53.557 7 ERROR nova During handling of the above exception, another exception occurred:
2025-07-09 20:26:53.557 7 ERROR nova
2025-07-09 20:26:53.557 7 ERROR nova Traceback (most recent call last):
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/bin/nova-api-wsgi", line 52, in <module>
2025-07-09 20:26:53.557 7 ERROR nova     application = init_application()
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/nova/api/openstack/compute/wsgi.py", line 20, in init_application
2025-07-09 20:26:53.557 7 ERROR nova     return wsgi_app.init_application(NAME)
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/nova/api/openstack/wsgi_app.py", line 128, in init_application
2025-07-09 20:26:53.557 7 ERROR nova     init_global_data(conf_files, name)
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/nova/utils.py", line 1133, in wrapper
2025-07-09 20:26:53.557 7 ERROR nova     return func(*args, **kwargs)
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/nova/api/openstack/wsgi_app.py", line 114, in init_global_data
2025-07-09 20:26:53.557 7 ERROR nova     CONF.log_opt_values(
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2828, in log_opt_values
2025-07-09 20:26:53.557 7 ERROR nova     _sanitize(opt, getattr(group_attr, opt_name)))
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 3378, in __getattr__
2025-07-09 20:26:53.557 7 ERROR nova     return self._conf._get(name, self._group)
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2870, in _get
2025-07-09 20:26:53.557 7 ERROR nova     value, loc = self._do_get(name, group, namespace)
2025-07-09 20:26:53.557 7 ERROR nova   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_config/cfg.py", line 2949, in _do_get
2025-07-09 20:26:53.557 7 ERROR nova     raise ConfigFileValueError(message)
2025-07-09 20:26:53.557 7 ERROR nova oslo_config.cfg.ConfigFileValueError: Value for option ram from LocationInfo(location=<Locations.user: (4, True)>, detail='/etc/nova/nova.conf') is not valid: invalid literal for int() with base 10: '1.024e+06'
```