### PR TITLE
chore(argo-workflows): Use the rabbitmq service host instead of a single node

### DIFF
--- a/charts/site-workflows/values.yaml
+++ b/charts/site-workflows/values.yaml
@@ -8,7 +8,7 @@ enabled:
   nova: true
 
 rabbitmq:
-  url: amqp://rabbitmq-server-0.rabbitmq-nodes.openstack.svc.cluster.local:5672
+  url: amqp://rabbitmq.openstack.svc.cluster.local:5672
 
 eventsources:
   cinder:


### PR DESCRIPTION
Fixes the argo settings to use the rabbitmq service address instead of wrongly forcing connections to a single node.
