### PR TITLE
chore(workflows): convert to k8s object triggers

### DIFF
--- a/workflows/argo-events/sensors/alertmanager-webhook-sensor.yaml
+++ b/workflows/argo-events/sensors/alertmanager-webhook-sensor.yaml
@@ -31,11 +31,9 @@ spec:
   triggers:
     - template:
         name: alertmanager-workflow-trigger
-        # uses 'argo' CLI instead of 'kubectl'
-        argoWorkflow:
-          # sets the operation to 'argo submit'
-          operation: submit
-
+        # creates workflow object directly via k8s API
+        k8s:
+          operation: create
           parameters:
           - src:
               dependencyName: alertmanager-dep

--- a/workflows/openstack/sensors/sensor-ironic-node-port.yaml
+++ b/workflows/openstack/sensors/sensor-ironic-node-port.yaml
@@ -45,11 +45,9 @@ spec:
   triggers:
     - template:
         name: ironic-node-port
-        # uses 'argo' CLI instead of 'kubectl'
-        argoWorkflow:
-          # sets the operation to 'argo submit'
-          operation: submit
-          # edits source section
+        # creates workflow object directly via k8s API
+        k8s:
+          operation: create
           parameters:
             # first parameter is the parsed oslo.message
             - dest: spec.arguments.parameters.0.value

--- a/workflows/openstack/sensors/sensor-ironic-node-update.yaml
+++ b/workflows/openstack/sensors/sensor-ironic-node-update.yaml
@@ -45,11 +45,9 @@ spec:
   triggers:
     - template:
         name: ironic-node-update
-        # uses 'argo' CLI instead of 'kubectl'
-        argoWorkflow:
-          # sets the operation to 'argo submit'
-          operation: submit
-          # edits source section
+        # creates workflow object directly via k8s API
+        k8s:
+          operation: create
           parameters:
             # first parameter's value is replaced with the uuid
             - dest: spec.arguments.parameters.0.value

--- a/workflows/openstack/sensors/sensor-ironic-reclean.yaml
+++ b/workflows/openstack/sensors/sensor-ironic-reclean.yaml
@@ -35,11 +35,9 @@ spec:
   triggers:
     - template:
         name: ironic-reclean
-        # uses 'argo' CLI instead of 'kubectl'
-        argoWorkflow:
-          # sets the operation to 'argo submit'
-          operation: submit
-          # edits source section
+        # creates workflow object directly via k8s API
+        k8s:
+          operation: create
           parameters:
             # first parameter's value is replaced with the uuid
             - dest: spec.arguments.parameters.0.value

--- a/workflows/openstack/sensors/sensor-keystone-event-project.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-event-project.yaml
@@ -49,11 +49,9 @@ spec:
   triggers:
     - template:
         name: keystone-event-project
-        # uses 'argo' CLI instead of 'kubectl'
-        argoWorkflow:
-          # sets the operation to 'argo submit'
-          operation: submit
-          # edits the source section
+        # creates workflow object directly via k8s API
+        k8s:
+          operation: create
           parameters:
             # first parameter's value is replaced with the event type
             - dest: spec.arguments.parameters.0.value

--- a/workflows/openstack/sensors/sensor-neutron-event-network-segment-range.yaml
+++ b/workflows/openstack/sensors/sensor-neutron-event-network-segment-range.yaml
@@ -46,11 +46,9 @@ spec:
   triggers:
     - template:
         name: neutron-event-network-segment-range
-        # uses 'argo' CLI instead of 'kubectl'
-        argoWorkflow:
-          # sets the operation to 'argo submit'
-          operation: submit
-          # edits the source section
+        # creates workflow object directly via k8s API
+        k8s:
+          operation: create
           parameters:
             - dest: spec.arguments.parameters.0.value
               src:


### PR DESCRIPTION
Change the Argo Events Sensors to using the k8s object creation trigger instead of the argoWorkflow trigger which will require less permissions and to better specify the service accounts.

ref: PUC-1125