### PR TITLE
fix(postgres): specify antiaffinity rules

### DIFF
--- a/components/nautobot/cloudnative-postgres-nautobot.yaml
+++ b/components/nautobot/cloudnative-postgres-nautobot.yaml
@@ -11,6 +11,9 @@ spec:
   instances: 3
   storage:
     size: 20Gi
+  affinity:
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
   monitoring:
     enablePodMonitor: true
 ---


### PR DESCRIPTION
With current setup we are running into situations where postgres instances are not spread evenly across the nodes:

```
❯ kubectl cnpg status nautobot-cluster -n nautobot
...
Instances status
Name                Current LSN   Replication role  Status  QoS         Manager Version  Node
----                -----------   ----------------  ------  ---         ---------------  ----
nautobot-cluster-4  16C/C4001338  Primary           OK      BestEffort  1.26.0           1327175-hp3
nautobot-cluster-5  16C/C4001338  Standby (async)   OK      BestEffort  1.26.0           1327174-hp2
nautobot-cluster-6  16C/C4001338  Standby (async)   OK      BestEffort  1.26.0           1327174-hp2
```

Adding the rules here will ensure that they are distributed across multiple servers.