### PR TITLE
chore(octavia): Bump openstack-helm octavia load balanacer chart version

### DIFF
--- a/apps/openstack/octavia.yaml
+++ b/apps/openstack/octavia.yaml
@@ -1,4 +1,4 @@
 ---
 component: octavia
 repoURL: https://tarballs.opendev.org/openstack/openstack-helm
-chartVersion: 2025.1.12+80041dfbb
+chartVersion: 2025.1.14+36775efa1


### PR DESCRIPTION
Pulls in updates and bug fixes from the upstream openstack-helm octavia chart.