### PR TITLE
fix(rally): We no longer need to use a custom user plugin

### DIFF
--- a/python/understack-tests/build_a_single_server_with_network.yaml
+++ b/python/understack-tests/build_a_single_server_with_network.yaml
@@ -12,7 +12,7 @@ subtasks:
           config_drive: true
           force_delete: false
       contexts:
-        users_custom:
+        users:
           tenants: 1
           users_per_tenant: 1
         network:


### PR DESCRIPTION
The original issue necessitating the use of the `users_custom` plugin was that we had to wait for the project creation sync from keystone to nautobot to complete. This process has been refactored and we no longer need to wait for the sync.