### PR TITLE
chore: ensure Argo Workflows upgrade as one PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,15 @@
       ],
       "automerge": true,
       "automergeType": "branch"
+    },
+    {
+      "matchPackageNames": [
+        "quay.io/argoproj/workflow-controller",
+        "quay.io/argoproj/argoexec",
+        "quay.io/argoproj/argocli"
+      ],
+      "groupName": "Argo Workflows",
+      "commitMessageTopic": "Argo Workflows"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Instead of a PR per Argo Workflow container, create one PR for all of them together to bump the version as one.