### PR TITLE
chore(octavia): ensure we do not break from newer chart

### DIFF
--- a/components/octavia/values.yaml
+++ b/components/octavia/values.yaml
@@ -52,6 +52,11 @@ conf:
       ovn_sb_connection: tcp:ovn-ovsdb-sb.openstack.svc.cluster.local:6642
     task_flow:
       jobboard_enabled: false
+  octavia_api_uwsgi:
+    uwsgi:
+      # When upgrading to 2025.2 remove this as the wsgi script was removed
+      # https://opendev.org/openstack/openstack-helm/commit/b1d85c20e36adac9eaee584ef095d9c010cc1dc4
+      wsgi-file: /var/lib/openstack/bin/octavia-wsgi
 
 dependencies:
   dynamic:


### PR DESCRIPTION
The Octavia chart switched to defaulting to the behavior of the 2025.2 version but we are not yet upgrading so we need to ensure we maintain 2025.1 and older support by default.