### PR TITLE
fix: external-dns chart version update

### DIFF
--- a/apps/operators/external-dns.yaml
+++ b/apps/operators/external-dns.yaml
@@ -3,7 +3,7 @@ component: external-dns
 sources:
   - repoURL: ghcr.io/rackerlabs/charts
     chart: external-dns-rackspace
-    targetRevision: 0.0.1
+    targetRevision: 0.0.2
     helm:
       releaseName: external-dns-rackspace
       namespace: "external-dns"


### PR DESCRIPTION
This is updating chart version for external-dns full change log for external-dns can be found here 
https://github.com/rackerlabs/external-dns-rackspace-webhook/releases/tag/v0.0.2