### PR TITLE
fix(nautobot): Performance tuning for nautobot

### DIFF
--- a/components/nautobot/values.yaml
+++ b/components/nautobot/values.yaml
@@ -54,6 +54,12 @@ nautobot:
     timeoutSeconds: 60
 
 celery:
+  # Concurrency defaults to the number of CPUs detected on the system.
+  # If your concurrency is set too high for the resource requests and limits then
+  # you'll have a large amount of memory taken by all the worker processes.
+  # https://github.com/nautobot/helm-charts/issues/433
+  # https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/guides/celery-queues/#concurrency-setting
+  concurrency: 2
   replicaCount: 1
   extraEnvVarsSecret:
     - nautobot-django
@@ -66,7 +72,6 @@ celery:
     initialDelaySeconds: 60
     periodSeconds: 120
     timeoutSeconds: 60
-
 
 postgresql:
   enabled: false


### PR DESCRIPTION
This sets Nautobot to use the same limits for all our environments. For celery, I'm also limiting concurrency. We don't run a lot of jobs currently so we maybe need to tune that more in the future.

Concurrency defaults to number of CPUs in the system: https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/guides/celery-queues/

A nautobot issue related to OOM issues: https://github.com/nautobot/helm-charts/issues/433 says "If your concurrency is set too high for the resource requests and limits then you'll have a large amount of memory taken by all the worker processes."
