### PR TITLE
chore: sync_keystone: Stop managing OUTSIDE networks for tenants

### DIFF
--- a/python/understack-workflows/tests/test_sync_keystone.py
+++ b/python/understack-workflows/tests/test_sync_keystone.py
@@ -117,9 +117,6 @@ def test_handle_project_delete(
         tenant_obj if tenant_exists else None
     )
 
-    mock_delete_network = mocker.patch(
-        "understack_workflows.main.sync_keystone._delete_outside_network"
-    )
     mock_unmap_devices = mocker.patch(
         "understack_workflows.main.sync_keystone._unmap_tenant_from_devices"
     )
@@ -130,12 +127,10 @@ def test_handle_project_delete(
     mock_pynautobot_api.tenancy.tenants.get.assert_called_once_with(id=project_id)
 
     if tenant_exists:
-        mock_delete_network.assert_called_once_with(conn_mock, project_id)
         mock_unmap_devices.assert_called_once_with(
             tenant_id=project_id, nautobot=mock_pynautobot_api
         )
         tenant_obj.delete.assert_called_once()
     else:
-        mock_delete_network.assert_not_called()
         mock_unmap_devices.assert_not_called()
         tenant_obj.delete.assert_not_called()


### PR DESCRIPTION
We needed to create this network on behalf of the tenant because it
required admin privs to make an "external" network.   We can now achieve
the same effect using a normal network that a tenant can create for
themselves.

The user will create a network, subnet and router.  This has the same end result, and therefore we are no longer going to support the OUTSIDE network.

The intention is to proactively delete all existing OUTSIDE networks, so I have gone ahead and removed the cleanup code from here.