### PR TITLE
fix: renovate needs to update to handle digest pinning

### DIFF
--- a/.github/renovate/understackContainerMatch.json
+++ b/.github/renovate/understackContainerMatch.json
@@ -5,10 +5,11 @@
       "customType": "regex",
       "fileMatch": ["(^|/)images-openstack\\.ya?ml$"],
       "matchStrings": [
-        "ghcr\\.io/rackerlabs/(?<depName>understack/[\\w\\-]+):(?<currentValue>v[\\d\\.]+)"
+        "ghcr\\.io/rackerlabs/(?<depName>understack/[\\w\\-]+)(?::(?<currentValue>[-a-zA-Z0-9.]+))?(?:@(?<currentDigest>sha256:[a-zA-Z0-9]+))?"
       ],
       "datasourceTemplate": "docker",
-      "packageNameTemplate": "ghcr.io/rackerlabs/{{depName}}"
+      "packageNameTemplate": "ghcr.io/rackerlabs/{{depName}}",
+      "autoReplaceStringTemplate": "ghcr.io/rackerlabs/{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Update the renovate regex rule to handle digest pinning as per https://github.com/renovatebot/renovate/issues/10993