### PR TITLE
fix(argo-workflows): partially revert 8f5726d4427fe9

### DIFF
--- a/components/argo/argo-server-role.yaml
+++ b/components/argo/argo-server-role.yaml
@@ -1,0 +1,30 @@
+# This is a role and rolebinding to provide the argo-server with permissions
+# it needs to run in its own namespace.
+# - to read the configmap for its configuration
+# - read the SSO secret
+# - create and read other secrets for auth tokens
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-server-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+    resourceNames:
+      - workflow-controller-configmap
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+    resourceNames:
+      - argo-sso
+      - sso

--- a/components/argo/argo-server-rolebinding.yaml
+++ b/components/argo/argo-server-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-server-role
+subjects:
+  - kind: ServiceAccount
+    name: argo-server

--- a/components/argo/kustomization.yaml
+++ b/components/argo/kustomization.yaml
@@ -11,6 +11,10 @@ resources:
   # to the ClusterRole for just the namespaces we want.
   - https://github.com/argoproj/argo-workflows/manifests/cluster-install/?ref=v3.6.10
 
+  # adds argo-server role so the argo-server has enough permissions to run
+  - argo-server-role.yaml
+  - argo-server-rolebinding.yaml
+
   # ingress for workflows.${DNS_ZONE} to the argo server for the UI
   - ingress.yaml
 
@@ -40,6 +44,13 @@ patches:
     kind: ClusterRoleBinding
     name: argo-server-binding
   path: delete-argo-server-crb.yaml
+
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: Role
+    name: argo-role
+  path: workflow-controller-role.yaml
 
 # see the patch for details on the change
 - target:

--- a/components/argo/workflow-controller-role.yaml
+++ b/components/argo/workflow-controller-role.yaml
@@ -1,0 +1,8 @@
+---
+- op: add
+  path: /rules/-
+  value:
+    apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "watch"]
+    resourceNames: ["workflow-controller-configmap"]


### PR DESCRIPTION
The change was wrong that we didn't need to give the Argo Server and the Workflow Controller additional permissions in the argo namespace so this restores that but builds on the existing roles from upstream.