### PR TITLE
chore(external-dns): Bump up the chart version for external-dns

### DIFF
--- a/apps/operators/external-dns.yaml
+++ b/apps/operators/external-dns.yaml
@@ -3,7 +3,7 @@ component: external-dns
 sources:
   - repoURL: ghcr.io/rackerlabs/charts
     chart: external-dns-rackspace
-    targetRevision: 0.2.0
+    targetRevision: 0.2.2
     helm:
       releaseName: external-dns-rackspace
       namespace: "external-dns"


### PR DESCRIPTION
This PR updates the external dns chart version.