### PR TITLE
feat(nautobotop): add UCVNI group support to VLAN group sync

### DIFF
--- a/go/nautobotop/internal/nautobot/client/client.go
+++ b/go/nautobotop/internal/nautobot/client/client.go
@@ -17,6 +17,7 @@ import (
 type NautobotClient struct {
 	Config    *nb.Configuration
 	APIClient *nb.APIClient
+	ReqClient *req.Client
 	Username  string
 	Report    map[string][]string
 	Cache     *cache.Cache
@@ -61,6 +62,7 @@ func NewNautobotClient(apiURL string, username, authToken string, cacheMaxSize i
 		Username:  username,
 		Config:    config,
 		APIClient: client,
+		ReqClient: reqClient,
 		Report:    make(map[string][]string),
 		Cache:     c,
 	}, nil

--- a/go/nautobotop/internal/nautobot/helpers/compare.go
+++ b/go/nautobotop/internal/nautobot/helpers/compare.go
@@ -26,6 +26,10 @@ func CompareJSONFields(existing, desired any) bool {
 		return false
 	}
 
+	// Ignore the "relationships" field from comparison
+	// This will ignore too nested deep relationships
+	delete(desiredMap, "relationships")
+
 	return compareJSONMaps(existingMap, desiredMap)
 }
 

--- a/go/nautobotop/internal/nautobot/helpers/helpers.go
+++ b/go/nautobotop/internal/nautobot/helpers/helpers.go
@@ -53,6 +53,32 @@ func BuildNullableBulkWritablePrefixRequestRir(id string) nb.NullableBulkWritabl
 	return *nb.NewNullableBulkWritablePrefixRequestRir(&rir)
 }
 
+// BuildRelationshipSource builds a relationship value with the given object IDs on the source side.
+func BuildRelationshipSource(ids ...string) nb.ApprovalWorkflowDefinitionRequestRelationshipsValue {
+	objects := make([]nb.ApprovalWorkflowDefinitionRequestRelationshipsValueSourceObjectsInner, len(ids))
+	for i, id := range ids {
+		objects[i] = nb.ApprovalWorkflowDefinitionRequestRelationshipsValueSourceObjectsInner{Id: nb.PtrString(id)}
+	}
+	return nb.ApprovalWorkflowDefinitionRequestRelationshipsValue{
+		Source: &nb.ApprovalWorkflowDefinitionRequestRelationshipsValueSource{
+			Objects: objects,
+		},
+	}
+}
+
+// BuildRelationshipDestination builds a relationship value with the given object IDs on the destination side.
+func BuildRelationshipDestination(ids ...string) nb.ApprovalWorkflowDefinitionRequestRelationshipsValue {
+	objects := make([]nb.ApprovalWorkflowDefinitionRequestRelationshipsValueSourceObjectsInner, len(ids))
+	for i, id := range ids {
+		objects[i] = nb.ApprovalWorkflowDefinitionRequestRelationshipsValueSourceObjectsInner{Id: nb.PtrString(id)}
+	}
+	return nb.ApprovalWorkflowDefinitionRequestRelationshipsValue{
+		Destination: &nb.ApprovalWorkflowDefinitionRequestRelationshipsValueSource{
+			Objects: objects,
+		},
+	}
+}
+
 // ReadResponseBody safely reads and closes the response body.
 // Returns the body content as a string. If resp is nil, returns empty string.
 func ReadResponseBody(resp *http.Response) string {

--- a/go/nautobotop/internal/nautobot/ipam/ucvniGroup.go
+++ b/go/nautobotop/internal/nautobot/ipam/ucvniGroup.go
@@ -3,14 +3,11 @@ package ipam
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/charmbracelet/log"
 	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/cache"
 	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/client"
-	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/helpers"
-	"k8s.io/apimachinery/pkg/util/json"
 )
 
 // UcvniGroup represents a UCVNI group from the undercloud-vni plugin API.
@@ -42,42 +39,25 @@ func (s *UcvniGroupService) GetByName(ctx context.Context, name string) UcvniGro
 	}
 
 	baseURL := s.client.Config.Servers[0].URL
-	url := fmt.Sprintf("%s/plugins/undercloud-vni/ucvni-groups/?name=%s&depth=0&limit=1000&offset=0", baseURL, name)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		s.client.AddReport("GetUcvniGroupByName", "failed to create request", "name", name, "error", err.Error())
-		return UcvniGroup{}
-	}
-
-	for key, value := range s.client.Config.DefaultHeader {
-		req.Header.Set(key, value)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := s.client.Config.HTTPClient.Do(req)
+	var listResp ucvniGroupListResponse
+	resp, err := s.client.ReqClient.R().
+		SetContext(ctx).
+		SetHeaders(s.client.Config.DefaultHeader).
+		SetQueryParams(map[string]string{
+			"name":   name,
+			"depth":  "0",
+			"limit":  "1000",
+			"offset": "0",
+		}).
+		SetSuccessResult(&listResp).
+		Get(baseURL + "/plugins/undercloud-vni/ucvni-groups/")
 	if err != nil {
 		s.client.AddReport("GetUcvniGroupByName", "failed to get", "name", name, "error", err.Error())
 		return UcvniGroup{}
 	}
-	defer resp.Body.Close() //nolint:errcheck
-
 	if resp.StatusCode != http.StatusOK {
-		bodyString := helpers.ReadResponseBody(resp)
-		s.client.AddReport("GetUcvniGroupByName", "unexpected status code", "name", name, "status", fmt.Sprintf("%d", resp.StatusCode), "response_body", bodyString)
-		return UcvniGroup{}
-	}
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		s.client.AddReport("GetUcvniGroupByName", "failed to read response", "name", name, "error", err.Error())
-		return UcvniGroup{}
-	}
-
-	var listResp ucvniGroupListResponse
-	if err := json.Unmarshal(bodyBytes, &listResp); err != nil {
-		s.client.AddReport("GetUcvniGroupByName", "failed to unmarshal response", "name", name, "error", err.Error())
+		s.client.AddReport("GetUcvniGroupByName", "unexpected status code", "name", name, "status", fmt.Sprintf("%d", resp.StatusCode), "response_body", resp.String())
 		return UcvniGroup{}
 	}
 

--- a/go/nautobotop/internal/nautobot/ipam/ucvniGroup.go
+++ b/go/nautobotop/internal/nautobot/ipam/ucvniGroup.go
@@ -1,0 +1,93 @@
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/charmbracelet/log"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/cache"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/client"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/helpers"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+// UcvniGroup represents a UCVNI group from the undercloud-vni plugin API.
+type UcvniGroup struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type ucvniGroupListResponse struct {
+	Results []UcvniGroup `json:"results"`
+}
+
+type UcvniGroupService struct {
+	client *client.NautobotClient
+}
+
+func NewUcvniGroupService(nautobotClient *client.NautobotClient) *UcvniGroupService {
+	return &UcvniGroupService{
+		client: nautobotClient,
+	}
+}
+
+// GetByName looks up a UCVNI group by name
+func (s *UcvniGroupService) GetByName(ctx context.Context, name string) UcvniGroup {
+	if group, ok := cache.FindByName(s.client.Cache, "ucvnigroups", name, func(g UcvniGroup) string {
+		return g.Name
+	}); ok {
+		return group
+	}
+
+	baseURL := s.client.Config.Servers[0].URL
+	url := fmt.Sprintf("%s/plugins/undercloud-vni/ucvni-groups/?name=%s&depth=0&limit=1000&offset=0", baseURL, name)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		s.client.AddReport("GetUcvniGroupByName", "failed to create request", "name", name, "error", err.Error())
+		return UcvniGroup{}
+	}
+
+	for key, value := range s.client.Config.DefaultHeader {
+		req.Header.Set(key, value)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.client.Config.HTTPClient.Do(req)
+	if err != nil {
+		s.client.AddReport("GetUcvniGroupByName", "failed to get", "name", name, "error", err.Error())
+		return UcvniGroup{}
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("GetUcvniGroupByName", "unexpected status code", "name", name, "status", fmt.Sprintf("%d", resp.StatusCode), "response_body", bodyString)
+		return UcvniGroup{}
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.client.AddReport("GetUcvniGroupByName", "failed to read response", "name", name, "error", err.Error())
+		return UcvniGroup{}
+	}
+
+	var listResp ucvniGroupListResponse
+	if err := json.Unmarshal(bodyBytes, &listResp); err != nil {
+		s.client.AddReport("GetUcvniGroupByName", "failed to unmarshal response", "name", name, "error", err.Error())
+		return UcvniGroup{}
+	}
+
+	if len(listResp.Results) == 0 {
+		return UcvniGroup{}
+	}
+
+	group := listResp.Results[0]
+	cache.AddToCollection(s.client.Cache, "ucvnigroups", group)
+	log.Info("GetUcvniGroupByName", "found ucvni group", group.Name, "id", group.ID)
+
+	return group
+}

--- a/go/nautobotop/internal/nautobot/models/vlanGroup.go
+++ b/go/nautobotop/internal/nautobot/models/vlanGroup.go
@@ -5,8 +5,8 @@ type VlanGroups struct {
 }
 
 type VlanGroup struct {
-	Name           string `json:"name" yaml:"name"`
-	Location       string `json:"location" yaml:"location"`
-	UcvniGroupName string `json:"ucvni_group_name" yaml:"ucvni_group_name"`
-	Range          string `json:"range" yaml:"range"`
+	Name       string `json:"name" yaml:"name"`
+	Location   string `json:"location" yaml:"location"`
+	UcvniGroup string `json:"ucvni_group" yaml:"ucvni_group"`
+	Range      string `json:"range" yaml:"range"`
 }

--- a/go/nautobotop/internal/nautobot/sync/vlanGroup.go
+++ b/go/nautobotop/internal/nautobot/sync/vlanGroup.go
@@ -57,22 +57,22 @@ func (s *VlanGroupSync) SyncAll(ctx context.Context, data map[string]string) err
 func (s *VlanGroupSync) syncSingleVlanGroup(ctx context.Context, vlanGroup models.VlanGroup) error {
 	existingVlanGroup := s.vlanGroupSvc.GetByName(ctx, vlanGroup.Name)
 
-	customFields := map[string]interface{}{
-		"range": vlanGroup.Range,
+	vlanGroupRequest := nb.VLANGroupRequest{
+		Name:     vlanGroup.Name,
+		Location: s.buildLocationReference(ctx, vlanGroup.Location),
+		Range:    nb.PtrString(vlanGroup.Range),
 	}
+
 	if vlanGroup.UcvniGroup != "" {
 		ucvniGroup := s.ucvniGroupSvc.GetByName(ctx, vlanGroup.UcvniGroup)
 		if ucvniGroup.ID != "" {
-			customFields["ucvni_group"] = ucvniGroup.ID
+			relationships := map[string]nb.ApprovalWorkflowDefinitionRequestRelationshipsValue{
+				"ucvnigroup_vlangroup": helpers.BuildRelationshipSource(ucvniGroup.ID),
+			}
+			vlanGroupRequest.Relationships = &relationships
 		} else {
-			log.Warn("ucvni group not found, skipping field", "name", vlanGroup.UcvniGroup)
+			log.Info("ucvni group not found, skipping relationship", "name", vlanGroup.UcvniGroup)
 		}
-	}
-
-	vlanGroupRequest := nb.VLANGroupRequest{
-		Name:         vlanGroup.Name,
-		Location:     s.buildLocationReference(ctx, vlanGroup.Location),
-		CustomFields: customFields,
 	}
 
 	if existingVlanGroup.Id == nil {

--- a/go/nautobotop/internal/nautobot/sync/vlanGroup.go
+++ b/go/nautobotop/internal/nautobot/sync/vlanGroup.go
@@ -63,17 +63,15 @@ func (s *VlanGroupSync) syncSingleVlanGroup(ctx context.Context, vlanGroup model
 		Range:    nb.PtrString(vlanGroup.Range),
 	}
 
+	relationships := map[string]nb.ApprovalWorkflowDefinitionRequestRelationshipsValue{
+		"ucvnigroup_vlangroup": helpers.BuildRelationshipSource(),
+	}
 	if vlanGroup.UcvniGroup != "" {
-		ucvniGroup := s.ucvniGroupSvc.GetByName(ctx, vlanGroup.UcvniGroup)
-		if ucvniGroup.ID != "" {
-			relationships := map[string]nb.ApprovalWorkflowDefinitionRequestRelationshipsValue{
-				"ucvnigroup_vlangroup": helpers.BuildRelationshipSource(ucvniGroup.ID),
-			}
-			vlanGroupRequest.Relationships = &relationships
-		} else {
-			log.Info("ucvni group not found, skipping relationship", "name", vlanGroup.UcvniGroup)
+		if id := s.ucvniGroupSvc.GetByName(ctx, vlanGroup.UcvniGroup).ID; id != "" {
+			relationships["ucvnigroup_vlangroup"] = helpers.BuildRelationshipSource(id)
 		}
 	}
+	vlanGroupRequest.Relationships = &relationships
 
 	if existingVlanGroup.Id == nil {
 		return s.createVlanGroup(ctx, vlanGroupRequest)

--- a/go/nautobotop/internal/nautobot/sync/vlanGroup.go
+++ b/go/nautobotop/internal/nautobot/sync/vlanGroup.go
@@ -17,16 +17,18 @@ import (
 )
 
 type VlanGroupSync struct {
-	client       *client.NautobotClient
-	vlanGroupSvc *ipam.VlanGroupService
-	locationSvc  *dcim.LocationService
+	client        *client.NautobotClient
+	vlanGroupSvc  *ipam.VlanGroupService
+	locationSvc   *dcim.LocationService
+	ucvniGroupSvc *ipam.UcvniGroupService
 }
 
 func NewVlanGroupSync(nautobotClient *client.NautobotClient) *VlanGroupSync {
 	return &VlanGroupSync{
-		client:       nautobotClient.GetClient(),
-		vlanGroupSvc: ipam.NewVlanGroupService(nautobotClient),
-		locationSvc:  dcim.NewLocationService(nautobotClient.GetClient()),
+		client:        nautobotClient.GetClient(),
+		vlanGroupSvc:  ipam.NewVlanGroupService(nautobotClient),
+		locationSvc:   dcim.NewLocationService(nautobotClient.GetClient()),
+		ucvniGroupSvc: ipam.NewUcvniGroupService(nautobotClient),
 	}
 }
 
@@ -55,13 +57,22 @@ func (s *VlanGroupSync) SyncAll(ctx context.Context, data map[string]string) err
 func (s *VlanGroupSync) syncSingleVlanGroup(ctx context.Context, vlanGroup models.VlanGroup) error {
 	existingVlanGroup := s.vlanGroupSvc.GetByName(ctx, vlanGroup.Name)
 
+	customFields := map[string]interface{}{
+		"range": vlanGroup.Range,
+	}
+	if vlanGroup.UcvniGroup != "" {
+		ucvniGroup := s.ucvniGroupSvc.GetByName(ctx, vlanGroup.UcvniGroup)
+		if ucvniGroup.ID != "" {
+			customFields["ucvni_group"] = ucvniGroup.ID
+		} else {
+			log.Warn("ucvni group not found, skipping field", "name", vlanGroup.UcvniGroup)
+		}
+	}
+
 	vlanGroupRequest := nb.VLANGroupRequest{
-		Name:     vlanGroup.Name,
-		Location: s.buildLocationReference(ctx, vlanGroup.Location),
-		CustomFields: map[string]interface{}{
-			"ucvni_group_name": vlanGroup.UcvniGroupName,
-			"range":            vlanGroup.Range,
-		},
+		Name:         vlanGroup.Name,
+		Location:     s.buildLocationReference(ctx, vlanGroup.Location),
+		CustomFields: customFields,
 	}
 
 	if existingVlanGroup.Id == nil {


### PR DESCRIPTION
Add UCVNI group support to VLAN group sync.

Example of yaml config.
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: vlan-groups
  namespace: nautobot
data:
  vlan-groups.yaml: |
    - name: management-vlans
      location: iad3
      range: "100-199"
      ucvni_group: spine402-1.iad3
    - name: guest-vlans
      location: dfw1
      range: "200-299"
      ucvni_group: spine402-1.iad3
    - name: production-vlans
      location: iad3
      range: "300-399"
      ucvni_group: spine402-1.iad3
```