### PR TITLE
chore(renovate): config mariadb-operator and mariadb-operator-crds

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,14 @@
       "commitMessageTopic": "Go"
     },
     {
+      "matchPackageNames": [
+        "mariadb-operator",
+        "mariadb-operator-crds"
+      ],
+      "groupName": "MariaDB Operator",
+      "commitMessageTopic": "MariaDB Operator"
+    },
+    {
       "enabled": false,
       "matchPackageNames": ["python"],
       "matchUpdateTypes": ["major", "minor"]


### PR DESCRIPTION
We want these to be one PR and get bumped together and never separately to avoid out of sync deployments.