### PR TITLE
fix(openstack): include more fields for the service users

### DIFF
--- a/components/openstack/templates/_helpers.tpl
+++ b/components/openstack/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "openstack.serviceuser.user_domain_name" -}}
+{{- eq .usage "admin" | ternary "default" "service" }}
+{{- end }}
+
+{{- define "openstack.serviceuser.project_domain_name" -}}
+{{-  eq .usage "admin" | ternary "default" ( default "service" .project_domain_name ) }}
+{{- end }}
+
+{{- define "openstack.serviceuser.project_name" -}}
+{{- eq .usage "admin" | ternary "admin" ( default "service" .project_name ) }}
+{{- end }}


### PR DESCRIPTION
The upstream charts do not include a few more of these fields by default for service users so we need to include those in our chart as well. To avoid duplication create helpers so that the behavior stays consistent.