### PR TITLE
fix: Set dnsmasq "dhcp-ignore-clid" to avoid superfluous DHCP assignments

### DIFF
--- a/containers/dnsmasq/dnsmasq/dnsmasq.conf.j2
+++ b/containers/dnsmasq/dnsmasq/dnsmasq.conf.j2
@@ -73,7 +73,14 @@ dhcp-option={{ tag }}{{ option_prefix }}{{ option|replace('_', '-')|lower }},{{ 
 {%- endif %}
 {%- endmacro %}
 
+# This DHCP server is allowed to send NAK responses:
 dhcp-authoritative
+# This DHCP server will issue a single IP per client MAC address.  The client-id
+# can be used to differentiate VMs sharing a NIC (and thus requiring multiple
+# IPs for a single MAC address).  We don't have that requirement, and in fact in
+# our case it causes us to assign additional IPs to every server because the
+# different stages of boot (iPXE, linux) use different client-ids:
+dhcp-ignore-clid
 # DHCP ranges to hand out
 {% set dhcp_proxy_list = [] -%}
 {% set dhcp_allowed_srvids_list = [] -%}


### PR DESCRIPTION
The bad behaviour is evident in the dnsmasq logs.  When the box boots, each layer of bootstrap code performs its own DHCP request (pxe boot loader and finally the operating system proper) so the box gets three
different IP addresses assigned.   This is a waste of resources.  It
would be better if the DHCP server re-cycled the original lease for the
second and third request, as this would reduce the IP space usage by two
thirds.

Apr 10 00:31:38 dnsmasq-dhcp[1]: 2794502840 DHCPACK(bond0) 10.4.50.108 d4:04:e6:4f:71:28
Apr 10 00:31:45 dnsmasq-dhcp[1]: 3690497858 DHCPACK(bond0) 10.4.50.108 d4:04:e6:4f:71:28
Apr 10 00:32:49 dnsmasq-dhcp[1]: 3610553376 DHCPACK(bond0) 10.4.50.109 d4:04:e6:4f:71:28 debian

However, with this new config in place, The logs look more sensible:

Apr 10 16:23:07 dnsmasq-dhcp[1]: 1261281903 DHCPACK(bond0) 10.4.50.66 d4:04:e6:4f:8d:b4
Apr 10 16:23:14 dnsmasq-dhcp[1]: 3372163389 DHCPACK(bond0) 10.4.50.66 d4:04:e6:4f:8d:b4
Apr 10 16:24:04 dnsmasq-dhcp[1]: 2389679207 DHCPACK(bond0) 10.4.50.66 d4:04:e6:4f:8d:b4 debian
