### PR TITLE
feat: Trigger Ansible on SVM creation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,4 +116,4 @@ repos:
         # entry: bash -c 'trufflehog --no-update git file://. --since-commit HEAD --results=verified,unknown --fail'
         entry: bash -c 'docker run --rm -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --since-commit HEAD --results=verified,unknown --fail'
         language: system
-        stages: ["pre-commit", "pre-push"]
+        stages: ["pre-push"]

--- a/python/understack-workflows/pyproject.toml
+++ b/python/understack-workflows/pyproject.toml
@@ -74,7 +74,9 @@ testpaths = [
 ]
 filterwarnings = [
   # sushy
-  "ignore:pkg_resources is deprecated as an API.:DeprecationWarning"
+  "ignore:pkg_resources is deprecated as an API.:DeprecationWarning",
+  # netapp
+  "ignore:.*Number` field should not be instantiated.*"
 ]
 
 [tool.ruff]

--- a/python/understack-workflows/tests/test_keystone_project.py
+++ b/python/understack-workflows/tests/test_keystone_project.py
@@ -123,22 +123,29 @@ class TestHandleProjectCreated:
         assert result == 1
 
     @patch("understack_workflows.oslo_event.keystone_project._keystone_project_tags")
+    @patch("builtins.open")
     def test_handle_project_created_no_svm_tag(
-        self, mock_tags, mock_conn, mock_nautobot, valid_event_data
+        self, mock_open, mock_tags, mock_conn, mock_nautobot, valid_event_data
     ):
         """Test handling project creation without SVM tag."""
         mock_tags.return_value = ["tag1", "tag2"]
 
-        with pytest.raises(SystemExit) as exc_info:
-            handle_project_created(mock_conn, mock_nautobot, valid_event_data)
-
-        assert exc_info.value.code == 0
+        result = handle_project_created(mock_conn, mock_nautobot, valid_event_data)
+        assert result == 0
         mock_tags.assert_called_once_with(mock_conn, "test-project-123")
+        mock_open.assert_called_with("/var/run/argo/output.svm_enabled", "w")
 
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
     @patch("understack_workflows.oslo_event.keystone_project._keystone_project_tags")
+    @patch("builtins.open")
     def test_handle_project_created_with_svm_tag(
-        self, mock_tags, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_tags,
+        mock_netapp_class,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Test successful project creation handling with SVM tag."""
         mock_tags.return_value = ["tag1", SVM_PROJECT_TAG, "tag2"]
@@ -158,11 +165,19 @@ class TestHandleProjectCreated:
             volume_size=VOLUME_SIZE,
             aggregate_name=AGGREGATE_NAME,
         )
+        mock_open.assert_called()
 
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
     @patch("understack_workflows.oslo_event.keystone_project._keystone_project_tags")
+    @patch("builtins.open")
     def test_handle_project_created_netapp_manager_failure(
-        self, mock_tags, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_tags,
+        mock_netapp_class,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Test handling when NetAppManager creation fails."""
         mock_tags.return_value = [SVM_PROJECT_TAG]
@@ -173,11 +188,19 @@ class TestHandleProjectCreated:
 
         mock_tags.assert_called_once_with(mock_conn, "test-project-123")
         mock_netapp_class.assert_called_once()
+        mock_open.assert_called()
 
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
     @patch("understack_workflows.oslo_event.keystone_project._keystone_project_tags")
+    @patch("builtins.open")
     def test_handle_project_created_svm_creation_failure(
-        self, mock_tags, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_tags,
+        mock_netapp_class,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Test handling when SVM creation fails."""
         mock_tags.return_value = [SVM_PROJECT_TAG]
@@ -196,8 +219,15 @@ class TestHandleProjectCreated:
 
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
     @patch("understack_workflows.oslo_event.keystone_project._keystone_project_tags")
+    @patch("builtins.open")
     def test_handle_project_created_volume_creation_failure(
-        self, mock_tags, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_tags,
+        mock_netapp_class,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Test handling when volume creation fails."""
         mock_tags.return_value = [SVM_PROJECT_TAG]
@@ -232,8 +262,9 @@ class TestHandleProjectCreated:
             handle_project_created(mock_conn, mock_nautobot, invalid_event_data)
 
     @patch("understack_workflows.oslo_event.keystone_project._keystone_project_tags")
+    @patch("builtins.open")
     def test_handle_project_created_constants_used(
-        self, mock_tags, mock_conn, mock_nautobot, valid_event_data
+        self, mock_open, mock_tags, mock_conn, mock_nautobot, valid_event_data
     ):
         """Test constants used for aggregate name and volume size."""
         mock_tags.return_value = [SVM_PROJECT_TAG]
@@ -253,6 +284,7 @@ class TestHandleProjectCreated:
             )
             mock_netapp_manager.create_volume.assert_called_once_with(
                 project_id="test-project-123",
-                volume_size="1GB",  # VOLUME_SIZE constant
+                volume_size="514GB",  # VOLUME_SIZE constant
                 aggregate_name="aggr02_n02_NVME",  # AGGREGATE_NAME constant
             )
+        mock_open.assert_called()

--- a/python/understack-workflows/understack_workflows/oslo_event/keystone_project.py
+++ b/python/understack-workflows/understack_workflows/oslo_event/keystone_project.py
@@ -11,7 +11,7 @@ logger = setup_logger(__name__)
 
 SVM_PROJECT_TAG = "UNDERSTACK_SVM"
 AGGREGATE_NAME = "aggr02_n02_NVME"
-VOLUME_SIZE = "1GB"
+VOLUME_SIZE = "514GB"
 
 
 @dataclass

--- a/scripts/delete_volumes_and_svms_netapp.py
+++ b/scripts/delete_volumes_and_svms_netapp.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import requests
+import sys
+import urllib3
+from requests.auth import HTTPBasicAuth
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def delete_volume(hostname, login, password, project_id):
+    """Delete volume named vol_$project_id"""
+    volume_name = f"vol_{project_id}"
+    url = f"https://{hostname}/api/storage/volumes"
+
+    # First, find the volume by name
+    params = {"name": volume_name}
+    response = requests.get(
+        url, auth=HTTPBasicAuth(login, password), params=params, verify=False
+    )
+
+    if response.status_code != 200:
+        print(
+            f"Error finding volume {volume_name}: {response.status_code} - {response.text}"
+        )
+        return False
+
+    volumes = response.json().get("records", [])
+    if not volumes:
+        print(f"Volume {volume_name} not found")
+        return False
+
+    volume_uuid = volumes[0]["uuid"]
+
+    # Delete the volume
+    delete_url = f"{url}/{volume_uuid}"
+    response = requests.delete(
+        delete_url, auth=HTTPBasicAuth(login, password), verify=False
+    )
+
+    if response.status_code == 202:
+        print(f"Volume {volume_name} deletion initiated successfully")
+        return True
+    else:
+        print(
+            f"Error deleting volume {volume_name}: {response.status_code} - {response.text}"
+        )
+        return False
+
+
+def delete_svm(hostname, login, password, project_id):
+    """Delete SVM named os-$project_id"""
+    svm_name = f"os-{project_id}"
+    url = f"https://{hostname}/api/svm/svms"
+
+    # First, find the SVM by name
+    params = {"name": svm_name}
+    response = requests.get(
+        url, auth=HTTPBasicAuth(login, password), params=params, verify=False
+    )
+
+    if response.status_code != 200:
+        print(f"Error finding SVM {svm_name}: {response.status_code} - {response.text}")
+        return False
+
+    svms = response.json().get("records", [])
+    if not svms:
+        print(f"SVM {svm_name} not found")
+        return False
+
+    svm_uuid = svms[0]["uuid"]
+
+    # Delete the SVM
+    delete_url = f"{url}/{svm_uuid}"
+    response = requests.delete(
+        delete_url, auth=HTTPBasicAuth(login, password), verify=False
+    )
+
+    if response.status_code == 202:
+        print(f"SVM {svm_name} deletion initiated successfully")
+        return True
+    else:
+        print(
+            f"Error deleting SVM {svm_name}: {response.status_code} - {response.text}"
+        )
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Delete NetApp ONTAP volume and SVM for a project"
+    )
+    parser.add_argument("project_id", help="Project ID")
+
+    args = parser.parse_args()
+
+    # Get credentials from environment variables
+    hostname = os.getenv("NETAPP_HOST")
+    login = os.getenv("NETAPP_LOGIN")
+    password = os.getenv("NETAPP_PASSWORD")
+
+    if not hostname or not login or not password:
+        print(
+            "Error: NETAPP_HOST, NETAPP_LOGIN, and NETAPP_PASSWORD environment variables must be set"
+        )
+        sys.exit(1)
+
+    print(f"Deleting resources for project: {args.project_id}")
+    print(f"Connecting to ONTAP: {hostname}")
+
+    # Delete volume first
+    volume_success = delete_volume(hostname, login, password, args.project_id)
+
+    # Delete SVM
+    svm_success = delete_svm(hostname, login, password, args.project_id)
+
+    if volume_success and svm_success:
+        print("All resources deleted successfully")
+        sys.exit(0)
+    else:
+        print("Some resources failed to delete")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/argo-events/workflowtemplates/openstack-oslo-event.yaml
+++ b/workflows/argo-events/workflowtemplates/openstack-oslo-event.yaml
@@ -62,3 +62,11 @@ spec:
         - name: netapp-ini
           secret:
             secretName: netapp-config
+      outputs:
+        parameters:
+          - name: exit_code
+            valueFrom:
+              path: /var/run/argo/output.exit_code
+          - name: msg
+            valueFrom:
+              path: /var/run/argo/output.msg

--- a/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
@@ -9,7 +9,6 @@ metadata:
       Triggers on the following Keystone Events:
 
       - identity.project.created
-      - identity.project.deleted
       - other events are silently ignored now
 
       Resulting code should be very similar to:
@@ -38,7 +37,6 @@ spec:
           type: "string"
           value:
             - "identity.project.created"
-            - "identity.project.deleted"
   template:
     serviceAccountName: sensor-submit-workflow
   triggers:
@@ -64,10 +62,39 @@ spec:
                 generateName: keystone-project-
                 namespace: argo-events
               spec:
+                serviceAccountName: workflow
+                entrypoint: main
                 # defines the parameters being replaced above
                 arguments:
                   parameters:
                     - name: event-json
-                # references the workflow
-                workflowTemplateRef:
-                  name: openstack-oslo-event
+                templates:
+                - name: main
+                  steps:
+                  - - name: oslo-events
+                      templateRef:
+                        name: openstack-oslo-event
+                        template: main
+                      arguments:
+                        parameters:
+                        - name: event-json
+                          value: "{{workflow.parameters.event-json}}"
+                  - - name: ansible-to-nautobot
+                      inline:
+                        container:
+                          image: ghcr.io/rss-engineering/undercloud-nautobot/ansible:latest
+                          args:
+                          - "ansible-playbook"
+                          - "storage_on_svm_create.yml"
+                          - --extra-vars
+                          - "svm_name=os-{{workflow.parameters.project_id}} project_name={{workflow.parameters.project_id}}"
+                          - "-i"
+                          - "inventory/uc-dev/01-nautobot.yaml"
+                            # TODO: this shouldn't be hardcodod to dev, but will work since
+                            # it really talks to https://nautobot-default.svc
+                          env:
+                            - name: NAUTOBOT_TOKEN
+                              valueFrom:
+                                secretKeyRef:
+                                  key: token
+                                  name: nautobot-token

--- a/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
@@ -53,6 +53,10 @@ spec:
               src:
                 dataKey: body
                 dependencyName: keystone-dep
+            - dest: spec.arguments.parameters.1.value
+              src:
+                dataKey: body.payload.target.id
+                dependencyName: keystone-dep
           source:
             # create a workflow in argo-events prefixed with keystone-project-
             resource:
@@ -68,6 +72,7 @@ spec:
                 arguments:
                   parameters:
                     - name: event-json
+                    - name: project_id
                 templates:
                 - name: main
                   steps:
@@ -79,6 +84,16 @@ spec:
                         parameters:
                         - name: event-json
                           value: "{{workflow.parameters.event-json}}"
+                    - name: convert-project-id
+                      inline:
+                        script:
+                          image: python:alpine
+                          command: [python]
+                          source: |
+                              import uuid
+                              project_id_without_dashes = "{{workflow.parameters.project_id}}"
+                              print(str(uuid.UUID(project_id_without_dashes)))
+
                   - - name: ansible-to-nautobot
                       inline:
                         container:
@@ -87,7 +102,7 @@ spec:
                           - "ansible-playbook"
                           - "storage_on_svm_create.yml"
                           - --extra-vars
-                          - "svm_name=os-{{workflow.parameters.project_id}} project_name={{workflow.parameters.project_id}}"
+                          - "svm_name=os-{{workflow.parameters.project_id}} project_name={{steps.convert-project-id.outputs.result}} env=dev"
                           - "-i"
                           - "inventory/uc-dev/01-nautobot.yaml"
                             # TODO: this shouldn't be hardcodod to dev, but will work since

--- a/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
@@ -42,10 +42,8 @@ spec:
   triggers:
     - template:
         name: keystone-project
-        # uses 'argo' CLI instead of 'kubectl'
-        argoWorkflow:
-          # sets the operation to 'argo submit'
-          operation: submit
+        k8s:
+          operation: create
           # edits source section
           parameters:
             # first parameter is the parsed oslo.message

--- a/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
@@ -93,6 +93,7 @@ spec:
                               print(str(uuid.UUID(project_id_without_dashes)))
 
                   - - name: ansible-to-nautobot
+                      when: "{{steps.oslo-events.outputs.svm_enabled}} == 'true'"
                       inline:
                         container:
                           image: ghcr.io/rss-engineering/undercloud-nautobot/ansible:latest

--- a/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
@@ -102,7 +102,7 @@ spec:
                           - "ansible-playbook"
                           - "storage_on_svm_create.yml"
                           - --extra-vars
-                          - "svm_name=os-{{workflow.parameters.project_id}} project_name={{steps.convert-project-id.outputs.result}} env=dev"
+                          - "svm_name=os-{{workflow.parameters.project_id}} project_id={{steps.convert-project-id.outputs.result}} env=dev"
                           - "-i"
                           - "inventory/uc-dev/01-nautobot.yaml"
                             # TODO: this shouldn't be hardcodod to dev, but will work since


### PR DESCRIPTION
When the Keystone project is created and it has `UNDERSTACK_SVM` tag, it will now:
- create the actual SVM on the NetAPP
- convert received Keystone project ID to a version with dashes
- if the NetApp creation was successful, it will kickoff the `storage_on_svm_create.yml` playbook

<img width="651" height="812" alt="image" src="https://github.com/user-attachments/assets/63192935-7fb6-419f-bdc7-88797646564b" />
