### PR TITLE
fix(renovate): simplify the container match rule

### DIFF
--- a/.github/renovate/understackContainerMatch.json
+++ b/.github/renovate/understackContainerMatch.json
@@ -5,11 +5,9 @@
       "customType": "regex",
       "fileMatch": ["(^|/)images-openstack\\.ya?ml$"],
       "matchStrings": [
-        "(?<registryUrl>[a-zA-Z0-9.-]+(?:\\:[0-9]+)?)/(?<depName>[^\\s:@]+)(?::(?<currentValue>[-a-zA-Z_0-9.]+))?(?:@(?<currentDigest>sha256:[a-zA-Z0-9]+))?"
+        ":\\s+\"+(?<depName>[^\\s:@\"]+)(?::(?<currentValue>[-a-zA-Z_0-9.]+))?(?:@(?<currentDigest>sha256:[a-zA-Z0-9]+))\"?"
       ],
-      "datasourceTemplate": "docker",
-      "packageNameTemplate": "{{registryUrl}}/{{depName}}",
-      "autoReplaceStringTemplate": "{{registryUrl}}/{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
This should hopefully simplify the whole match and just support docker container image references in general. Looks like some of the prior things I had been doing are no longer required but are still showing up in searches and results on renovate's site but its all been upstreamed.