### PR TITLE
feat(ansible): include task to set nautobot connectivity for nautobot

### DIFF
--- a/ansible/nautobot-post-deploy.yaml
+++ b/ansible/nautobot-post-deploy.yaml
@@ -25,6 +25,9 @@
   # - Devices
 
   pre_tasks:
+    - name: Check Nautobot connectivity
+      ansible.builtin.import_tasks: tasks/check_nautobot_auth.yml
+
     - name: Ensure nautobot is up and responding
       ansible.builtin.uri:
         url: "{{ nautobot_url }}/health/"


### PR DESCRIPTION
The nautobot playbook didn't include the task to set nautobot
connectivity requiring the usage of inventory overrides to provide this
so this simplifies deployments of this.
