### PR TITLE
fix(argo-workflows): re-enable argo-server ClusterRoleBinding

### DIFF
--- a/components/argo-workflows/delete-argo-server-crb.yaml
+++ b/components/argo-workflows/delete-argo-server-crb.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: argo-server-binding
-$patch: delete

--- a/components/argo-workflows/kustomization.yaml
+++ b/components/argo-workflows/kustomization.yaml
@@ -38,13 +38,6 @@ patches:
 - target:
     group: rbac.authorization.k8s.io
     version: v1
-    kind: ClusterRoleBinding
-    name: argo-server-binding
-  path: delete-argo-server-crb.yaml
-
-- target:
-    group: rbac.authorization.k8s.io
-    version: v1
     kind: Role
     name: argo-role
   path: workflow-controller-role.yaml


### PR DESCRIPTION
Since 3.7 we need to give the Argo Server needs a CRB to see the workflows.