### PR TITLE
fix(argocd): fix the disabling of syncPolicy

### DIFF
--- a/apps/appsets/appset-understack-global.yaml
+++ b/apps/appsets/appset-understack-global.yaml
@@ -12,7 +12,7 @@ spec:
     - jsonPointers:
       # Allow temporarily disabling auto-sync for troubleshooting
       # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
-      - /spec/syncPolicy
+      - /spec/syncPolicy/automated
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-infra.yaml
+++ b/apps/appsets/appset-understack-infra.yaml
@@ -12,7 +12,7 @@ spec:
     - jsonPointers:
       # Allow temporarily disabling auto-sync for troubleshooting
       # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
-      - /spec/syncPolicy
+      - /spec/syncPolicy/automated
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-openstack.yaml
+++ b/apps/appsets/appset-understack-openstack.yaml
@@ -12,7 +12,7 @@ spec:
     - jsonPointers:
       # Allow temporarily disabling auto-sync for troubleshooting
       # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
-      - /spec/syncPolicy
+      - /spec/syncPolicy/automated
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-operators.yaml
+++ b/apps/appsets/appset-understack-operators.yaml
@@ -12,7 +12,7 @@ spec:
     - jsonPointers:
       # Allow temporarily disabling auto-sync for troubleshooting
       # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
-      - /spec/syncPolicy
+      - /spec/syncPolicy/automated
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:

--- a/apps/appsets/appset-understack-site.yaml
+++ b/apps/appsets/appset-understack-site.yaml
@@ -12,7 +12,7 @@ spec:
     - jsonPointers:
       # Allow temporarily disabling auto-sync for troubleshooting
       # https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Controlling-Resource-Modification/#allow-temporarily-toggling-auto-sync
-      - /spec/syncPolicy
+      - /spec/syncPolicy/automated
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:


### PR DESCRIPTION
We only want to allow for modifications in the syncPolicy.automated section and not for the entire syncPolicy. This has caused us to not apply other updates we have done to the syncPolicy.