### PR TITLE
chore(renovate): combine golang updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,7 @@
       "commitMessageTopic": "Argo Workflows"
     },
     {
+      "matchManagers": ["asdf", "gomod"],
       "matchDatasources": ["golang-version"],
       "groupName": "Go",
       "commitMessageTopic": "Go"


### PR DESCRIPTION
Renovate is creating updates to .tool-version and go.mod separately which doesn't work so we need to tell it to create those together.