### PR TITLE
feat(argocd): re-enable pruning of application resources

### DIFF
--- a/apps/appsets/appset-understack-global.yaml
+++ b/apps/appsets/appset-understack-global.yaml
@@ -78,6 +78,11 @@ spec:
         namespace: '{{coalesce (get . "componentNamespace") .component}}'
       syncPolicy:
         automated:
+          # auto-sync is enabled
+          enabled: true
+          # prune resources no longer present in the application during sync
+          prune: true
+          # sync should be run if a change is detected in the resource objects
           selfHeal: true
         syncOptions:
           # Create the namespace we are using if it doesn't already exist.

--- a/apps/appsets/appset-understack-infra.yaml
+++ b/apps/appsets/appset-understack-infra.yaml
@@ -79,6 +79,11 @@ spec:
         namespace: '{{coalesce (get . "componentNamespace") .component}}'
       syncPolicy:
         automated:
+          # auto-sync is enabled
+          enabled: true
+          # prune resources no longer present in the application during sync
+          prune: true
+          # sync should be run if a change is detected in the resource objects
           selfHeal: true
         syncOptions:
           # Create the namespace we are using if it doesn't already exist.

--- a/apps/appsets/appset-understack-openstack.yaml
+++ b/apps/appsets/appset-understack-openstack.yaml
@@ -107,6 +107,11 @@ spec:
         namespace: openstack
       syncPolicy:
         automated:
+          # auto-sync is enabled
+          enabled: true
+          # prune resources no longer present in the application during sync
+          prune: true
+          # sync should be run if a change is detected in the resource objects
           selfHeal: true
         syncOptions:
           # Use the server side apply behavior of kubernetes for resources, we've got the

--- a/apps/appsets/appset-understack-operators.yaml
+++ b/apps/appsets/appset-understack-operators.yaml
@@ -79,6 +79,11 @@ spec:
         namespace: '{{coalesce (get . "componentNamespace") .component}}'
       syncPolicy:
         automated:
+          # auto-sync is enabled
+          enabled: true
+          # prune resources no longer present in the application during sync
+          prune: true
+          # sync should be run if a change is detected in the resource objects
           selfHeal: true
         syncOptions:
           # Create the namespace we are using if it doesn't already exist.

--- a/apps/appsets/appset-understack-site.yaml
+++ b/apps/appsets/appset-understack-site.yaml
@@ -78,6 +78,11 @@ spec:
         namespace: '{{coalesce (get . "componentNamespace") .component}}'
       syncPolicy:
         automated:
+          # auto-sync is enabled
+          enabled: true
+          # prune resources no longer present in the application during sync
+          prune: true
+          # sync should be run if a change is detected in the resource objects
           selfHeal: true
         syncOptions:
           # Create the namespace we are using if it doesn't already exist.


### PR DESCRIPTION
On sync we should prune removed resources from the application by default. Document the syncPolicy and be explicit able the enabled flag.

ref: PUC-1021