### PR TITLE
fix(neutron-understack): Update undersync address for new Undersync chart

### DIFF
--- a/python/neutron-understack/neutron_understack/undersync.py
+++ b/python/neutron-understack/neutron_understack/undersync.py
@@ -22,7 +22,7 @@ class Undersync:
     ) -> None:
         """Simple client for Undersync."""
         self.token = auth_token or self._fetch_undersync_token()
-        self.url = "http://undersync-service.undersync.svc.cluster.local:8080"
+        self.url = "http://undersync.undersync.svc.cluster.local:8080"
         self.api_url = api_url or self.url
         self.timeout = timeout
 

--- a/python/understack-workflows/understack_workflows/undersync/client.py
+++ b/python/understack-workflows/understack_workflows/undersync/client.py
@@ -8,7 +8,7 @@ class Undersync:
     def __init__(
         self,
         auth_token: str,
-        api_url="http://undersync-service.undersync.svc.cluster.local:8080",
+        api_url="http://undersync.undersync.svc.cluster.local:8080",
     ) -> None:
         """Simple client for Undersync."""
         self.token = auth_token


### PR DESCRIPTION
The new undersync chart changed the deployment / service names. This updates to use the new names.