### PR TITLE
feat(enroll): early redfish inspection on node enroll

### DIFF
--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -211,6 +211,13 @@ def test_enrol_happy_path_uses_real_ironic_workflow(mocker):
             ),
             call(
                 created_node.uuid,
+                "inspect",
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                created_node.uuid,
                 "clean",
                 cleansteps=[
                     {"interface": "raid", "step": "delete_configuration"},
@@ -245,6 +252,7 @@ def test_enrol_happy_path_uses_real_ironic_workflow(mocker):
     expected_reset = [{"op": "remove", "path": "/inspect_interface"}]
     expected_agent = [{"op": "add", "path": "/inspect_interface", "value": "agent"}]
     assert fake_ironic.node.update.call_args_list == [
+        call(created_node.uuid, expected_reset),
         call(created_node.uuid, expected_reset),
         call(created_node.uuid, expected_agent),
     ]
@@ -327,6 +335,13 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
             call(
                 existing_node.uuid,
                 "manage",
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                existing_node.uuid,
+                "inspect",
                 cleansteps=None,
                 runbook=None,
                 disable_ramdisk=None,

--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -242,9 +242,12 @@ def test_enrol_happy_path_uses_real_ironic_workflow(mocker):
             ),
         ]
     )
-    fake_ironic.node.update.assert_called_once()
-    patch = fake_ironic.node.update.call_args.args[1]
-    assert patch == [{"op": "add", "path": "/inspect_interface", "value": "agent"}]
+    expected_reset = [{"op": "remove", "path": "/inspect_interface"}]
+    expected_agent = [{"op": "add", "path": "/inspect_interface", "value": "agent"}]
+    assert fake_ironic.node.update.call_args_list == [
+        call(created_node.uuid, expected_reset),
+        call(created_node.uuid, expected_agent),
+    ]
 
 
 def test_power_on_and_wait_retries_temporary_redfish_503(mocker):

--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -1,3 +1,4 @@
+import secrets
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock
@@ -9,7 +10,67 @@ from ironicclient.v1.node import Node
 from understack_workflows.bmc import RedfishRequestError
 from understack_workflows.bmc_chassis_info import ChassisInfo
 from understack_workflows.bmc_chassis_info import InterfaceInfo
+from understack_workflows.ironic_node import NodeInterface
+from understack_workflows.ironic_node import get_lldp_connected_interfaces
 from understack_workflows.main import enroll_server
+
+
+def random_mac() -> str:
+    return ":".join(f"{b:02x}" for b in secrets.token_bytes(6))
+
+
+DEFAULT_INTERFACE_NAMES = [
+    "NIC.Embedded.1-1-1",
+    "NIC.Embedded.2-1-1",
+    "NIC.Integrated.1-2",
+    "NIC.Integrated.1-1",
+    "NIC.Slot.1-2",
+    "NIC.Slot.1-1",
+]
+
+
+def make_node_inventory(
+    *,
+    interfaces: list[dict] | None = None,
+    serial_number: str = "FL6PC14",
+) -> dict:
+    """Build a realistic Ironic node inventory dict, suitable for mocking.
+
+    Override ``interfaces`` to supply custom name/mac_address/speed_mbps entries.
+    When using the defaults, each interface gets a freshly randomized MAC address
+    so tests don't share state between runs.
+    """
+    if interfaces is None:
+        interfaces = [
+            {"mac_address": random_mac(), "name": name, "speed_mbps": 0}
+            for name in DEFAULT_INTERFACE_NAMES
+        ]
+    all_interfaces = {
+        iface["name"]: {**iface, "pxe_enabled": False, "ipv6_address": None}
+        for iface in interfaces
+    }
+    parsed_lldp = {
+        iface["name"]: {
+            "switch_chassis_id": random_mac(),
+            "switch_port_id": "Ethernet1/1",
+        }
+        for iface in interfaces
+    }
+    return {
+        "inventory": {
+            "interfaces": interfaces,
+            "system_vendor": {
+                "product_name": "PowerEdge R7615",
+                "serial_number": serial_number,
+                "manufacturer": "Dell Inc.",
+            },
+        },
+        "plugin_data": {
+            "all_interfaces": all_interfaces,
+            "parsed_lldp": parsed_lldp,
+            "macs": [iface["mac_address"] for iface in interfaces],
+        },
+    }
 
 
 def make_device_info(
@@ -71,6 +132,7 @@ def make_ironic_client(
     inspect_interfaces: list[str] | None = None,
     traits: list[str] | None = None,
     runbook_ids: dict[str, str] | None = None,
+    inventory: dict | None = None,
 ):
     if inspect_interfaces is None:
         inspect_interfaces = ["idrac-redfish", "idrac-redfish"]
@@ -92,6 +154,8 @@ def make_ironic_client(
     )
     fake_client.node.create.return_value = created_node
     fake_client.node.get_traits.return_value = traits
+    if inventory is not None:
+        fake_client.node.get_inventory.return_value = inventory
 
     def get_node(ident, fields=None):
         if ident == node_name and fields is None:
@@ -459,3 +523,84 @@ def test_guess_pxe_interface_unknown_name_avoids_bmc_interface():
     assert enroll_server.guess_pxe_interfaces(device_info, {"AA:BB:CC:DD:EE:FF"}) == [
         "NIC.Custom.9-1"
     ]
+
+
+def test_get_node_interfaces_parses_inventory(mocker):
+    mac1 = random_mac()
+    mac2 = random_mac()
+    inventory = make_node_inventory(
+        interfaces=[
+            {"name": "NIC.Embedded.1-1-1", "mac_address": mac1, "speed_mbps": 25000},
+            {"name": "NIC.Slot.1-1", "mac_address": mac2, "speed_mbps": 0},
+        ]
+    )
+    fake_ironic, node = make_ironic_client(
+        node_name="Dell-TEST01",
+        node_uuid="node-abc",
+        inventory=inventory,
+    )
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    result = enroll_server.ironic_node.get_node_interfaces(cast(Node, node))
+
+    assert result == [
+        NodeInterface(name="NIC.Embedded.1-1-1", mac_address=mac1, speed_mbps=25000),
+        NodeInterface(name="NIC.Slot.1-1", mac_address=mac2, speed_mbps=0),
+    ]
+    fake_ironic.node.get_inventory.assert_called_once_with("node-abc")
+
+
+def test_get_lldp_connected_interfaces_returns_matched():
+    mac = random_mac()
+    interfaces = [
+        NodeInterface(name="NIC.Embedded.1-1-1", mac_address=mac, speed_mbps=0),
+        NodeInterface(name="NIC.Slot.1-1", mac_address=random_mac(), speed_mbps=0),
+    ]
+    parsed_lldp = {
+        "NIC.Embedded.1-1-1": {
+            "switch_chassis_id": "aa:bb:cc:dd:ee:ff",
+            "switch_port_id": "Ethernet1/5",
+        },
+    }
+
+    result = get_lldp_connected_interfaces(interfaces, parsed_lldp)
+
+    assert result == [
+        NodeInterface(name="NIC.Embedded.1-1-1", mac_address=mac, speed_mbps=0)
+    ]
+
+
+def test_get_lldp_connected_interfaces_excludes_not_available():
+    interfaces = [
+        NodeInterface(name="NIC.Slot.1-1", mac_address=random_mac(), speed_mbps=0),
+        NodeInterface(name="NIC.Slot.1-2", mac_address=random_mac(), speed_mbps=0),
+    ]
+    parsed_lldp = {
+        "NIC.Slot.1-1": {
+            "switch_chassis_id": "Not Available",
+            "switch_port_id": "Not Available",
+        },
+        "NIC.Slot.1-2": {
+            "switch_chassis_id": "Not Available",
+            "switch_port_id": "Not Available",
+        },
+    }
+
+    result = get_lldp_connected_interfaces(interfaces, parsed_lldp)
+
+    assert result == []
+
+
+def test_get_lldp_connected_interfaces_absent_from_lldp():
+    interfaces = [
+        NodeInterface(
+            name="NIC.Embedded.2-1-1", mac_address=random_mac(), speed_mbps=0
+        ),
+    ]
+
+    result = get_lldp_connected_interfaces(interfaces, parsed_lldp={})
+
+    assert result == []

--- a/python/understack-workflows/understack_workflows/ironic_node.py
+++ b/python/understack-workflows/understack_workflows/ironic_node.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import ironicclient.common.apiclient.exceptions
 from ironicclient.common.utils import args_array_to_patch
@@ -10,6 +11,15 @@ from understack_workflows.bmc import Bmc
 from understack_workflows.ironic.client import IronicClient
 
 FIRMWARE_UPDATE_TRAIT_PREFIX = "CUSTOM_FIRMWARE_UPDATE_"
+
+
+@dataclass
+class NodeInterface:
+    name: str
+    mac_address: str
+    speed_mbps: int
+
+
 ENROLLABLE_STATES = {"clean failed", "inspect failed", "enroll", "manageable"}
 
 logger = logging.getLogger(__name__)
@@ -204,6 +214,41 @@ def inspect_out_of_band(node: Node):
     IronicClient().update_node(node.uuid, intf_reset)
     logger.info("[node:%s] Performing out-of-band inspection", node.uuid)
     transition(node, target_state="inspect", expected_state="manageable")
+
+
+def get_node_inventory(node: Node) -> dict:
+    """Return the raw inventory dict populated by OOB inspection."""
+    return IronicClient().get_node_inventory(node.uuid)
+
+
+def get_node_interfaces(node: Node) -> list[NodeInterface]:
+    """Return interfaces from the inventory populated by OOB inspection."""
+    inventory_data = get_node_inventory(node)
+    interfaces_raw = inventory_data.get("inventory", {}).get("interfaces", [])
+    return [
+        NodeInterface(
+            name=iface["name"],
+            mac_address=iface["mac_address"],
+            speed_mbps=iface.get("speed_mbps", 0),
+        )
+        for iface in interfaces_raw
+    ]
+
+
+def get_lldp_connected_interfaces(
+    interfaces: list[NodeInterface], parsed_lldp: dict
+) -> list[NodeInterface]:
+    """Return interfaces that have a confirmed LLDP switch connection.
+
+    An interface is considered connected when it appears in ``parsed_lldp``
+    with a ``switch_port_id`` that is not ``"Not Available"``.
+    """
+    return [
+        iface
+        for iface in interfaces
+        if parsed_lldp.get(iface.name, {}).get("switch_port_id")
+        not in (None, "Not Available")
+    ]
 
 
 def inspect(node: Node, inspect_interface: str = "agent"):

--- a/python/understack-workflows/understack_workflows/ironic_node.py
+++ b/python/understack-workflows/understack_workflows/ironic_node.py
@@ -199,17 +199,11 @@ def set_target_raid_config(node: Node, raid_config: dict) -> None:
 
 
 def inspect_out_of_band(node: Node):
-    refreshed_node = refresh(node, fields=["driver"])
-    if refreshed_node.driver == "idrac":
-        inspect_interface = "idrac-redfish"
-    elif refreshed_node.driver == "redfish":
-        inspect_interface = "redfish"
-    else:
-        logger.warning("No out-of-band inspection for driver %s", refreshed_node.driver)
-        return
-
-    logger.info("%s Performing out-of-band inspection", node.uuid)
-    inspect(node, inspect_interface)
+    intf_reset = args_array_to_patch("remove", ["inspect_interface"])
+    logger.info("[node:%s] Resetting to redfish interface", node.uuid)
+    IronicClient().update_node(node.uuid, intf_reset)
+    logger.info("[node:%s] Performing out-of-band inspection", node.uuid)
+    transition(node, target_state="inspect", expected_state="manageable")
 
 
 def inspect(node: Node, inspect_interface: str = "agent"):

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -101,6 +101,11 @@ def enrol(
         enrolled_pxe_ports=pxe_interfaces,
     )
 
+    # Once we've added to the node to Ironic, perform a redfish
+    # inspection immediately to populate the BIOS data and initial
+    # hardware information
+    ironic_node.inspect_out_of_band(node)
+
     if raid_configure:
         # Raid configuration runs a clean step which does a PXE boot.  That
         # can't work unless we first apply_bios_settings.

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -105,6 +105,26 @@ def enrol(
     # inspection immediately to populate the BIOS data and initial
     # hardware information
     ironic_node.inspect_out_of_band(node)
+    interfaces = ironic_node.get_node_interfaces(node)
+    logger.info(
+        "[node:%s] Found %d interfaces from OOB inspection", node.uuid, len(interfaces)
+    )
+    for iface in interfaces:
+        logger.info(
+            "[node:%s]   %s  mac=%s  speed_mbps=%s",
+            node.uuid,
+            iface.name,
+            iface.mac_address,
+            iface.speed_mbps,
+        )
+    inventory_data = ironic_node.get_node_inventory(node)
+    parsed_lldp = inventory_data.get("plugin_data", {}).get("parsed_lldp", {})
+    lldp_interfaces = ironic_node.get_lldp_connected_interfaces(interfaces, parsed_lldp)
+    logger.info(
+        "[node:%s] %d interfaces with confirmed LLDP switch connections",
+        node.uuid,
+        len(lldp_interfaces),
+    )
 
     if raid_configure:
         # Raid configuration runs a clean step which does a PXE boot.  That


### PR DESCRIPTION
When enrolling a node, run the redfish inspection early in the process so that we can get some initial data about the hardware and can make further decisions about what to configure in follow up operations.
