### PR TITLE
chore: ensure OpenStack RabbitMQ notifications are enabled

### DIFF
--- a/components/cinder/values.yaml
+++ b/components/cinder/values.yaml
@@ -14,13 +14,15 @@ conf:
       volume_backend_name: netapp_nvme
       volume_driver: cinder_understack.dynamic_netapp_driver.NetappCinderDynamicDriver
   cinder:
-    oslo_messaging_rabbit:
-      amqp_durable_queues: true
     DEFAULT:
       enabled_backends: netapp_nvme
       default_volume_type: __DEFAULT__
       # add DriverFilter to the default list so our SVM filtering function gets called
       scheduler_default_filters: DriverFilter,AvailabilityZoneFilter,CapacityFilter,CapabilitiesFilter
+    oslo_messaging_notifications:
+      driver: messagingv2
+    oslo_messaging_rabbit:
+      amqp_durable_queues: true
   rabbitmq:
     policies: [] # Override the policy being injected by OSH
   cinder_api_uwsgi:

--- a/components/glance/values.yaml
+++ b/components/glance/values.yaml
@@ -116,6 +116,8 @@ pod:
 
 conf:
   glance:
+    oslo_messaging_notifications:
+      driver: messagingv2
     oslo_messaging_rabbit:
       amqp_durable_queues: true
   glance_api_uwsgi:

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -89,6 +89,8 @@ conf:
       post_deploy_get_power_state_retry_interval: 18
     dhcp:
       dhcp_provider: dnsmasq
+    oslo_messaging_notifications:
+      driver: messagingv2
     oslo_messaging_rabbit:
       amqp_durable_queues: true
     pxe:

--- a/components/keystone/values.yaml
+++ b/components/keystone/values.yaml
@@ -189,6 +189,8 @@ conf:
       backend_argument: memcached_expire_time:3600
     DEFAULT:
       max_token_size: 512
+    oslo_messaging_notifications:
+      driver: messagingv2
     oslo_messaging_rabbit:
       amqp_durable_queues: true
 

--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -83,6 +83,8 @@ conf:
       default_availability_zones: ""
       # add 50 to the max MTU we want of 9000 to handle Neutron's -50 for VXLAN type
       global_physnet_mtu: 9050
+    oslo_messaging_notifications:
+      driver: messagingv2
     oslo_messaging_rabbit:
       amqp_durable_queues: true
       # https://docs.openstack.org/large-scale/journey/configure/rabbitmq.html#rabbit-transient-queues-ttl

--- a/components/nova/values.yaml
+++ b/components/nova/values.yaml
@@ -76,6 +76,8 @@ conf:
     ironic:
       api_max_retries: 90  # number of times to retry. default is 60.
       api_retry_interval: 10  # number of sesconds between retries. default is 2.
+    oslo_messaging_notifications:
+      driver: messagingv2
     oslo_messaging_rabbit:
       amqp_durable_queues: true
 

--- a/components/octavia/values.yaml
+++ b/components/octavia/values.yaml
@@ -47,8 +47,10 @@ conf:
       ovn_sb_connection: tcp:ovn-ovsdb-sb.openstack.svc.cluster.local:6642
     task_flow:
       jobboard_enabled: false
-  oslo_messaging_rabbit:
-    amqp_durable_queues: true
+    oslo_messaging_notifications:
+      driver: messagingv2
+    oslo_messaging_rabbit:
+      amqp_durable_queues: true
 
 dependencies:
   dynamic:


### PR DESCRIPTION
Ensure that for all the services that we want notifications from
OpenStack we have them enabled in a consistent manner through RabbitMQ.
Fixed Octavia's incorrect indent for the oslo_messaging_rabbit as well.
