### PR TITLE
feat(placement): replace lazy-apps with close-on-exec/need-app in uWSGI

### DIFF
--- a/components/placement/values.yaml
+++ b/components/placement/values.yaml
@@ -1,6 +1,17 @@
 ---
 release_group: null
 
+conf:
+  placement_api_uwsgi:
+    uwsgi:
+      start-time: "%t"
+      # Replace lazy-apps with need-app + close-on-exec per
+      # https://review.opendev.org/c/openstack/devstack/+/983361
+      lazy-apps: false
+      need-app: true
+      close-on-exec: true
+      close-on-exec2: true
+
 network:
   # configure OpenStack Helm to use Undercloud's ingress
   # instead of expecting the ingress controller provided


### PR DESCRIPTION
lazy-apps=true was originally added to work around a bug where connections opened during app init (e.g. memcache sockets) were shared between uWSGI workers after forking (LP: #1600394). While effective, it defeats uWSGI's Copy-on-Write optimization from the master process and defers app loading until after fork, meaning a broken application won't be caught until workers try to serve.

close-on-exec=true and close-on-exec2=true directly fix the fd-sharing problem by instructing uWSGI to close inherited file descriptors in each worker after forking, without sacrificing CoW.

need-app=true causes uWSGI to exit immediately if the application fails to load, rather than leaving the master process running and appearing healthy while workers can't serve requests. This makes failures visible to liveness probes and the process manager.

Ref: https://review.opendev.org/c/openstack/devstack/+/983361
Ref: https://bugs.launchpad.net/keystone/+bug/1600394