### PR TITLE
chore: remove unused password refs in the openstack helm values file

### DIFF
--- a/components/openstack-secrets.tpl.yaml
+++ b/components/openstack-secrets.tpl.yaml
@@ -7,42 +7,6 @@ endpoints:
 
   # 'identity' endpoints are for keystone access
   identity:
-    auth:
-      # this is the 'admin' user created in keystone by the initial start
-      # and used by the other services to create their service accounts
-      # and endpoint in the service catalog.
-      admin:
-        password: "${ADMIN_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-      # this user is the service account that glance uses
-      glance:
-        password: "${GLANCE_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-      # this user is the service account that ironic uses
-      ironic:
-        password: "${IRONIC_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-      # this user is the service account that neutron uses
-      neutron:
-        password: "${NEUTRON_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-      # this user is the service account that nova uses
-      nova:
-        password: "${NOVA_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-      # this user is the service account that placement uses
-      placement:
-        password: "${PLACEMENT_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-      # this user is the service account that cinder uses
-      cinder:
-        password: "${CINDER_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-      # this user is the service account that octavia uses
-      octavia:
-        password: "${OCTAVIA_KEYSTONE_PASSWORD}"
-        region_name: "${DEPLOY_NAME}"
-
     # set our public facing URL
     host_fqdn_override:
       public:


### PR DESCRIPTION
We do not need this templated in anymore since we are using ESO to configure these secrets and no longer need the OpenStack Helm charts to template them in.