### PR TITLE
fix(keystone): when bootstrapping, need to enable sso federation

### DIFF
--- a/ansible/roles/keystone_bootstrap/tasks/sso.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/sso.yml
@@ -29,6 +29,7 @@
     name: sso
     domain_id: "{{ _domain_sso.domain.id }}"
     description: 'Identity Provider to dex'
+    is_enabled: true
     remote_ids:
       - "{{ keystone_bootstrap_dex_url }}"
 


### PR DESCRIPTION
The sso domain is using federation to our dex. The default behavior is to create the federation disabled but we need it to be enabled.