### PR TITLE
feat: make ironic port names node-name:port-name as a standard

### DIFF
--- a/python/understack-workflows/tests/test_sync_interfaces.py
+++ b/python/understack-workflows/tests/test_sync_interfaces.py
@@ -20,7 +20,7 @@ def test_sync_with_no_existing_interfaces(dell_nautobot_device):
             "address": "14:23:f3:f5:25:f1",
             "uuid": "8c28941c-02cd-4aad-9e3f-93c39e08b58a",
             "node_uuid": "a3a2983f-d906-4663-943c-c41ab73c9b62",
-            "name": "8c28941c-02cd-4aad-9e3f-93c39e08b58a NIC.Slot.1-2",
+            "name": f"{dell_nautobot_device.name}:NIC.Slot.1-2",
             "pxe_enabled": False,
             "local_link_connection": {
                 "switch_id": "9c:54:16:f5:ad:27",
@@ -36,7 +36,7 @@ def test_sync_with_no_existing_interfaces(dell_nautobot_device):
             "address": "d4:04:e6:4f:8d:b5",
             "uuid": "39d98f09-3199-40e0-87dc-e5ed6dce78e5",
             "node_uuid": "a3a2983f-d906-4663-943c-c41ab73c9b62",
-            "name": "39d98f09-3199-40e0-87dc-e5ed6dce78e5 NIC.Integrated.1-2",
+            "name": f"{dell_nautobot_device.name}:NIC.Integrated.1-2",
             "pxe_enabled": False,
             "local_link_connection": {
                 "switch_id": "9c:54:16:f5:ac:27",
@@ -52,7 +52,7 @@ def test_sync_with_no_existing_interfaces(dell_nautobot_device):
             "address": "14:23:f3:f5:25:f0",
             "uuid": "7ac587c4-015b-4a0e-b579-91284cbd0406",
             "node_uuid": "a3a2983f-d906-4663-943c-c41ab73c9b62",
-            "name": "7ac587c4-015b-4a0e-b579-91284cbd0406 NIC.Slot.1-1",
+            "name": f"{dell_nautobot_device.name}:NIC.Slot.1-1",
             "pxe_enabled": False,
             "local_link_connection": {
                 "switch_id": "9c:54:16:f5:ad:27",
@@ -68,7 +68,7 @@ def test_sync_with_no_existing_interfaces(dell_nautobot_device):
             "address": "d4:04:e6:4f:8d:b4",
             "uuid": "ac2f1eae-188e-4fc6-9245-f9a6cf8b4ea8",
             "node_uuid": "a3a2983f-d906-4663-943c-c41ab73c9b62",
-            "name": "ac2f1eae-188e-4fc6-9245-f9a6cf8b4ea8 NIC.Integrated.1-1",
+            "name": f"{dell_nautobot_device.name}:NIC.Integrated.1-1",
             "pxe_enabled": False,
             "local_link_connection": {
                 "switch_id": "9c:54:16:f5:ab:27",

--- a/python/understack-workflows/understack_workflows/sync_interfaces.py
+++ b/python/understack-workflows/understack_workflows/sync_interfaces.py
@@ -65,21 +65,19 @@ def get_nautobot_interfaces(
     Excludes interfaces with no MAC address
 
     """
-    device_id = nautobot_device.id
-
     return [
-        port_configuration(interface, pxe_interface, device_id)
+        port_configuration(interface, pxe_interface, nautobot_device)
         for interface in nautobot_device.interfaces
         if interface_is_relevant(interface)
     ]
 
 
 def port_configuration(
-    interface: NautobotInterface, pxe_interface: str, device_id: str
+    interface: NautobotInterface, pxe_interface: str, device: NautobotDevice
 ) -> PortConfiguration:
     # Interface names have their UUID prepended because Ironic wants them
     # globally unique across all devices.
-    name = f"{interface.id} {interface.name}"
+    name = f"{device.name}:{interface.name}"
     pxe_enabled = interface.name == pxe_interface
 
     if interface.neighbor_chassis_mac:
@@ -92,7 +90,7 @@ def port_configuration(
         local_link_connection = {}
 
     return PortConfiguration(
-        node_uuid=device_id,
+        node_uuid=device.id,
         address=interface.mac_address.lower(),
         uuid=interface.id,
         name=name,


### PR DESCRIPTION
Standardize the ironic port names to be the node-name:port-name since they have to be unique in Ironic but we want to include the BMC name to make it clear to folks which NIC is which.

ref: PUC-1037