### PR TITLE
fix: Cleans up old, unneeded rabbitmq queues

### DIFF
--- a/components/glance/glance-rabbitmq-queue.yaml
+++ b/components/glance/glance-rabbitmq-queue.yaml
@@ -27,21 +27,6 @@ spec:
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
-kind: Queue
-metadata:
-  name: glance-queue
-  namespace: openstack
-spec:
-  name: glance-qq  # name of the queue
-  vhost: "glance"  # default to '/' if not provided
-  type: quorum  # without providing a queue type, rabbitmq creates a classic queue
-  autoDelete: false
-  durable: true  # setting 'durable' to false means this queue won't survive a server restart
-  rabbitmqClusterReference:
-    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
-    namespace: openstack
----
-apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: glance-permission

--- a/components/ironic/ironic-rabbitmq-queue.yaml
+++ b/components/ironic/ironic-rabbitmq-queue.yaml
@@ -27,21 +27,6 @@ spec:
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
-kind: Queue
-metadata:
-  name: ironic-queue
-  namespace: openstack
-spec:
-  name: ironic-qq  # name of the queue
-  vhost: "ironic"  # default to '/' if not provided
-  type: quorum  # without providing a queue type, rabbitmq creates a classic queue
-  autoDelete: false
-  durable: true  # setting 'durable' to false means this queue won't survive a server restart
-  rabbitmqClusterReference:
-    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
-    namespace: openstack
----
-apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: ironic-permission

--- a/components/keystone/keystone-rabbitmq-queue.yaml
+++ b/components/keystone/keystone-rabbitmq-queue.yaml
@@ -27,21 +27,6 @@ spec:
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
-kind: Queue
-metadata:
-  name: keystone-queue
-  namespace: openstack
-spec:
-  name: keystone-qq  # name of the queue
-  vhost: "keystone"  # default to '/' if not provided
-  type: quorum  # without providing a queue type, rabbitmq creates a classic queue
-  autoDelete: false
-  durable: true  # setting 'durable' to false means this queue won't survive a server restart
-  rabbitmqClusterReference:
-    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
-    namespace: openstack
----
-apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: keystone-permission

--- a/components/neutron/neutron-rabbitmq-queue.yaml
+++ b/components/neutron/neutron-rabbitmq-queue.yaml
@@ -27,21 +27,6 @@ spec:
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
-kind: Queue
-metadata:
-  name: neutron-queue
-  namespace: openstack
-spec:
-  name: neutron-qq  # name of the queue
-  vhost: "neutron"  # default to '/' if not provided
-  type: quorum  # without providing a queue type, rabbitmq creates a classic queue
-  autoDelete: false
-  durable: true  # setting 'durable' to false means this queue won't survive a server restart
-  rabbitmqClusterReference:
-    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
-    namespace: openstack
----
-apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: neutron-permission

--- a/components/nova/nova-rabbitmq-queue.yaml
+++ b/components/nova/nova-rabbitmq-queue.yaml
@@ -27,21 +27,6 @@ spec:
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
-kind: Queue
-metadata:
-  name: nova-queue
-  namespace: openstack
-spec:
-  name: nova-qq  # name of the queue
-  vhost: "nova"  # default to '/' if not provided
-  type: quorum  # without providing a queue type, rabbitmq creates a classic queue
-  autoDelete: false
-  durable: true  # setting 'durable' to false means this queue won't survive a server restart
-  rabbitmqClusterReference:
-    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
-    namespace: openstack
----
-apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: nova-permission

--- a/components/octavia/octavia-rabbitmq-queue.yaml
+++ b/components/octavia/octavia-rabbitmq-queue.yaml
@@ -27,21 +27,6 @@ spec:
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
-kind: Queue
-metadata:
-  name: octavia-queue
-  namespace: openstack
-spec:
-  name: octavia-qq  # name of the queue
-  vhost: "octavia"  # default to '/' if not provided
-  type: quorum  # without providing a queue type, rabbitmq creates a classic queue
-  autoDelete: false
-  durable: true  # setting 'durable' to false means this queue won't survive a server restart
-  rabbitmqClusterReference:
-    name: rabbitmq  # rabbitmqCluster must exist in the same namespace as this resource
-    namespace: openstack
----
-apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
   name: octavia-permission


### PR DESCRIPTION
These queues aren't being used, and the OpenStack services will create their own queues.