### PR TITLE
feat: PUC-1014: do not append default novalocal domain to hostname

### DIFF
--- a/components/nova/values.yaml
+++ b/components/nova/values.yaml
@@ -68,6 +68,8 @@ conf:
       # adjust default quotas to make it possible to use baremetal
       cores: 512
       ram: "1024000"
+    api:
+      dhcp_domain: ""
 
     # (TODO) This is to help with an upstream Nova bug:
     # https://review.opendev.org/c/openstack/nova/+/883411


### PR DESCRIPTION
By default, Nova appends the value of dhcp_domain to the hostname to form the instance's FQDN in metadata.
and default value is [novalocal](https://opendev.org/openstack/nova/src/commit/1c034293379f4a319b65c52e5ee4fe332f83f34d/nova/conf/api.py#L211)