### PR TITLE
feat: add the ability to create Keystone service users

### DIFF
--- a/docs/deploy-guide/openstack-svc-users.md
+++ b/docs/deploy-guide/openstack-svc-users.md
@@ -1,0 +1,36 @@
+# OpenStack Service Users
+
+Should you need to create service accounts in OpenStack you can do so
+by creating a Kubernetes Secret in the `openstack` namespace with
+the following labels:
+
+`understack.rackspace.com/keystone-role`:
+  Defines what this account will have access to do.
+
+`understack.rackspace.com/keystone-user`:
+  Defines the username in OpenStack Keystone in the `service` domain
+  which will be created.
+
+Possible roles are:
+
+- `tenant-reader` which allows read access to tenant resources
+- `tenant-readwrite` which allows read and write access to tenant resources
+- `infra-reader` which allows read access to infrastructure resources
+- `infra-readwrite` which allows read and write access to infrastructure resources
+
+Roles can be comma separated.
+
+An example secret would look like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysvc
+  labels:
+    understack.rackspace.com/keystone-role: tenant-reader
+    understack.rackspace.com/keystone-user: mysvc
+type: Opaque
+dataString:
+  password: MY_PASSWORD
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - deploy-guide/config-dex.md
       - deploy-guide/config-openstack.md
       - deploy-guide/secrets-eso-setup.md
+      - deploy-guide/openstack-svc-users.md
       - deploy-guide/auth.md
       - deploy-guide/config-argo-workflows.md
     - Starting the Deployment:

--- a/workflows/openstack/eventsources/eventsource-k8s-openstack-secrets.yaml
+++ b/workflows/openstack/eventsources/eventsource-k8s-openstack-secrets.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: k8s-openstack-secrets
+  namespace: openstack
+spec:
+  template:
+    serviceAccountName: k8s-openstack-events-secrets
+  # Kubernetes resource event sources
+  resource:
+    keystone-integration-reader-add:
+      # monitor deployment resources under openstack namespace
+      namespace: openstack
+      group: ""
+      version: v1
+      resource: secrets
+      # Event types to listen for (e.g., ADD, UPDATE, DELETE).
+      eventTypes:
+        - ADD
+        - UPDATE
+      filter:
+        labels:
+          - key: understack.rackspace.com/keystone-role
+            operation: exists
+          - key: understack.rackspace.com/keystone-user
+            operation: exists
+    keystone-integration-reader-delete:
+      # monitor deployment resources under openstack namespace
+      namespace: openstack
+      group: ""
+      version: v1
+      resource: secrets
+      # Event types to listen for (e.g., ADD, UPDATE, DELETE).
+      eventTypes:
+        - DELETE
+      filter:
+        labels:
+          - key: understack.rackspace.com/keystone-user
+            operation: exists

--- a/workflows/openstack/sensors/sensor-keystone-integration-reader-add.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-integration-reader-add.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: keystone-integration-reader-add
+  namespace: openstack
+spec:
+  template:
+    serviceAccountName: k8s-openstack-events-secrets
+  # events the Sensor listens for
+  dependencies:
+    - name: secret-dep
+      eventName: keystone-integration-reader-add
+      eventSourceName: k8s-openstack-secrets
+  # actions executed when dependencies are satisfied (StandardK8STrigger designed to create or update a generic Kubernetes resource.)
+  triggers:
+    - template:
+        name: keystone-user-create-update
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                generateName: keystone-integration-reader-add-
+              spec:
+                ttlSecondsAfterFinished: 600
+                backoffLimit: 3
+                template:
+                  spec:
+                    containers:
+                      - name: keystone-user-create-update
+                        image: quay.io/airshipit/heat:2024.2-ubuntu_jammy
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            echo "Received Secret Event ${EVENT_TYPE} for ${SECRET_NAME}"
+                            set -x
+                            SVC_ROLES=$(python -c "import json,os; print(json.loads(os.environ.get('LABELS') or '{}').get('understack.rackspace.com/keystone-role',''))")
+                            SVC_USER=$(python -c "import json,os; print(json.loads(os.environ.get('LABELS') or '{}').get('understack.rackspace.com/keystone-user',''))")
+                            SVC_USER=${SVC_USER:-$SECRET_NAME}
+                            PROJ_ID=$(openstack project create --or-show --domain service integration -f value -c id)
+                            SVC_ID=$(openstack user create --or-show --domain service --project "${PROJ_ID}" --description "${SECRET_NAME}" "${SVC_USER}" -f value -c id)
+                            openstack user set --description "${SECRET_NAME}" --project "${PROJ_ID}" "${SVC_ID}"
+                            set +x
+                            svc_pass=$(cat /tmp/user-create/password)
+                            openstack user set --password "${svc_pass}" "${SVC_ID}"
+                            set -x
+                            openstack role add --user "${SVC_ID}" --project "${PROJ_ID}" reader
+                            IFS=','
+                            for svc_role in ${SVC_ROLES}; do
+                              case ${svc_role} in
+                              tenant-reader)
+                                openstack role add --user "${SVC_ID}" --domain default --inherited reader
+                                ;;
+                              tenant-readwrite)
+                                openstack role add --user "${SVC_ID}" --domain default --inherited member
+                                ;;
+                              infra-reader)
+                                openstack role add --user "${SVC_ID}" --project-domain infra --project baremetal reader
+                                ;;
+                              infra-readwrite)
+                                openstack role add --user "${SVC_ID}" --project-domain infra --project baremetal admin
+                                ;;
+                              *)
+                                echo "Invalid role ${svc_role}"
+                                ;;
+                              esac
+                            done
+                        env:
+                          - name: EVENT_TYPE
+                            value: "placeholder"
+                          - name: SECRET_NAME
+                            value: "placeholder"
+                          - name: LABELS
+                            value: "placeholder"
+                        envFrom:
+                          - secretRef:
+                              name: keystone-keystone-admin
+                        volumeMounts:
+                          - name: user-create
+                            mountPath: /tmp/user-create
+                    volumes:
+                      - name: user-create
+                        secret:
+                          secretName: "placeholder"
+                    restartPolicy: OnFailure
+          parameters:
+            - src:
+                dependencyName: secret-dep
+                dataKey: body.type
+              dest: spec.template.spec.containers.0.env.0.value
+            - src:
+                dependencyName: secret-dep
+                dataKey: body.metadata.name
+              dest: spec.template.spec.containers.0.env.1.value
+            - src:
+                dependencyName: secret-dep
+                dataKey: body.metadata.labels
+              dest: spec.template.spec.containers.0.env.2.value
+            - src:
+                dependencyName: secret-dep
+                dataKey: body.metadata.name
+              dest: spec.template.spec.volumes.0.secret.secretName

--- a/workflows/openstack/sensors/sensor-keystone-integration-reader-rm.yaml
+++ b/workflows/openstack/sensors/sensor-keystone-integration-reader-rm.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: keystone-integration-reader-rm
+  namespace: openstack
+spec:
+  template:
+    serviceAccountName: k8s-openstack-events-secrets
+  # events the Sensor listens for
+  dependencies:
+    - name: secret-dep
+      eventName: keystone-integration-reader-delete
+      eventSourceName: k8s-openstack-secrets
+  # actions executed when dependencies are satisfied (StandardK8STrigger designed to create or update a generic Kubernetes resource.)
+  triggers:
+    - template:
+        name: keystone-user-delete
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                generateName: keystone-integration-reader-rm-
+              spec:
+                ttlSecondsAfterFinished: 600
+                backoffLimit: 3
+                template:
+                  spec:
+                    containers:
+                      - name: keystone-user-delete
+                        image: quay.io/airshipit/heat:2024.2-ubuntu_jammy
+                        command: ["sh", "-c"]
+                        args:
+                          - |
+                            echo "Received Secret Event ${EVENT_TYPE} for ${SECRET_NAME}"
+                            set -x
+                            SVC_USER=$(python -c "import json,os; print(json.loads(os.environ.get('LABELS') or '{}').get('understack.rackspace.com/keystone-user',''))")
+                            SVC_USER=${SVC_USER:-$SECRET_NAME}
+                            openstack user delete --domain service "${SVC_USER}"
+                        env:
+                          - name: EVENT_TYPE
+                            value: "placeholder"
+                          - name: SECRET_NAME
+                            value: "placeholder"
+                          - name: LABELS
+                            value: "placeholder"
+                        envFrom:
+                          - secretRef:
+                              name: keystone-keystone-admin
+                    restartPolicy: OnFailure
+          parameters:
+            - src:
+                dependencyName: secret-dep
+                dataKey: body.type
+              dest: spec.template.spec.containers.0.env.0.value
+            - src:
+                dependencyName: secret-dep
+                dataKey: body.metadata.name
+              dest: spec.template.spec.containers.0.env.1.value
+            - src:
+                dependencyName: secret-dep
+                dataKey: body.metadata.labels
+              dest: spec.template.spec.containers.0.env.2.value

--- a/workflows/openstack/serviceaccounts/serviceaccount-k8s-openstack-events-secrets.yaml
+++ b/workflows/openstack/serviceaccounts/serviceaccount-k8s-openstack-events-secrets.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: openstack
+  name: k8s-openstack-events-secrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: openstack
+  name: k8s-openstack-events-secrets
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openstack
+  name: k8s-openstack-events-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: k8s-openstack-events-secrets
+subjects:
+  - kind: ServiceAccount
+    name: k8s-openstack-events-secrets
+    namespace: openstack


### PR DESCRIPTION
For various integrations user might want to create Keystone users for different purposes. This allows users to define a Kubernetes Secret in the cluster and have a Keystone service user created for them at different permission levels.