### PR TITLE
chore(renovate): include more in Argo Workflows updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,8 @@
       "matchPackageNames": [
         "quay.io/argoproj/workflow-controller",
         "quay.io/argoproj/argoexec",
-        "quay.io/argoproj/argocli"
+        "quay.io/argoproj/argocli",
+        "argoproj/argo-workflows"
       ],
       "groupName": "Argo Workflows",
       "commitMessageTopic": "Argo Workflows"


### PR DESCRIPTION
We will need to include packages from argoproj/argo-workflows in Argo Workflows updates as well. ref PUC-1229