### PR TITLE
chore(argocd-understack): switch to unified 'understack' AppProject

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
 - appsets/project-understack-infra.yaml
 - appsets/project-understack-operators.yaml
-- appsets/project-understack.yaml
+- ../bootstrap/argocd-understack/appproject-understack.yaml

--- a/charts/argocd-understack/templates/application-cert-manager.yaml
+++ b/charts/argocd-understack/templates/application-cert-manager.yaml
@@ -18,7 +18,7 @@ spec:
   destination:
     namespace: cert-manager
     server: {{ $.Values.cluster_server }}
-  project: understack-infra
+  project: understack
   sources:
   {{- if $installApp }}
   - chart: cert-manager

--- a/charts/argocd-understack/templates/application-cilium.yaml
+++ b/charts/argocd-understack/templates/application-cilium.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: cilium
     server: {{ $.Values.cluster_server }}
-  project: understack-infra
+  project: understack
   sources:
   - path: {{ include "understack.deploy_path" $ }}/cilium
     ref: deploy

--- a/charts/argocd-understack/templates/application-cnpg-system.yaml
+++ b/charts/argocd-understack/templates/application-cnpg-system.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: cnpg-system
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - path: operators/cnpg-system
     ref: understack

--- a/charts/argocd-understack/templates/application-envoy-gateway.yaml
+++ b/charts/argocd-understack/templates/application-envoy-gateway.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: envoy-gateway
     server: {{ $.Values.cluster_server }}
-  project: understack-infra
+  project: understack
   sources:
   - chart: gateway-helm
     helm:

--- a/charts/argocd-understack/templates/application-etcdbackup.yaml
+++ b/charts/argocd-understack/templates/application-etcdbackup.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: kube-system
     server: {{ $.Values.cluster_server }}
-  project: understack-infra
+  project: understack
   sources:
   - helm:
       ignoreMissingValueFiles: true

--- a/charts/argocd-understack/templates/application-external-dns.yaml
+++ b/charts/argocd-understack/templates/application-external-dns.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: external-dns
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - chart: external-dns-rackspace
     helm:

--- a/charts/argocd-understack/templates/application-external-secrets.yaml
+++ b/charts/argocd-understack/templates/application-external-secrets.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: external-secrets
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   {{- if $installApp }}
   - path: operators/external-secrets

--- a/charts/argocd-understack/templates/application-ingress-nginx.yaml
+++ b/charts/argocd-understack/templates/application-ingress-nginx.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: ingress-nginx
     server: {{ $.Values.cluster_server }}
-  project: understack-infra
+  project: understack
   sources:
   - chart: ingress-nginx
     helm:

--- a/charts/argocd-understack/templates/application-mariadb-operator-crds.yaml
+++ b/charts/argocd-understack/templates/application-mariadb-operator-crds.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: mariadb-operator
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   source:
     repoURL: https://mariadb-operator.github.io/mariadb-operator
     chart: mariadb-operator-crds

--- a/charts/argocd-understack/templates/application-mariadb-operator.yaml
+++ b/charts/argocd-understack/templates/application-mariadb-operator.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: mariadb-operator
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - path: operators/mariadb-operator
     ref: understack

--- a/charts/argocd-understack/templates/application-monitoring.yaml
+++ b/charts/argocd-understack/templates/application-monitoring.yaml
@@ -11,7 +11,7 @@ spec:
   destination:
     namespace: monitoring
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - chart: kube-prometheus-stack
     helm:

--- a/charts/argocd-understack/templates/application-openebs.yaml
+++ b/charts/argocd-understack/templates/application-openebs.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: openebs
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - chart: openebs
     helm:

--- a/charts/argocd-understack/templates/application-openstack-resource-controller.yaml
+++ b/charts/argocd-understack/templates/application-openstack-resource-controller.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: orc-system
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - path: operators/openstack-resource-controller
     ref: understack

--- a/charts/argocd-understack/templates/application-opentelemetry-operator.yaml
+++ b/charts/argocd-understack/templates/application-opentelemetry-operator.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: opentelemetry-operator
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - chart: opentelemetry-operator
     helm:

--- a/charts/argocd-understack/templates/application-prometheus-operator-crds.yaml
+++ b/charts/argocd-understack/templates/application-prometheus-operator-crds.yaml
@@ -15,7 +15,7 @@ spec:
   destination:
     namespace: monitoring
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: prometheus-operator-crds

--- a/charts/argocd-understack/templates/application-rabbitmq-system.yaml
+++ b/charts/argocd-understack/templates/application-rabbitmq-system.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: rabbitmq-system
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - path: operators/rabbitmq-system
     ref: understack

--- a/charts/argocd-understack/templates/application-rook-ceph-cluster.yaml
+++ b/charts/argocd-understack/templates/application-rook-ceph-cluster.yaml
@@ -16,7 +16,7 @@ spec:
   destination:
     namespace: rook-ceph
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   {{- if $installApp }}
   - chart: rook-ceph-cluster

--- a/charts/argocd-understack/templates/application-rook-ceph-operator.yaml
+++ b/charts/argocd-understack/templates/application-rook-ceph-operator.yaml
@@ -16,7 +16,7 @@ spec:
   destination:
     namespace: rook-ceph
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   {{- if $installApp }}
   - chart: rook-ceph

--- a/charts/argocd-understack/templates/application-rook.yaml
+++ b/charts/argocd-understack/templates/application-rook.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: rook-ceph
     server: {{ $.Values.cluster_server }}
-  project: understack-operators
+  project: understack
   sources:
   - chart: rook-ceph
     helm:

--- a/charts/argocd-understack/templates/application-sealed-secrets.yaml
+++ b/charts/argocd-understack/templates/application-sealed-secrets.yaml
@@ -13,7 +13,7 @@ spec:
   destination:
     namespace: kube-system
     server: {{ $.Values.cluster_server }}
-  project: understack-infra
+  project: understack
   sources:
   - path: bootstrap/sealed-secrets
     ref: understack


### PR DESCRIPTION
This switches us to the unified 'understack' AppProject for ArgoCD. From
here we'll be able to grant controls and actions on all Applications
that are part of Understack and start to craft proper limiting rules.
