### PR TITLE
feat(nautobotop): add ownership validation to update and destroy

### DIFF
--- a/go/nautobotop/internal/nautobot/client/graphql.go
+++ b/go/nautobotop/internal/nautobot/client/graphql.go
@@ -27,6 +27,54 @@ type GraphQLData struct {
 	ObjectChanges []ObjectChanges `json:"object_changes"`
 }
 
+// IsCreatedByUser checks if a specific object was created by the configured username.
+func (n *NautobotClient) IsCreatedByUser(ctx context.Context, objectID string) (bool, error) {
+	req := nb.GraphQLAPIRequest{
+		Query: `
+		query CheckObjectOwnership($changedObjectId: [String], $userName: [String]) {
+		object_changes(
+			changed_object_id: $changedObjectId
+			user_name: $userName
+            action__ic: ["CREATE"]
+		) {
+			id
+			user_name
+			action
+			changed_object_id
+		}
+		}`,
+		Variables: map[string]any{
+			"changedObjectId": []string{objectID},
+			"userName":        []string{n.Username},
+		},
+	}
+
+	_, resp, err := n.APIClient.GraphqlAPI.GraphqlCreate(ctx).
+		GraphQLAPIRequest(req).
+		Execute()
+	if err != nil {
+		return false, err
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+	resp.Body.Close()
+
+	var graphQL GraphQL
+	if err := json.Unmarshal(bodyBytes, &graphQL); err != nil {
+		return false, err
+	}
+
+	for _, change := range graphQL.Data.ObjectChanges {
+		if change.Action == "CREATE" && change.UserName == n.Username {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (n *NautobotClient) GetCreateChangeList(ctx context.Context, objectType string) ([]ObjectChanges, *http.Response, error) {
 	var allObjectChanges []ObjectChanges
 	var lastResp *http.Response

--- a/go/nautobotop/internal/nautobot/client/graphql.go
+++ b/go/nautobotop/internal/nautobot/client/graphql.go
@@ -60,7 +60,7 @@ func (n *NautobotClient) IsCreatedByUser(ctx context.Context, objectID string) (
 	if err != nil {
 		return false, err
 	}
-	resp.Body.Close()
+	resp.Body.Close() //nolint:errcheck
 
 	var graphQL GraphQL
 	if err := json.Unmarshal(bodyBytes, &graphQL); err != nil {

--- a/go/nautobotop/internal/nautobot/dcim/devicetype.go
+++ b/go/nautobotop/internal/nautobot/dcim/devicetype.go
@@ -76,6 +76,16 @@ func (s *DeviceTypeService) ListAll(ctx context.Context) []nb.DeviceType {
 }
 
 func (s *DeviceTypeService) Update(ctx context.Context, id string, req nb.WritableDeviceTypeRequest) (*nb.DeviceType, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateDeviceType", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	deviceType, resp, err := s.client.APIClient.DcimAPI.DcimDeviceTypesUpdate(ctx, id).WritableDeviceTypeRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -91,6 +101,16 @@ func (s *DeviceTypeService) Update(ctx context.Context, id string, req nb.Writab
 }
 
 func (s *DeviceTypeService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyDeviceType", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimDeviceTypesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/location.go
+++ b/go/nautobotop/internal/nautobot/dcim/location.go
@@ -77,6 +77,16 @@ func (s *LocationService) ListAll(ctx context.Context) []nb.Location {
 }
 
 func (s *LocationService) Update(ctx context.Context, id string, req nb.LocationRequest) (*nb.Location, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateLocation", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	location, resp, err := s.client.APIClient.DcimAPI.DcimLocationsUpdate(ctx, id).LocationRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *LocationService) Update(ctx context.Context, id string, req nb.Location
 }
 
 func (s *LocationService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyLocation", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimLocationsDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/locationtype.go
+++ b/go/nautobotop/internal/nautobot/dcim/locationtype.go
@@ -76,6 +76,16 @@ func (s *LocationTypeService) ListAll(ctx context.Context) []nb.LocationType {
 }
 
 func (s *LocationTypeService) Update(ctx context.Context, id string, req nb.LocationTypeRequest) (*nb.LocationType, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateLocationType", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	locationType, resp, err := s.client.APIClient.DcimAPI.DcimLocationTypesUpdate(ctx, id).LocationTypeRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -91,6 +101,16 @@ func (s *LocationTypeService) Update(ctx context.Context, id string, req nb.Loca
 }
 
 func (s *LocationTypeService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyLocationType", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimLocationTypesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/rack.go
+++ b/go/nautobotop/internal/nautobot/dcim/rack.go
@@ -75,6 +75,16 @@ func (s *RackService) ListAll(ctx context.Context) []nb.Rack {
 }
 
 func (s *RackService) Update(ctx context.Context, id string, req nb.WritableRackRequest) (*nb.Rack, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateRack", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	rack, resp, err := s.client.APIClient.DcimAPI.DcimRacksUpdate(ctx, id).WritableRackRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -91,6 +101,16 @@ func (s *RackService) Update(ctx context.Context, id string, req nb.WritableRack
 }
 
 func (s *RackService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyRack", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimRacksDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/rackGroup.go
+++ b/go/nautobotop/internal/nautobot/dcim/rackGroup.go
@@ -76,6 +76,16 @@ func (s *RackGroupService) ListAll(ctx context.Context) []nb.RackGroup {
 }
 
 func (s *RackGroupService) Update(ctx context.Context, id string, req nb.RackGroupRequest) (*nb.RackGroup, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateRackGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	rackGroup, resp, err := s.client.APIClient.DcimAPI.DcimRackGroupsUpdate(ctx, id).RackGroupRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *RackGroupService) Update(ctx context.Context, id string, req nb.RackGro
 }
 
 func (s *RackGroupService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyRackGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimRackGroupsDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/templates/console_port.go
+++ b/go/nautobotop/internal/nautobot/dcim/templates/console_port.go
@@ -78,6 +78,16 @@ func (s *ConsolePortTemplateService) Create(ctx context.Context, req nb.Writable
 }
 
 func (s *ConsolePortTemplateService) Update(ctx context.Context, id string, req nb.WritableConsolePortTemplateRequest) (*nb.ConsolePortTemplate, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateConsolePortTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	consolePort, resp, err := s.client.APIClient.DcimAPI.DcimConsolePortTemplatesUpdate(ctx, id).WritableConsolePortTemplateRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -89,6 +99,16 @@ func (s *ConsolePortTemplateService) Update(ctx context.Context, id string, req 
 }
 
 func (s *ConsolePortTemplateService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyConsolePortTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimConsolePortTemplatesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/templates/interface.go
+++ b/go/nautobotop/internal/nautobot/dcim/templates/interface.go
@@ -76,6 +76,16 @@ func (s *InterfaceTemplateService) Create(ctx context.Context, req nb.WritableIn
 }
 
 func (s *InterfaceTemplateService) Update(ctx context.Context, id string, req nb.WritableInterfaceTemplateRequest) (*nb.InterfaceTemplate, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateInterfaceTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	consolePort, resp, err := s.client.APIClient.DcimAPI.DcimInterfaceTemplatesUpdate(ctx, id).WritableInterfaceTemplateRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -87,6 +97,16 @@ func (s *InterfaceTemplateService) Update(ctx context.Context, id string, req nb
 }
 
 func (s *InterfaceTemplateService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyInterfaceTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimInterfaceTemplatesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/templates/module_bay.go
+++ b/go/nautobotop/internal/nautobot/dcim/templates/module_bay.go
@@ -78,6 +78,16 @@ func (s *ModuleBayTemplateService) Create(ctx context.Context, req nb.ModuleBayT
 }
 
 func (s *ModuleBayTemplateService) Update(ctx context.Context, id string, req nb.ModuleBayTemplateRequest) (*nb.ModuleBayTemplate, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateModuleBayTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	consolePort, resp, err := s.client.APIClient.DcimAPI.DcimModuleBayTemplatesUpdate(ctx, id).ModuleBayTemplateRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -89,6 +99,16 @@ func (s *ModuleBayTemplateService) Update(ctx context.Context, id string, req nb
 }
 
 func (s *ModuleBayTemplateService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyModuleBayTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimModuleBayTemplatesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/dcim/templates/power_port.go
+++ b/go/nautobotop/internal/nautobot/dcim/templates/power_port.go
@@ -78,6 +78,16 @@ func (s *PowerPortTemplateService) Create(ctx context.Context, req nb.WritablePo
 }
 
 func (s *PowerPortTemplateService) Update(ctx context.Context, id string, req nb.WritablePowerPortTemplateRequest) (*nb.PowerPortTemplate, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdatePowerPortTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	powerPort, resp, err := s.client.APIClient.DcimAPI.DcimPowerPortTemplatesUpdate(ctx, id).WritablePowerPortTemplateRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -89,6 +99,16 @@ func (s *PowerPortTemplateService) Update(ctx context.Context, id string, req nb
 }
 
 func (s *PowerPortTemplateService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyPowerPortTemplate", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.DcimAPI.DcimPowerPortTemplatesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/extras/role.go
+++ b/go/nautobotop/internal/nautobot/extras/role.go
@@ -74,6 +74,16 @@ func (s *RoleService) ListAll(ctx context.Context) []nb.Role {
 }
 
 func (s *RoleService) Update(ctx context.Context, id string, req nb.RoleRequest) (*nb.Role, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateRole", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	role, resp, err := s.client.APIClient.ExtrasAPI.ExtrasRolesUpdate(ctx, id).RoleRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -88,6 +98,16 @@ func (s *RoleService) Update(ctx context.Context, id string, req nb.RoleRequest)
 }
 
 func (s *RoleService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyRole", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.ExtrasAPI.ExtrasRolesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/ipam/namespace.go
+++ b/go/nautobotop/internal/nautobot/ipam/namespace.go
@@ -76,6 +76,16 @@ func (s *NamespaceService) ListAll(ctx context.Context) []nb.Namespace {
 }
 
 func (s *NamespaceService) Update(ctx context.Context, id string, req nb.NamespaceRequest) (*nb.Namespace, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateNamespace", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	namespace, resp, err := s.client.APIClient.IpamAPI.IpamNamespacesUpdate(ctx, id).NamespaceRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *NamespaceService) Update(ctx context.Context, id string, req nb.Namespa
 }
 
 func (s *NamespaceService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyNamespace", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.IpamAPI.IpamNamespacesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/ipam/prefix.go
+++ b/go/nautobotop/internal/nautobot/ipam/prefix.go
@@ -76,6 +76,16 @@ func (s *PrefixService) ListAll(ctx context.Context) []nb.Prefix {
 }
 
 func (s *PrefixService) Update(ctx context.Context, id string, req nb.WritablePrefixRequest) (*nb.Prefix, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdatePrefix", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	prefix, resp, err := s.client.APIClient.IpamAPI.IpamPrefixesUpdate(ctx, id).WritablePrefixRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *PrefixService) Update(ctx context.Context, id string, req nb.WritablePr
 }
 
 func (s *PrefixService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyPrefix", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.IpamAPI.IpamPrefixesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/ipam/rir.go
+++ b/go/nautobotop/internal/nautobot/ipam/rir.go
@@ -74,6 +74,16 @@ func (s *RirService) ListAll(ctx context.Context) []nb.RIR {
 }
 
 func (s *RirService) Update(ctx context.Context, id string, req nb.RIRRequest) (*nb.RIR, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateRir", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	rir, resp, err := s.client.APIClient.IpamAPI.IpamRirsUpdate(ctx, id).RIRRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -88,6 +98,16 @@ func (s *RirService) Update(ctx context.Context, id string, req nb.RIRRequest) (
 }
 
 func (s *RirService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyRir", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.IpamAPI.IpamRirsDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/ipam/vlan.go
+++ b/go/nautobotop/internal/nautobot/ipam/vlan.go
@@ -76,6 +76,16 @@ func (s *VlanService) ListAll(ctx context.Context) []nb.VLAN {
 }
 
 func (s *VlanService) Update(ctx context.Context, id string, req nb.VLANRequest) (*nb.VLAN, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateVlan", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	vlan, resp, err := s.client.APIClient.IpamAPI.IpamVlansUpdate(ctx, id).VLANRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *VlanService) Update(ctx context.Context, id string, req nb.VLANRequest)
 }
 
 func (s *VlanService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyVlan", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.IpamAPI.IpamVlansDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/ipam/vlanGroup.go
+++ b/go/nautobotop/internal/nautobot/ipam/vlanGroup.go
@@ -76,6 +76,16 @@ func (s *VlanGroupService) ListAll(ctx context.Context) []nb.VLANGroup {
 }
 
 func (s *VlanGroupService) Update(ctx context.Context, id string, req nb.VLANGroupRequest) (*nb.VLANGroup, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateVlanGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	vlanGroup, resp, err := s.client.APIClient.IpamAPI.IpamVlanGroupsUpdate(ctx, id).VLANGroupRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *VlanGroupService) Update(ctx context.Context, id string, req nb.VLANGro
 }
 
 func (s *VlanGroupService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyVlanGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.IpamAPI.IpamVlanGroupsDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/tenancy/tenant.go
+++ b/go/nautobotop/internal/nautobot/tenancy/tenant.go
@@ -74,6 +74,16 @@ func (s *TenantService) ListAll(ctx context.Context) []nb.Tenant {
 }
 
 func (s *TenantService) Update(ctx context.Context, id string, req nb.TenantRequest) (*nb.Tenant, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateTenant", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	tenant, resp, err := s.client.APIClient.TenancyAPI.TenancyTenantsUpdate(ctx, id).TenantRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -88,6 +98,16 @@ func (s *TenantService) Update(ctx context.Context, id string, req nb.TenantRequ
 }
 
 func (s *TenantService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyTenant", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.TenancyAPI.TenancyTenantsDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/tenancy/tenantGroup.go
+++ b/go/nautobotop/internal/nautobot/tenancy/tenantGroup.go
@@ -74,6 +74,16 @@ func (s *TenantGroupService) ListAll(ctx context.Context) []nb.TenantGroup {
 }
 
 func (s *TenantGroupService) Update(ctx context.Context, id string, req nb.TenantGroupRequest) (*nb.TenantGroup, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateTenantGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	tg, resp, err := s.client.APIClient.TenancyAPI.TenancyTenantGroupsUpdate(ctx, id).TenantGroupRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -88,6 +98,16 @@ func (s *TenantGroupService) Update(ctx context.Context, id string, req nb.Tenan
 }
 
 func (s *TenantGroupService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyTenantGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.TenancyAPI.TenancyTenantGroupsDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/virtualization/cluster.go
+++ b/go/nautobotop/internal/nautobot/virtualization/cluster.go
@@ -76,6 +76,16 @@ func (s *ClusterService) ListAll(ctx context.Context) []nb.Cluster {
 }
 
 func (s *ClusterService) Update(ctx context.Context, id string, req nb.ClusterRequest) (*nb.Cluster, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateCluster", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	cluster, resp, err := s.client.APIClient.VirtualizationAPI.VirtualizationClustersUpdate(ctx, id).ClusterRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *ClusterService) Update(ctx context.Context, id string, req nb.ClusterRe
 }
 
 func (s *ClusterService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyCluster", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.VirtualizationAPI.VirtualizationClustersDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/virtualization/clusterGroup.go
+++ b/go/nautobotop/internal/nautobot/virtualization/clusterGroup.go
@@ -76,6 +76,16 @@ func (s *ClusterGroupService) ListAll(ctx context.Context) []nb.ClusterGroup {
 }
 
 func (s *ClusterGroupService) Update(ctx context.Context, id string, req nb.ClusterGroupRequest) (*nb.ClusterGroup, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateClusterGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	clusterGroup, resp, err := s.client.APIClient.VirtualizationAPI.VirtualizationClusterGroupsUpdate(ctx, id).ClusterGroupRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *ClusterGroupService) Update(ctx context.Context, id string, req nb.Clus
 }
 
 func (s *ClusterGroupService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyClusterGroup", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.VirtualizationAPI.VirtualizationClusterGroupsDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)

--- a/go/nautobotop/internal/nautobot/virtualization/clusterType.go
+++ b/go/nautobotop/internal/nautobot/virtualization/clusterType.go
@@ -76,6 +76,16 @@ func (s *ClusterTypeService) ListAll(ctx context.Context) []nb.ClusterType {
 }
 
 func (s *ClusterTypeService) Update(ctx context.Context, id string, req nb.ClusterTypeRequest) (*nb.ClusterType, error) {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("UpdateClusterType", "failed to check ownership", "id", id, "error", err.Error())
+		return nil, err
+	}
+	if !owned {
+		log.Warn("skipping update, object not created by user", "id", id, "user", s.client.Username)
+		return nil, nil
+	}
+
 	clusterType, resp, err := s.client.APIClient.VirtualizationAPI.VirtualizationClusterTypesUpdate(ctx, id).ClusterTypeRequest(req).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)
@@ -92,6 +102,16 @@ func (s *ClusterTypeService) Update(ctx context.Context, id string, req nb.Clust
 }
 
 func (s *ClusterTypeService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyClusterType", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
 	resp, err := s.client.APIClient.VirtualizationAPI.VirtualizationClusterTypesDestroy(ctx, id).Execute()
 	if err != nil {
 		bodyString := helpers.ReadResponseBody(resp)


### PR DESCRIPTION
This PR adds an additional ownership check before updating or deleting any resource in Nautobot. 

Before each Update or Destroy call, a small GraphQL query is made to the Nautobot API to verify that the object was originally created by the configured username. 
If the object wasn't created by our user, the operation is skipped with a warning log.

This makes an additional small GraphQL call to the Nautobot API per update/delete operation, but it's important to be 100% sure about the owner of a resource and have no leaky behavior.