### PR TITLE
feat: make infra projects configurable and add extra permissions for Nautobot

### DIFF
--- a/ansible/roles/keystone_bootstrap/defaults/main.yml
+++ b/ansible/roles/keystone_bootstrap/defaults/main.yml
@@ -11,6 +11,9 @@ keystone_bootstrap_project_domains:
     description: Sandbox Projects
 
 # these groups live inside the sso domain
+# Each group can have both domain_roles and project_roles:
+# - domain_roles: grants permissions at domain level (can use inherited flag)
+# - project_roles: grants permissions at project level (no inherited flag needed)
 keystone_bootstrap_groups:
   - name: ucadmin
     desc: 'Users Federated with Admin'
@@ -59,3 +62,9 @@ keystone_bootstrap_groups:
       - domain: infra
         role: member
         inherited: true
+    # Example of project-level role assignments (optional)
+    # project_roles:
+    #   - project: baremetal
+    #     role: member
+    #   - project: shared-services
+    #     role: reader

--- a/ansible/roles/keystone_bootstrap/tasks/main.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/main.yml
@@ -7,9 +7,6 @@
     role: admin
     state: present
 
-- name: Define baremetal
-  ansible.builtin.include_tasks: baremetal.yml
-
 - name: Define SSO
   ansible.builtin.include_tasks: sso.yml
 

--- a/ansible/roles/keystone_bootstrap/tasks/sso_groups.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/sso_groups.yml
@@ -25,7 +25,15 @@
 # so need to do this manually done
 - name: Assign role to group for domain
   ansible.builtin.include_tasks: sso_domain_role.yml
-  loop: "{{ group_item.domain_roles }}"
+  loop: "{{ group_item.domain_roles | default([]) }}"
+  loop_control:
+    loop_var: role_item
+  vars:
+    group_id: "{{ _group.group.id }}"
+
+- name: Assign role to group for project
+  ansible.builtin.include_tasks: sso_project_role.yml
+  loop: "{{ group_item.project_roles | default([]) }}"
   loop_control:
     loop_var: role_item
   vars:

--- a/ansible/roles/keystone_bootstrap/tasks/sso_project_role.yml
+++ b/ansible/roles/keystone_bootstrap/tasks/sso_project_role.yml
@@ -1,0 +1,28 @@
+---
+# Copyright (c) 2026 Rackspace Technology, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+- name: Create the role if it does not exist
+  openstack.cloud.identity_role:
+    name: "{{ role_item.role }}"
+    state: present
+
+- name: Assign role to group for project
+  openstack.cloud.role_assignment:
+    group: "{{ group_id }}"
+    project: "{{ role_item.project }}"
+    role: "{{ role_item.role }}"
+    state: present
+  when: dont_set_roles is not defined

--- a/ansible/roles/keystone_domains_projects/defaults/main.yml
+++ b/ansible/roles/keystone_domains_projects/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# Default variables for keystone_domains_projects role
+# This role creates domains and projects inside of them
+
+# Define the domains and their projects
+# Note: projects key is optional - domains can be created without projects
+keystone_domains_projects_list:
+  - domain_name: infra
+    description: 'System Infra'
+    projects:
+      - project_name: baremetal
+        description: 'Ironic resources'
+  # Example of domain without projects:
+  # - domain_name: example
+  #   description: 'Example domain with no projects'

--- a/ansible/roles/keystone_domains_projects/tasks/main.yml
+++ b/ansible/roles/keystone_domains_projects/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2025 Rackspace Technology, Inc.
+# Copyright (c) 2026 Rackspace Technology, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,15 +13,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Create 'infra' domain
+- name: "Create domain {{ item.domain_name }}"
   openstack.cloud.identity_domain:
-    name: infra
-    description: 'System Infra'
+    name: "{{ item.domain_name }}"
+    description: "{{ item.description }}"
     state: present
+  loop: "{{ keystone_domains_projects_list }}"
 
-- name: Create 'baremetal' project in 'infra' domain
-  openstack.cloud.project:
-    name: baremetal
-    domain: infra
-    description: 'Ironic Resources'
-    state: present
+- name: "Create projects for domain {{ item.domain_name }}"
+  ansible.builtin.include_tasks: projects.yml
+  vars:
+    domain: "{{ item }}"
+  loop: "{{ keystone_domains_projects_list }}"
+  when: item.projects is defined and item.projects | length > 0

--- a/ansible/roles/keystone_domains_projects/tasks/projects.yml
+++ b/ansible/roles/keystone_domains_projects/tasks/projects.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2025 Rackspace Technology, Inc.
+# Copyright (c) 2026 Rackspace Technology, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,14 +13,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Keystone Bootstrap
-  hosts: keystone
-  connection: local
-
-  pre_tasks:
-    - name: Check OpenStack connectivity
-      ansible.builtin.import_tasks: tasks/check_openstack_auth.yml
-
-  roles:
-    - role: keystone_domains_projects
-    - role: keystone_bootstrap
+- name: "Create project {{ item.project_name }}"
+  openstack.cloud.project:
+    name: "{{ item.project_name }}"
+    domain: "{{ domain.domain_name }}"
+    description: "{{ item.description }}"
+    state: present
+  loop: "{{ domain.projects }}"

--- a/ansible/roles/nautobot_permissions/defaults/main.yml
+++ b/ansible/roles/nautobot_permissions/defaults/main.yml
@@ -10,6 +10,10 @@ nautobot_permissions_groups:
   user-api-tokens:
     - ucadmin
     - ucuser
+  job-execution:
+    - ucadmin
+  sys-admin:
+    - ucadmin
 
 # definition of a permission and the various settings on that permission
 nautobot_permissions_permissions:
@@ -93,3 +97,22 @@ nautobot_permissions_permissions:
       - users.token
     constraints:
       - user: "$user"
+  job-execution:
+    description: Execute diagnostic and maintenance jobs for hardware troubleshooting
+    enabled: true
+    actions:
+      - run
+    object_types:
+      - extras.job
+  sys-admin:
+    description: System administration read access for git repositories and secrets
+    enabled: true
+    actions:
+      - view
+    object_types:
+      # Git repository management - view source control integrations
+      - extras.gitrepository
+      # Secrets management - view system secrets and credentials
+      - extras.secret
+      - extras.secretsgroup
+      - extras.secretsgroupassociation


### PR DESCRIPTION
The goal of this is to allow us to create more projects inside of the infra domain. The permissions on these are fairly ridge as well so then further allow us to define role permissions to projects as well as domains. Lastly define some additional permissions for admins to have inside of Nautobot to troubleshoot more data.
