### PR TITLE
feat(nautobot): plumb the partition data down to a ConfigMap

### DIFF
--- a/charts/argocd-understack/templates/application-nautobot.yaml
+++ b/charts/argocd-understack/templates/application-nautobot.yaml
@@ -31,6 +31,15 @@ spec:
     ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
+    kustomize:
+      patches:
+        - patch: |
+            - op: replace
+              path: /data/UNDERSTACK_PARTITION
+              value: "{{ index $.Values.appLabels "understack.rackspace.com/partition" | default "" }}"
+          target:
+            kind: ConfigMap
+            name: cluster-data
   - path: {{ include "understack.deploy_path" $ }}/nautobot
     ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}

--- a/components/nautobot/kustomization.yaml
+++ b/components/nautobot/kustomization.yaml
@@ -10,6 +10,11 @@ resources:
   - rule-nautobot-absent.yaml
 
 configMapGenerator:
+  - name: cluster-data
+    literals:
+      - UNDERSTACK_PARTITION=""
+    options:
+      disableNameSuffixHash: true
   - name: nautobot-sso
     literals:
       # enables SOCIAL_AUTH_PIPELINE to load the group_sync plugin

--- a/components/nautobot/values.yaml
+++ b/components/nautobot/values.yaml
@@ -37,6 +37,7 @@ nautobot:
 
   extraEnvVarsCM:
     - nautobot-sso
+    - cluster-data
   extraEnvVarsSecret:
     - nautobot-custom-env
 
@@ -61,6 +62,8 @@ celery:
   # https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/guides/celery-queues/#concurrency-setting
   concurrency: 2
   replicaCount: 1
+  extraEnvVarsCM:
+    - cluster-data
   extraEnvVarsSecret:
     - nautobot-django
     - nautobot-custom-env


### PR DESCRIPTION
Use the partition data that's available as an annotation on the cluster
definitions down to a ConfigMap which can be used by Nautobot.
