### PR TITLE
feat: Updated new driver for netapp dynamic svm

### DIFF
--- a/components/cinder/cinder-volume-netapp.yaml
+++ b/components/cinder/cinder-volume-netapp.yaml
@@ -26,9 +26,8 @@ spec:
           netapp_storage_protocol = nvme
           netapp_transport_type = https
           netapp_use_legacy_client = false
-          netapp_vserver = data-svm1
           volume_backend_name = netapp_nvme
-          volume_driver = cinder.volume.drivers.netapp.common.NetAppDriver
+          volume_driver = cinder_understack.dynamic_netapp_driver.NetappCinderDynamicDriver
   data:
   - secretKey: netapp_username
     remoteRef:


### PR DESCRIPTION
This change points to custom dynamic NetApp driver class located in the /python/cinder-understack/cinder_understack/dynamic_netapp_driver.py module. The path follows Python's module naming convention where the file path translates to the module path cinder_understack.dynamic_netapp_driver.NetappCinderDynamicDriver.