### PR TITLE
fix: set the MariaDB instance for OpenStack collation to 11.4 behavior

### DIFF
--- a/components/openstack/templates/mariadb-instance.yaml.tpl
+++ b/components/openstack/templates/mariadb-instance.yaml.tpl
@@ -32,6 +32,10 @@ spec:
     max_connections=1024
     innodb_flush_log_at_trx_commit=2
     innodb_buffer_pool_size=256M
+    # set charset/collate back to MariaDB 11.4 defaults
+    character-set-server=utf8mb3
+    collation-server=utf8mb3_general_ci
+    character-set-collations=utf8=utf8mb3_general_ci,utf8mb3=utf8mb3_general_ci,utf8mb4=utf8mb4_unicode_ci
 
   metrics:
     enabled: true


### PR DESCRIPTION
When upgrading to MariaDB 11.8 the values that these alias to has
changed from 11.4. OpenStack had assumed that these values would remain
constant so the surprise setting is not good. This pins the defaults
when creating new tables and new columns back to what MariaDB 11.4 used
so avoid surprises. Going forward OpenStack is being more explicit about
these values so they'll naturally be able to be dropped and we can
switch back to the defaults. This makes no changes to any tables or
columns that might have already been created so this is a noop for
existing environments.
