### PR TITLE
chore(renovate): skip Python version bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,7 +41,7 @@
     },
     {
       "enabled": false,
-      "matchPackageNames": ["python"],
+      "matchPackageNames": ["python", "actions/python-versions"],
       "matchUpdateTypes": ["major", "minor"]
     }
   ],


### PR DESCRIPTION
Our Python version comes from the OS container we are shipping with. There's multiple Python versions involved so let's skip this rule entirely for now and create something later to check the appropriate versions.