### PR TITLE
chore(renovate): combine golang updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,8 +26,8 @@
       "commitMessageTopic": "Argo Workflows"
     },
     {
+      "matchPackageNames": ["go", "golang"],
       "matchManagers": ["asdf", "gomod"],
-      "matchDatasources": ["golang-version"],
       "groupName": "Go",
       "commitMessageTopic": "Go"
     },


### PR DESCRIPTION
Renovate is creating updates to .tool-version and go.mod separately which doesn't work so we need to tell it to create those together. Attempt number 2.