### PR TITLE
fix: flavorsync service acct role

### DIFF
--- a/ansible/roles/keystone_bootstrap/tasks/misc.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/misc.yml
@@ -59,6 +59,6 @@
 - name: Set 'flavorsync' role
   openstack.cloud.role_assignment:
     user: "{{ _flavor_sync_user.user.id }}"
-    domain: default
+    domain: service
     role: flavorsync
     state: present


### PR DESCRIPTION
While the flavors themselves are not scoped to a specific project, the project scoped tokens by default are issued for the project that the user is in. As a result, if we are creating `'flavorsync'` service account in `'service'` project, we should assign the role there too instead of the `default`.


Following this change, I was able to test with:

clouds.yaml
```yaml
  uc_iad_dev_flavorsync:
    auth_url: https://keystone.dev.undercloud.rackspace.net/v3
    region_name: iad3-dev
    auth:
      user_domain_name: service
      username: flavorsync
      password: REDACTED
      project_domain_name: service
      project_name: service
    interface: public
    identity_api_version: 3
```

```
❯ OS_CLOUD=uc_iad_dev_flavorsync openstack flavor create gp3.small
+----------------------------+--------------------------------------+
| Field                      | Value                                |
+----------------------------+--------------------------------------+
| OS-FLV-DISABLED:disabled   | False                                |
| OS-FLV-EXT-DATA:ephemeral  | 0                                    |
| description                | None                                 |
| disk                       | 0                                    |
| id                         | c117f4e1-0e60-4d1a-a2d8-f911ee525a9f |
| name                       | gp3.small                            |
| os-flavor-access:is_public | True                                 |
| properties                 |                                      |
| ram                        | 256                                  |
| rxtx_factor                | 1.0                                  |
| swap                       | 0                                    |
| vcpus                      | 1                                    |
+----------------------------+--------------------------------------+
(devbox)
```