### PR TITLE
feat(dex): bump version to support device authorization flow

### DIFF
--- a/components/dex/values.yaml
+++ b/components/dex/values.yaml
@@ -2,6 +2,9 @@
 # https://github.com/dexidp/helm-charts/tree/master/charts/dex#values
 #
 
+image:
+  tag: v2.44.0
+
 replicaCount: 1
 config:
   # See https://dexidp.io/docs/storage/ for more options

--- a/docs/deploy-guide/config-dex.md
+++ b/docs/deploy-guide/config-dex.md
@@ -1,0 +1,15 @@
+# Configuring Dex
+
+As of Dex v2.44.0 the HTTP 302 redirects contain a `Location` header which
+is relative and not all clients like this in authentication flows. To workaround
+this easiest approach is have the ingress rewrite the URL for us.
+
+In `$DEPLOY_NAME/helm-configs/dex.yaml` in the `ingress.annotations` key, add the
+following:
+
+```yaml
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-redirect-from: "/"
+    nginx.ingress.kubernetes.io/proxy-redirect-to: "https://dex.your.url/"
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - Preparing Our Deployment:
       - deploy-guide/deploy-repo.md
       - deploy-guide/component-config.md
+      - deploy-guide/config-dex.md
       - deploy-guide/auth.md
       - deploy-guide/config-argo-workflows.md
     - Starting the Deployment:


### PR DESCRIPTION
There have been some fixes upstream which made it into v2.44.0 to be able to support the device authorization flow. Unfortunately we will need to add an ingress rule to make it work so document the change users will need to do.