### PR TITLE
feat(nova): add attach_volume/detach_volume to ironic driver

### DIFF
--- a/containers/nova/patches/ironic-attach-debug.patch
+++ b/containers/nova/patches/ironic-attach-debug.patch
@@ -1,0 +1,22 @@
+diff --git a/nova/virt/ironic/driver.py b/nova/virt/ironic/driver.py
+index 64ccdaa50c..cf7cc872d8 100644
+--- a/nova/virt/ironic/driver.py
++++ b/nova/virt/ironic/driver.py
+@@ -2237,3 +2237,17 @@ class IronicDriver(virt_driver.ComputeDriver):
+         """IronicDriver manages port bindings for baremetal instances.
+         """
+         return True
++
++    def attach_volume(self, context, connection_info, instance, mountpoint,
++                      disk_bus=None, device_type=None, encryption=None):
++        """Attach the disk to the instance at mountpoint using info.
++
++        :raises TooManyDiskDevices: if the maximum allowed devices to attach
++                                    to a single instance is exceeded.
++        """
++        LOG.debug("attach_volume connection_info %s", connection_info, instance=instance)
++
++    def detach_volume(self, context, connection_info, instance, mountpoint,
++                      encryption=None):
++        """Detach the disk attached to the instance."""
++        LOG.debug("detach_volume connection_info %s", connection_info, instance=instance)

--- a/containers/nova/patches/series
+++ b/containers/nova/patches/series
@@ -1,1 +1,2 @@
 0001_trunk_details_metadata.patch
+ironic-attach-debug.patch


### PR DESCRIPTION
Implements the attach_volume() and detach_volume() methods in the Nova Ironic driver so that we do not get a NotImplemented error. This merely just logs the data that these methods were called with.