### PR TITLE
fix: Update argo-server role to match upstream argo-server role

### DIFF
--- a/components/argo-workflows/argo-server-role.yaml
+++ b/components/argo-workflows/argo-server-role.yaml
@@ -25,6 +25,3 @@ rules:
     verbs:
       - get
       - create
-    resourceNames:
-      - argo-sso
-      - sso


### PR DESCRIPTION
Error is:

```
Error: failed to create secret: secrets is forbidden: User "system:serviceaccount:argo:argo-server" cannot create resource "secrets" in API group "" in the namespace "argo"
```