### PR TITLE
feat: Set OpenStack region name to the DEPLOY_NAME

### DIFF
--- a/components/openstack-secrets.tpl.yaml
+++ b/components/openstack-secrets.tpl.yaml
@@ -13,27 +13,35 @@ endpoints:
       # and endpoint in the service catalog.
       admin:
         password: "${ADMIN_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
       # this user is the service account that glance uses
       glance:
         password: "${GLANCE_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
       # this user is the service account that ironic uses
       ironic:
         password: "${IRONIC_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
       # this user is the service account that neutron uses
       neutron:
         password: "${NEUTRON_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
       # this user is the service account that nova uses
       nova:
         password: "${NOVA_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
       # this user is the service account that placement uses
       placement:
         password: "${PLACEMENT_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
       # this user is the service account that cinder uses
       cinder:
         password: "${CINDER_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
       # this user is the service account that octavia uses
       octavia:
         password: "${OCTAVIA_KEYSTONE_PASSWORD}"
+        region_name: "${DEPLOY_NAME}"
 
     # set our public facing URL
     host_fqdn_override:


### PR DESCRIPTION
We currently use the default OpenStack region name from openstack-helm which is `RegionOne`. This sets the OpenStack region name to the `DEPLOY_NAME` we choose during setup.