### PR TITLE
feat: Storage support multiple environments

### DIFF
--- a/workflows/argo-events/kustomization.yaml
+++ b/workflows/argo-events/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - workflowtemplates/reclean-server.yaml
   - workflowtemplates/openstack-oslo-event.yaml
   - workflowtemplates/netapp-configure-net.yaml
+  - workflowtemplates/ansible-run.yaml
   # Alert automation
   - sensors/alertmanager-webhook-sensor.yaml
   - eventsources/alertmanager-webhook-eventsource.yaml

--- a/workflows/argo-events/workflowtemplates/ansible-run.yaml
+++ b/workflows/argo-events/workflowtemplates/ansible-run.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: ansible-workflow-template
+  annotations:
+    workflows.argoproj.io/title: Run arbitrary ansible playbook from the undercloud-rackspace repo
+    workflows.argoproj.io/description: |
+      Defined in `workflows/argo-events/workflowtemplates/ansible-run.yaml`
+spec:
+  serviceAccountName: workflow
+  templates:
+  - name: ansible-run
+    inputs:
+      parameters:
+      - name: playbook
+        default: "nonexistent.yaml"
+      - name: extra_vars
+        default: "var=default"
+      - name: inventory_file
+        default: inventory/in-cluster/01-nautobot.yaml
+    container:
+      image: ghcr.io/rss-engineering/undercloud-nautobot/ansible:latest
+      command: [ansible-playbook]
+      args:
+      - "{{ inputs.parameters.playbook }}"
+      - --extra-vars
+      - "{{ inputs.parameters.extra_vars }}"
+      - "-i"
+      - "{{ inputs.parameters.inventory_file }}"
+      - "-vvv"
+      env:
+      - name: NAUTOBOT_TOKEN
+        valueFrom:
+          secretKeyRef:
+            key: token
+            name: nautobot-token
+      envFrom:
+      - configMapRef:
+          name: cluster-metadata
+          optional: false

--- a/workflows/openstack/sensors/sensor-ironic-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-ironic-oslo-event.yaml
@@ -99,45 +99,21 @@ spec:
                               print(str(uuid.UUID(project_id_without_dashes)))
                   - - name: ansible-on-server-create
                       when: "\"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted"
-                      inline:
-                        container:
-                          image: ghcr.io/rss-engineering/undercloud-nautobot/ansible:latest
-                          command: [ansible-playbook]
-                          args:
-                          - "storage_on_server_create.yml"
-                          - --extra-vars
-                          - "project_id={{steps.convert-project-id.outputs.result}} device_id={{workflow.parameters.device_id}}"
-                          - "-i"
-                          - "inventory/in-cluster/01-nautobot.yaml"
-                          - "-vvv"
-                          env:
-                            - name: NAUTOBOT_TOKEN
-                              valueFrom:
-                                secretKeyRef:
-                                  key: token
-                                  name: nautobot-token
-                          envFrom:
-                            - configMapRef:
-                                name: cluster-metadata
-                                optional: false
+                      templateRef:
+                        name: ansible-workflow-template
+                        template: ansible-run
+                      arguments:
+                        parameters:
+                        - name: playbook
+                          value: storage_on_server_create.yml
+                        - name: extra_vars
+                          value: project_id={{steps.convert-project-id.outputs.result}} device_id={{workflow.parameters.device_id}}
                   - - name: ansible-storage-update
                       when: "\"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted"
-                      inline:
-                        container:
-                          image: ghcr.io/rss-engineering/undercloud-nautobot/ansible:latest
-                          command: [ansible-playbook]
-                          args:
-                          - "storage_update_switches.yml"
-                          - "-i"
-                          - "inventory/in-cluster/01-nautobot.yaml"
-                          - "-vvv"
-                          env:
-                            - name: NAUTOBOT_TOKEN
-                              valueFrom:
-                                secretKeyRef:
-                                  key: token
-                                  name: nautobot-token
-                          envFrom:
-                            - configMapRef:
-                                name: cluster-metadata
-                                optional: false
+                      templateRef:
+                        name: ansible-workflow-template
+                        template: ansible-run
+                      arguments:
+                        parameters:
+                        - name: playbook
+                          value: storage_update_switches.yml

--- a/workflows/openstack/sensors/sensor-ironic-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-ironic-oslo-event.yaml
@@ -106,9 +106,9 @@ spec:
                           args:
                           - "storage_on_server_create.yml"
                           - --extra-vars
-                          - "project_id={{steps.convert-project-id.outputs.result}} device_id={{workflow.parameters.device_id}} env=dev"
+                          - "project_id={{steps.convert-project-id.outputs.result}} device_id={{workflow.parameters.device_id}}"
                           - "-i"
-                          - "inventory/uc-dev/01-nautobot.yaml"
+                          - "inventory/in-cluster/01-nautobot.yaml"
                           - "-vvv"
                           env:
                             - name: NAUTOBOT_TOKEN
@@ -116,6 +116,10 @@ spec:
                                 secretKeyRef:
                                   key: token
                                   name: nautobot-token
+                          envFrom:
+                            - configMapRef:
+                                name: cluster-metadata
+                                optional: false
                   - - name: ansible-storage-update
                       when: "\"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted"
                       inline:
@@ -125,7 +129,7 @@ spec:
                           args:
                           - "storage_update_switches.yml"
                           - "-i"
-                          - "inventory/uc-dev/01-nautobot.yaml"
+                          - "inventory/in-cluster/01-nautobot.yaml"
                           - "-vvv"
                           env:
                             - name: NAUTOBOT_TOKEN
@@ -133,3 +137,7 @@ spec:
                                 secretKeyRef:
                                   key: token
                                   name: nautobot-token
+                          envFrom:
+                            - configMapRef:
+                                name: cluster-metadata
+                                optional: false

--- a/workflows/openstack/sensors/sensor-ironic-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-ironic-oslo-event.yaml
@@ -39,6 +39,10 @@ spec:
           type: "string"
           value:
             - "baremetal.node.provision_set.end"
+        - path: "body.ironic_object.previous_provision_state"
+          type: "string"
+          value:
+            - "deploying"
   template:
     serviceAccountName: sensor-submit-workflow
   triggers:

--- a/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
@@ -97,50 +97,28 @@ spec:
 
                   - - name: ansible-create-project
                       when: "{{steps.oslo-events.outputs.parameters.svm_enabled}} == True"
-                      inline:
-                        container:
-                          image: ghcr.io/rss-engineering/undercloud-nautobot/ansible:latest
-                          command: [ansible-playbook]
-                          args:
-                          - "storage_on_create_project.yml"
-                          - --extra-vars
-                          - "project_id={{steps.convert-project-id.outputs.result}}"
-                          - "-i"
-                          - "inventory/in-cluster/01-nautobot.yaml"
-                          - "-vvv"
-                          env:
-                            - name: NAUTOBOT_TOKEN
-                              valueFrom:
-                                secretKeyRef:
-                                  key: token
-                                  name: nautobot-token
-                          envFrom:
-                            - configMapRef:
-                                name: cluster-metadata
-                                optional: false
+                      templateRef:
+                        name: ansible-workflow-template
+                        template: ansible-run
+                      arguments:
+                        parameters:
+                        - name: playbook
+                          value: storage_on_create_project.yml
+                        - name: extra_vars
+                          value: "project_id={{steps.convert-project-id.outputs.result}}"
+
                   - - name: ansible-create-svm
                       when: "{{steps.oslo-events.outputs.parameters.svm_created}} == True"
-                      inline:
-                        container:
-                          image: ghcr.io/rss-engineering/undercloud-nautobot/ansible:latest
-                          command: [ansible-playbook]
-                          args:
-                          - "storage_on_svm_create.yml"
-                          - --extra-vars
-                          - "svm_name=os-{{workflow.parameters.project_id}} project_id={{steps.convert-project-id.outputs.result}}"
-                          - "-i"
-                          - "inventory/in-cluster/01-nautobot.yaml"
-                          - "-vvv"
-                          env:
-                            - name: NAUTOBOT_TOKEN
-                              valueFrom:
-                                secretKeyRef:
-                                  key: token
-                                  name: nautobot-token
-                          envFrom:
-                            - configMapRef:
-                                name: cluster-metadata
-                                optional: false
+                      templateRef:
+                        name: ansible-workflow-template
+                        template: ansible-run
+                      arguments:
+                        parameters:
+                        - name: playbook
+                          value: storage_on_svm_create.yml
+                        - name: extra_vars
+                          value: svm_name=os-{{workflow.parameters.project_id}} project_id={{steps.convert-project-id.outputs.result}}
+
                   - - name: netapp-configure-net
                       when: "{{steps.oslo-events.outputs.parameters.svm_created}} == True"
                       templateRef:

--- a/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-oslo-event.yaml
@@ -104,18 +104,20 @@ spec:
                           args:
                           - "storage_on_create_project.yml"
                           - --extra-vars
-                          - "project_id={{steps.convert-project-id.outputs.result}} env=dev"
+                          - "project_id={{steps.convert-project-id.outputs.result}}"
                           - "-i"
-                          - "inventory/uc-dev/01-nautobot.yaml"
+                          - "inventory/in-cluster/01-nautobot.yaml"
                           - "-vvv"
-                            # TODO: this shouldn't be hardcodod to dev, but will work since
-                            # it really talks to https://nautobot-default.svc
                           env:
                             - name: NAUTOBOT_TOKEN
                               valueFrom:
                                 secretKeyRef:
                                   key: token
                                   name: nautobot-token
+                          envFrom:
+                            - configMapRef:
+                                name: cluster-metadata
+                                optional: false
                   - - name: ansible-create-svm
                       when: "{{steps.oslo-events.outputs.parameters.svm_created}} == True"
                       inline:
@@ -125,18 +127,20 @@ spec:
                           args:
                           - "storage_on_svm_create.yml"
                           - --extra-vars
-                          - "svm_name=os-{{workflow.parameters.project_id}} project_id={{steps.convert-project-id.outputs.result}} env=dev"
+                          - "svm_name=os-{{workflow.parameters.project_id}} project_id={{steps.convert-project-id.outputs.result}}"
                           - "-i"
-                          - "inventory/uc-dev/01-nautobot.yaml"
+                          - "inventory/in-cluster/01-nautobot.yaml"
                           - "-vvv"
-                            # TODO: this shouldn't be hardcodod to dev, but will work since
-                            # it really talks to https://nautobot-default.svc
                           env:
                             - name: NAUTOBOT_TOKEN
                               valueFrom:
                                 secretKeyRef:
                                   key: token
                                   name: nautobot-token
+                          envFrom:
+                            - configMapRef:
+                                name: cluster-metadata
+                                optional: false
                   - - name: netapp-configure-net
                       when: "{{steps.oslo-events.outputs.parameters.svm_created}} == True"
                       templateRef:


### PR DESCRIPTION
This PR changes the storage related Argo Workflows and Sensors to stop using hardcoded `env` variables and switches to [generic inventory added in undercloud-rackspace#533](https://github.com/RSS-Engineering/undercloud-rackspace/pull/533). 

The environment variables are now dynamically set by reading the `UNDERSTACK_ENV` variable that is injected through [`cluster-metadata` ConfigMap](https://github.com/RSS-Engineering/undercloud-deploy/pull/691)


Related:
- https://github.com/RSS-Engineering/undercloud-deploy/pull/691
- https://github.com/RSS-Engineering/undercloud-rackspace/pull/533
- https://rackspace.atlassian.net/browse/PUC-1170

Closes https://rackspace.atlassian.net/browse/PUC-1200