### PR TITLE
feat(ironic): ensure we always load ironic inspection rules

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -245,6 +245,9 @@ pod:
             mountPath: /var/lib/dnsmasq/
           - name: device-types
             mountPath: /var/lib/understack/device-types
+          - name: ironic-inspection-rules
+            mountPath: /etc/ironic/inspection-rules/
+            readOnly: true
         volumes:
           - name: dnsmasq-ironic
             persistentVolumeClaim:
@@ -255,8 +258,10 @@ pod:
           - name: device-types
             configMap:
               name: device-types
-          - name: pod-usr-share-novnc
-            emptyDir: {}
+          - name: ironic-inspection-rules
+            configMap:
+              name: ironic-inspection-rules
+              optional: true
   lifecycle:
     disruption_budget:
       api:


### PR DESCRIPTION
We'll always want to have some inspection rules for each environment so
standardize the loading of the inspection rules into the ironic
conductor. Remove an empty mount that was unused.
