### PR TITLE
fix(cinder-understack): handle SVM name stripped in pool name and bad values passed from nova

### DIFF
--- a/python/cinder-understack/cinder_understack/dynamic_netapp_driver.py
+++ b/python/cinder-understack/cinder_understack/dynamic_netapp_driver.py
@@ -402,6 +402,9 @@ class NetappCinderDynamicDriver(volume_driver.BaseVD):
 
     def initialize_connection(self, volume, connector):
         """Initialize connection to volume."""
+        # TODO: the nova ironic driver sends the field 'initiator' but the NetApp
+        # cinder driver expects the field to be 'nqn' so copy the field over
+        connector["nqn"] = connector["initiator"]
         with self._volume_to_library(volume) as lib:
             return lib.initialize_connection(volume, connector)
 

--- a/python/cinder-understack/cinder_understack/dynamic_netapp_driver.py
+++ b/python/cinder-understack/cinder_understack/dynamic_netapp_driver.py
@@ -328,7 +328,23 @@ class NetappCinderDynamicDriver(volume_driver.BaseVD):
         original_host = volume["host"]
         # svm plus pool_name
         svm_pool_name = volume_utils.extract_host(original_host, level="pool")
+        if not svm_pool_name:
+            raise exception.InvalidInput(
+                reason=f"pool name not found in {original_host}"
+            )
+
         svm_name = svm_pool_name.split(_SVM_NAME_DELIM)[0]
+        # workaround when the svm_name has already been stripped from the pool
+        prefix = self.configuration.netapp_vserver_prefix
+        if not svm_name.startswith(prefix):
+            LOG.debug(
+                "Volume host already had SVM name stripped %s, "
+                "using volume project_id %s",
+                original_host,
+                volume["project_id"],
+            )
+            svm_name = f"os-{volume['project_id']}"
+
         try:
             lib = self._libraries[svm_name]
         except KeyError:


### PR DESCRIPTION
The follow error can be seen in the Cinder logs because the SVM name has already been stripped from the pool name in the volume host due to one call calling another driver call. To handle this we will detect this case and detect the SVM name from the project ID and not fail.

```
ERROR cinder_understack.dynamic_netapp_driver [req-f6486c4b-bae2-4c4c-8a33-5ecdca412712 req-4b7cca6a-4421-4f8e-bfec-8858176fb723 c3fd23244abd42631651813496e0ee22bd2377690c1d9b0e7851804e0497775f 6c2fb34446bf4b35b4f1512e51f2303d - - - -] No such SVM vol_6c2fb34446bf4b35b4f1512e51f2303d instantiated
```

The second fix here is a workaround for the fact that nova ironic sets the key "initiator" with the necessary data when the cinder NetApp driver expects the key "nqn" to store the data. This copies "initator" over to "nqn" until upstream can resolve this.