### PR TITLE
feat(argocd-understack): create split rook-ceph Applications

### DIFF
--- a/charts/argocd-understack/templates/application-rook-ceph-cluster.yaml
+++ b/charts/argocd-understack/templates/application-rook-ceph-cluster.yaml
@@ -1,0 +1,53 @@
+{{- $installApp := eq (include "understack.componentOptionAny" (list $ "rook_ceph_cluster" "installApp" true)) "true" }}
+{{- $installConfigs := eq (include "understack.componentOptionAny" (list $ "rook_ceph_cluster" "installConfigs" false)) "true" }}
+{{- if or $installApp $installConfigs }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name "rook-ceph-cluster" }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+    argocd.argoproj.io/sync-wave: "1"
+{{- include "understack.appLabelsBlock" $ | nindent 2 }}
+spec:
+  destination:
+    namespace: rook-ceph
+    server: {{ $.Values.cluster_server }}
+  project: understack-operators
+  sources:
+  {{- if $installApp }}
+  - chart: rook-ceph-cluster
+    helm:
+      ignoreMissingValueFiles: true
+      releaseName: rook-ceph-cluster
+      valueFiles:
+      - $understack/operators/rook/values-cluster.yaml
+      - $deploy/{{ include "understack.deploy_path" $ }}/rook-ceph-cluster/values.yaml
+    repoURL: https://charts.rook.io/release
+    targetRevision: v1.16.4
+  - path: operators/rook
+    ref: understack
+    repoURL: {{ include "understack.understack_url" $ }}
+    targetRevision: {{ include "understack.understack_ref" $ }}
+  - ref: deploy
+    repoURL: {{ include "understack.deploy_url" $ }}
+    targetRevision: {{ include "understack.deploy_ref" $ }}
+  {{- end }}
+  {{- if $installConfigs }}
+  - path: {{ include "understack.deploy_path" $ }}/rook-ceph-cluster
+    repoURL: {{ include "understack.deploy_url" $ }}
+    targetRevision: {{ include "understack.deploy_ref" $ }}
+  {{- end }}
+  syncPolicy:
+    automated:
+      # to avoid data loss, do not auto-prune
+      prune: false
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+{{- end }}

--- a/charts/argocd-understack/templates/application-rook-ceph-operator.yaml
+++ b/charts/argocd-understack/templates/application-rook-ceph-operator.yaml
@@ -1,0 +1,57 @@
+{{- $installApp := eq (include "understack.componentOptionAny" (list $ "rook_ceph_operator" "installApp" true)) "true" }}
+{{- $installConfigs := eq (include "understack.componentOptionAny" (list $ "rook_ceph_operator" "installConfigs" false)) "true" }}
+{{- if or $installApp $installConfigs }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name "rook-ceph-operator" }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+    argocd.argoproj.io/sync-wave: "0"
+{{- include "understack.appLabelsBlock" $ | nindent 2 }}
+spec:
+  destination:
+    namespace: rook-ceph
+    server: {{ $.Values.cluster_server }}
+  project: understack-operators
+  sources:
+  {{- if $installApp }}
+  - chart: rook-ceph
+    helm:
+      ignoreMissingValueFiles: true
+      releaseName: rook-ceph
+      valueFiles:
+      - $understack/operators/rook/values-operator.yaml
+      - $deploy/{{ include "understack.deploy_path" $ }}/rook-ceph-operator/values.yaml
+    repoURL: https://charts.rook.io/release
+    targetRevision: v1.16.4
+  - path: operators/rook
+    ref: understack
+    repoURL: {{ include "understack.understack_url" $ }}
+    targetRevision: {{ include "understack.understack_ref" $ }}
+  - ref: deploy
+    repoURL: {{ include "understack.deploy_url" $ }}
+    targetRevision: {{ include "understack.deploy_ref" $ }}
+  {{- end }}
+  {{- if $installConfigs }}
+  - path: {{ include "understack.deploy_path" $ }}/rook-ceph-operator
+    repoURL: {{ include "understack.deploy_url" $ }}
+    targetRevision: {{ include "understack.deploy_ref" $ }}
+  {{- end }}
+  syncPolicy:
+    automated:
+      # to avoid data loss do not auto-prune
+      prune: false
+      selfHeal: true
+    managedNamespaceMetadata:
+      annotations:
+        argocd.argoproj.io/sync-options: Delete=false
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+    - RespectIgnoreDifferences=true
+    - ApplyOutOfSyncOnly=true
+{{- end }}

--- a/charts/argocd-understack/values.yaml
+++ b/charts/argocd-understack/values.yaml
@@ -193,6 +193,24 @@ global:
     # @default -- false
     enabled: false
 
+  # -- Rook Ceph Operator (split from main rook application)
+  rook_ceph_operator:
+    # -- Enable/disable deploying the Rook Ceph Operator Helm chart
+    # @default -- false
+    installApp: false
+    # -- Enable/disable deploying site-specific Rook operator configs from the deploy repo
+    # @default -- false
+    installConfigs: false
+
+  # -- Rook Ceph Cluster (split from main rook application)
+  rook_ceph_cluster:
+    # -- Enable/disable deploying the Rook Ceph Cluster Helm chart
+    # @default -- false
+    installApp: false
+    # -- Enable/disable deploying site-specific Rook cluster configs from the deploy repo
+    # @default -- false
+    installConfigs: false
+
   # Sealed Secrets operator
   sealed_secrets:
     # -- Enable/disable deploying sealed secrets
@@ -513,6 +531,24 @@ site:
     # -- Enable/disable deploying Rook
     # @default -- false
     enabled: false
+
+  # -- Rook Ceph Operator (split from main rook application)
+  rook_ceph_operator:
+    # -- Enable/disable deploying the Rook Ceph Operator Helm chart
+    # @default -- false
+    installApp: false
+    # -- Enable/disable deploying site-specific Rook operator configs from the deploy repo
+    # @default -- false
+    installConfigs: false
+
+  # -- Rook Ceph Cluster (split from main rook application)
+  rook_ceph_cluster:
+    # -- Enable/disable deploying the Rook Ceph Cluster Helm chart
+    # @default -- false
+    installApp: false
+    # -- Enable/disable deploying site-specific Rook cluster configs from the deploy repo
+    # @default -- false
+    installConfigs: false
 
   # -- Site-specific workflows and event handlers
   site_workflows:

--- a/docs/deploy-guide/components/index.md
+++ b/docs/deploy-guide/components/index.md
@@ -24,6 +24,15 @@ site:
     enabled: false
 ```
 
+For newer components that use separate app/config controls, disable both:
+
+```yaml title="$CLUSTER_NAME/deploy.yaml"
+site:
+  cert_manager:
+    installApp: false
+    installConfigs: false
+```
+
 ### Enabling a Component
 
 Set `enabled: true` for that component key:
@@ -32,6 +41,15 @@ Set `enabled: true` for that component key:
 site:
   monitoring:
     enabled: true
+```
+
+For newer components, enable the appropriate options:
+
+```yaml title="$CLUSTER_NAME/deploy.yaml"
+site:
+  cert_manager:
+    installApp: true     # Deploy the Helm chart
+    installConfigs: true # Deploy site-specific configs
 ```
 
 ## Modifying Helm Values or Kustomize Overlays
@@ -86,6 +104,8 @@ enablement defaults, validation, and troubleshooting notes.
 | [ovn](./ovn.md) | site |
 | [rabbitmq-system](./rabbitmq-system.md) | global, site |
 | [rook](./rook.md) | global, site |
+| [rook-ceph-operator](./rook-ceph-operator.md) | global, site |
+| [rook-ceph-cluster](./rook-ceph-cluster.md) | global, site |
 | [sealed-secrets](./sealed-secrets.md) | global, site |
 | [site-workflows](./site-workflows.md) | site |
 | [snmp-exporter](./snmp-exporter.md) | site |

--- a/docs/deploy-guide/components/rook-ceph-cluster.md
+++ b/docs/deploy-guide/components/rook-ceph-cluster.md
@@ -1,0 +1,91 @@
+---
+charts:
+- rook-ceph-cluster
+kustomize_paths:
+- operators/rook
+deploy_overrides:
+  helm:
+    mode: values_files
+    paths:
+    - rook-ceph-cluster/values.yaml
+  kustomize:
+    mode: none
+---
+
+# rook-ceph-cluster
+
+Rook Ceph cluster installation (split from the combined rook component).
+
+## Deployment Scope
+
+- Cluster scope: global or site
+- Values keys: `global.rook_ceph_cluster`, `site.rook_ceph_cluster`
+- ArgoCD Application template: `charts/argocd-understack/templates/application-rook-ceph-cluster.yaml`
+- Sync wave: `1` (deploys after rook-ceph-operator)
+
+## How ArgoCD Builds It
+
+{{ component_argocd_builds() }}
+
+## How to Enable
+
+Enable this component by setting one or both options under the scope that matches your deployment model:
+
+```yaml title="$CLUSTER_NAME/deploy.yaml"
+global:
+  rook_ceph_cluster:
+    installApp: true
+site:
+  rook_ceph_cluster:
+    installApp: true
+```
+
+### Options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `installApp` | `false` | Deploy the rook-ceph-cluster Helm chart |
+| `installConfigs` | `false` | Deploy site-specific Rook cluster configs from the deploy repo |
+
+Typical deployment patterns:
+
+- **Per-site clusters**: Deploy clusters per-site with global operator
+- **Global cluster**: Single cluster for development/testing environments
+
+```yaml title="$CLUSTER_NAME/deploy.yaml"
+# Per-site clusters with global operator
+global:
+  rook_ceph_cluster:
+    installApp: false
+    installConfigs: false
+site:
+  rook_ceph_cluster:
+    installApp: true
+    installConfigs: true
+```
+
+## Deployment Repo Content
+
+{{ secrets_disclaimer }}
+
+When `installConfigs: true`, the Application reads from:
+
+```text
+$DEPLOY_REPO/<cluster-name>/rook-ceph-cluster/
+```
+
+Required or commonly required items:
+
+- `rook-ceph-cluster/values.yaml`: Provide cluster topology, storage devices, pools, object stores, and CSI settings.
+
+Optional additions:
+
+- `Storage credential or class resources`: If your values reference Secrets, StorageClasses, CephObjectStores, or similar supporting resources, materialize those final resources with whatever workflow you prefer.
+- Additional cluster configuration resources can be placed in the `rook-ceph-cluster/` deploy-repo path when `installConfigs: true`.
+
+## Important Notes
+
+- **Data Protection**: Auto-prune is disabled (`prune: false`) to prevent accidental deletion of storage cluster resources and potential data loss.
+- **Deployment Order**: This component has sync wave `1` and requires `rook-ceph-operator` (sync wave `0`) to be deployed first.
+- **Prerequisites**: Requires the Rook Ceph operator to be installed and running before cluster deployment.
+- **Namespace**: Uses the `rook-ceph` namespace created by the operator component.

--- a/docs/deploy-guide/components/rook-ceph-operator.md
+++ b/docs/deploy-guide/components/rook-ceph-operator.md
@@ -1,0 +1,89 @@
+---
+charts:
+- rook-ceph
+kustomize_paths:
+- operators/rook
+deploy_overrides:
+  helm:
+    mode: values_files
+    paths:
+    - rook-ceph-operator/values.yaml
+  kustomize:
+    mode: none
+---
+
+# rook-ceph-operator
+
+Rook Ceph operator installation (split from the combined rook component).
+
+## Deployment Scope
+
+- Cluster scope: global or site
+- Values keys: `global.rook_ceph_operator`, `site.rook_ceph_operator`
+- ArgoCD Application template: `charts/argocd-understack/templates/application-rook-ceph-operator.yaml`
+- Sync wave: `0` (deploys before rook-ceph-cluster)
+
+## How ArgoCD Builds It
+
+{{ component_argocd_builds() }}
+
+## How to Enable
+
+Enable this component by setting one or both options under the scope that matches your deployment model:
+
+```yaml title="$CLUSTER_NAME/deploy.yaml"
+global:
+  rook_ceph_operator:
+    installApp: true
+site:
+  rook_ceph_operator:
+    installApp: true
+```
+
+### Options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `installApp` | `false` | Deploy the rook-ceph Helm chart (operator) |
+| `installConfigs` | `false` | Deploy site-specific Rook operator configs from the deploy repo |
+
+Typical deployment patterns:
+
+- **Global operator**: Deploy operator globally and clusters per-site
+- **Per-site operator**: Deploy both operator and cluster per-site for isolation
+
+```yaml title="$CLUSTER_NAME/deploy.yaml"
+# Global operator, site clusters
+global:
+  rook_ceph_operator:
+    installApp: true
+    installConfigs: true
+site:
+  rook_ceph_operator:
+    installApp: false
+    installConfigs: false
+```
+
+## Deployment Repo Content
+
+{{ secrets_disclaimer }}
+
+When `installConfigs: true`, the Application reads from:
+
+```text
+$DEPLOY_REPO/<cluster-name>/rook-ceph-operator/
+```
+
+Required or commonly required items:
+
+- `rook-ceph-operator/values.yaml`: Provide operator chart overrides when the shared defaults are not sufficient.
+
+Optional additions:
+
+- Additional operator configuration resources can be placed in the `rook-ceph-operator/` deploy-repo path when `installConfigs: true`.
+
+## Important Notes
+
+- **Data Protection**: Auto-prune is disabled (`prune: false`) to prevent accidental deletion of storage operator resources.
+- **Deployment Order**: This component has sync wave `0` and should deploy before `rook-ceph-cluster` (sync wave `1`).
+- **Namespace Management**: Creates the `rook-ceph` namespace with deletion protection.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,6 +207,8 @@ nav:
       - deploy-guide/components/placement.md
       - deploy-guide/components/rabbitmq-system.md
       - deploy-guide/components/rook.md
+      - deploy-guide/components/rook-ceph-cluster.md
+      - deploy-guide/components/rook-ceph-operator.md
       - deploy-guide/components/sealed-secrets.md
       - deploy-guide/components/site-workflows.md
       - deploy-guide/components/skyline.md


### PR DESCRIPTION
This allows us to install the operator and upgrade the operator
independently from the cluster as well as ensuring that the cluster
syncs after the operator does. This does not remove the existing
deployment to give us an opportunity to transition over.
