### PR TITLE
feat: allow alternative nautobot config

### DIFF
--- a/components/nautobot/nautobot_config.py
+++ b/components/nautobot/nautobot_config.py
@@ -1,7 +1,4 @@
-import json as _json
 import os
-import re as _re
-from ssl import CERT_REQUIRED
 
 from nautobot.core.settings import *  # noqa F401,F403
 from nautobot.core.settings_funcs import is_truthy
@@ -66,67 +63,6 @@ from nautobot.core.settings_funcs import is_truthy
 #
 if DATABASES["default"]["ENGINE"].endswith("mysql"):  # noqa F405
     DATABASES["default"]["OPTIONS"] = {"charset": "utf8mb4"}  # noqa F405
-
-# SSL/mTLS options for PostgreSQL connections.
-#
-# Supported NAUTOBOT_DB_SSLMODE values:
-#   "require"     -- encrypt the connection but skip server CA and client cert
-#                    verification. Suitable for same-cluster pods that just need
-#                    to satisfy hostssl pg_hba rules.
-#   "verify-ca"   -- encrypt and verify the server certificate against the CA
-#   "verify-full" -- like verify-ca but also checks the server hostname
-#
-# When sslmode is "verify-ca" or "verify-full", the client certificate, key,
-# and CA root cert must be present at the configured paths (full mTLS).
-# When sslmode is "require", only encryption is enforced -- no cert files are
-# needed and no client certificate is presented.
-_db_sslcert = os.getenv("NAUTOBOT_DB_SSLCERT", "/etc/nautobot/mtls/tls.crt")
-_db_sslkey = os.getenv("NAUTOBOT_DB_SSLKEY", "/etc/nautobot/mtls/tls.key")
-_db_sslrootcert = os.getenv("NAUTOBOT_DB_SSLROOTCERT", "/etc/nautobot/mtls/ca.crt")
-_db_sslmode = os.getenv("NAUTOBOT_DB_SSLMODE", "")
-
-if _db_sslmode in ("verify-ca", "verify-full"):
-    for _path, _label in [
-        (_db_sslcert, "NAUTOBOT_DB_SSLCERT"),
-        (_db_sslkey, "NAUTOBOT_DB_SSLKEY"),
-        (_db_sslrootcert, "NAUTOBOT_DB_SSLROOTCERT"),
-    ]:
-        if not os.path.isfile(_path):
-            raise FileNotFoundError(
-                f"SSL certificate file required by {_label} not found: {_path}"
-            )
-    DATABASES["default"]["OPTIONS"] = {  # noqa F405
-        "sslmode": _db_sslmode,
-        "sslcert": _db_sslcert,
-        "sslkey": _db_sslkey,
-        "sslrootcert": _db_sslrootcert,
-    }
-elif _db_sslmode == "require":
-    DATABASES["default"]["OPTIONS"] = {  # noqa F405
-        "sslmode": "require",
-    }
-
-# mTLS options for Redis connections.
-# When NAUTOBOT_REDIS_SSL env var is "true" (set by Helm `nautobot.redis.ssl`),
-# the Helm chart switches the URL scheme to rediss://.  We still need to tell
-# the Python redis client *which* certs to use for mutual TLS.
-_redis_ca = os.getenv("NAUTOBOT_REDIS_SSL_CA_CERTS", "/etc/nautobot/mtls/ca.crt")
-_redis_cert = os.getenv("NAUTOBOT_REDIS_SSL_CERTFILE", "/etc/nautobot/mtls/tls.crt")
-_redis_key = os.getenv("NAUTOBOT_REDIS_SSL_KEYFILE", "/etc/nautobot/mtls/tls.key")
-
-if os.path.isfile(_redis_ca):
-    _redis_ssl_kwargs = {
-        "ssl_cert_reqs": CERT_REQUIRED,
-        "ssl_ca_certs": _redis_ca,
-        "ssl_certfile": _redis_cert,
-        "ssl_keyfile": _redis_key,
-    }
-    CACHES["default"].setdefault("OPTIONS", {})  # noqa F405
-    CACHES["default"]["OPTIONS"].setdefault("CONNECTION_POOL_KWARGS", {})  # noqa F405
-    CACHES["default"]["OPTIONS"]["CONNECTION_POOL_KWARGS"].update(_redis_ssl_kwargs)  # noqa F405
-    CELERY_BROKER_USE_SSL = _redis_ssl_kwargs  # noqa F405
-    CELERY_REDIS_BACKEND_USE_SSL = _redis_ssl_kwargs  # noqa F405
-    CELERY_BROKER_TRANSPORT_OPTIONS = {"ssl": _redis_ssl_kwargs}  # noqa F405
 
 # This key is used for secure generation of random numbers and strings. It must never be exposed outside of this file.
 # For optimal security, SECRET_KEY should be at least 50 characters in length and contain a mix of letters, numbers, and
@@ -416,11 +352,6 @@ INSTALLATION_METRICS_ENABLED = is_truthy(
     os.getenv("NAUTOBOT_INSTALLATION_METRICS_ENABLED", "True")
 )
 
-# Partition identifier used by computed fields (e.g. device URN generation).
-# Populated from the cluster-data ConfigMap which is patched by ArgoCD from
-# the appLabels["understack.rackspace.com/partition"] value.
-UNDERSTACK_PARTITION = os.environ.get("UNDERSTACK_PARTITION", "")
-
 # Storage backend to use for Job input files and Job output files.
 #
 # Note: the default is for backwards compatibility and it is recommended to change it if possible for your deployment.
@@ -480,32 +411,8 @@ UNDERSTACK_PARTITION = os.environ.get("UNDERSTACK_PARTITION", "")
 # PER_PAGE_DEFAULTS = [25, 50, 100, 250, 500, 1000]
 
 # Enable installed plugins. Add the name of each plugin to the list.
-# Use try/except to only load plugins that are installed in this container,
-# since different deployments may have different plugin sets.
 #
-PLUGINS = []
-for _plugin_name in [
-    "nautobot_plugin_nornir",
-    "nautobot_golden_config",
-]:
-    try:
-        __import__(_plugin_name)
-        PLUGINS.append(_plugin_name)
-    except ImportError:
-        pass
-
-# Allow additional plugins to be specified via the NAUTOBOT_EXTRA_PLUGINS
-# environment variable (comma-separated list of plugin module names).
-# This lets private deployments add their own plugins without modifying
-# this file.
-_extra_plugins = os.getenv("NAUTOBOT_EXTRA_PLUGINS", "")
-for _plugin_name in (p.strip() for p in _extra_plugins.split(",") if p.strip()):
-    try:
-        __import__(_plugin_name)
-        if _plugin_name not in PLUGINS:
-            PLUGINS.append(_plugin_name)
-    except ImportError:
-        pass
+# PLUGINS = []
 
 # Plugins configuration settings. These settings are used by various plugins that the user may have installed.
 # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
@@ -516,67 +423,13 @@ for _plugin_name in (p.strip() for p in _extra_plugins.split(",") if p.strip()):
 #         'buzz': 'bazz'
 #     }
 # }
-PLUGINS_CONFIG = {}
-
-# Configuration for open-source plugins (only applied when the plugin is loaded).
-if "nautobot_plugin_nornir" in PLUGINS:
-    PLUGINS_CONFIG["nautobot_plugin_nornir"] = {
-        "nornir_settings": {
-            "credentials": "nautobot_plugin_nornir.plugins.credentials.nautobot_secrets.CredentialsNautobotSecrets",
-            "runner": {
-                "plugin": "threaded",
-                "options": {
-                    "num_workers": 20,
-                },
-            },
-        },
-        "use_config_context": {
-            "connection_options": True,
-        },
-    }
-
-if "nautobot_golden_config" in PLUGINS:
-    PLUGINS_CONFIG["nautobot_golden_config"] = {
-        "per_feature_bar_width": 0.15,
-        "per_feature_width": 13,
-        "per_feature_height": 4,
-        "enable_backup": True,
-        "enable_compliance": True,
-        "enable_intended": True,
-        "enable_sotagg": True,
-        "sot_agg_transposer": None,
-        "enable_postprocessing": True,
-        "postprocessing_callables": [],
-        "postprocessing_subscribed": [],
-        "platform_slug_map": None,
-    }
-
-
-# Allow plugin configuration via the NAUTOBOT_EXTRA_PLUGINS_CONFIG environment
-# variable. Value must be a JSON object whose keys are plugin names and values
-# are config dicts. Supports ${ENV_VAR} syntax for referencing environment
-# variables in string values (useful for secrets).
-def _interpolate_env(obj):
-    """Recursively replace ${VAR} patterns with environment variable values."""
-    if isinstance(obj, str):
-        return _re.sub(
-            r"\$\{(\w+)\}",
-            lambda m: os.environ.get(m.group(1), ""),
-            obj,
+PLUGINS_CONFIG = {
+    "vni_custom_model": {
+        "FORCE_UNIQUE_VLANS": is_truthy(
+            os.getenv("VNI_CUSTOM_MODEL_FORCE_UNIQUE_VLANS", "false")
         )
-    if isinstance(obj, dict):
-        return {k: _interpolate_env(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_interpolate_env(v) for v in obj]
-    return obj
-
-
-_extra_cfg = os.getenv("NAUTOBOT_EXTRA_PLUGINS_CONFIG", "")
-if _extra_cfg:
-    try:
-        PLUGINS_CONFIG.update(_interpolate_env(_json.loads(_extra_cfg)))
-    except (ValueError, TypeError):
-        pass
+    }
+}
 
 # Prefer IPv6 addresses or IPv4 addresses in selecting a device's primary IP address?
 #

--- a/docs/operator-guide/nautobot.md
+++ b/docs/operator-guide/nautobot.md
@@ -55,7 +55,8 @@ Key points:
 
 ### How nautobot_config.py Handles SSL
 
-The `nautobot_config.py` SSL logic is gated on the `NAUTOBOT_DB_SSLMODE`
+The shared deploy config's (`$deploy/apps/nautobot-config/nautobot_config.py`)
+SSL logic is gated on the `NAUTOBOT_DB_SSLMODE`
 environment variable:
 
 | Value | Behavior | Use Case |
@@ -206,11 +207,21 @@ for site workers:
 
 ## Configuration Architecture
 
+!!! important "All config changes go in the deploy repo"
+    The public `nautobot_config.py` at `$understack/components/nautobot/nautobot_config.py`
+    is intentionally kept as simple and generic as possible for open-source consumers.
+    It does **not** contain mTLS, plugin loading, UNDERSTACK_PARTITION, or any extra
+    plugins mechanism. **All deployment-specific Nautobot configuration changes MUST be
+    made in the shared deploy config** at `$deploy/apps/nautobot-config/nautobot_config.py`.
+    Do not modify the public config for private deployment needs.
+
 Nautobot requires a `nautobot_config.py` file that defines Django
 settings, plugin loading, database options, and authentication
-backends. In understack, this file lives at
-`components/nautobot/nautobot_config.py` and is injected into pods
-using the Helm chart's `fileParameters` feature.
+backends. For private deployments, this file lives at
+`$deploy/apps/nautobot-config/nautobot_config.py` and is injected into
+pods using the Helm chart's `fileParameters` feature. The public repo
+provides a minimal default at `components/nautobot/nautobot_config.py`
+for non-private deployments.
 
 ### How fileParameters Works
 
@@ -270,15 +281,17 @@ The effective configuration is built from multiple layers:
 
 1. **Nautobot defaults** -- `from nautobot.core.settings import *`
    provides all default Django and Nautobot settings
-2. **Component config** -- `components/nautobot/nautobot_config.py`
-   overrides defaults with understack-specific settings (mTLS, plugin
-   loading, SSO, partition identifier)
+2. **Deploy config** -- `$deploy/apps/nautobot-config/nautobot_config.py`
+   (for private deployments) overrides defaults with all deployment-specific
+   settings: mTLS, plugin loading, SSO, Sentry, production hardening,
+   UNDERSTACK_PARTITION, and verbose logging. For non-private deployments,
+   the public `components/nautobot/nautobot_config.py` provides a minimal
+   default with SSO and basic settings only.
 3. **Helm chart env vars** -- the base `components/nautobot/values.yaml`
    sets database, Redis, and other connection parameters as environment
    variables that the config reads via `os.getenv()`
 4. **Deploy repo values** -- site-specific overrides (hostnames, image
-   tags, extra plugins, credentials) that Helm merges on top of the
-   base values
+   tags, credentials) that Helm merges on top of the base values
 
 ### Important: Helm List Replacement
 
@@ -310,125 +323,12 @@ preserve.
 
 ## Plugin Loading
 
-The shared `nautobot_config.py` (mounted via Helm `fileParameters`)
-uses a generic plugin loading mechanism that works across different
-container images and deployments:
-
-1. Open-source plugins (`nautobot_plugin_nornir`, `nautobot_golden_config`)
-   are loaded automatically if installed in the container image.
-2. Additional plugins can be specified via the `NAUTOBOT_EXTRA_PLUGINS`
-   environment variable (comma-separated module names). Each plugin is
-   loaded only if it's actually installed in the container -- missing
-   plugins are silently skipped.
-3. Plugin configuration is provided via the `NAUTOBOT_EXTRA_PLUGINS_CONFIG`
-   environment variable as a JSON object. This supports `${ENV_VAR}`
-   syntax for referencing environment variables in string values, which
-   is useful for injecting secrets at runtime without hardcoding them in
-   the config.
-
-This design allows the same `nautobot_config.py` to be used by both
-the global Nautobot deployment (which may have additional private
-plugins) and site workers (which may have a different plugin set),
-without any deployment-specific code in the public repository.
-
-Example deploy values for adding custom plugins:
-
-```yaml
-nautobot:
-  extraEnvVars:
-    - name: NAUTOBOT_EXTRA_PLUGINS
-      value: 'my_custom_plugin,another_plugin'
-    - name: NAUTOBOT_EXTRA_PLUGINS_CONFIG
-      value: '{"my_custom_plugin":{"API_KEY":"${MY_API_KEY}"}}'
-```
-
-### Current Limitations
-
-The `NAUTOBOT_EXTRA_PLUGINS_CONFIG` environment variable works but has
-ergonomic drawbacks as the number of plugins grows:
-
-- All plugin config is a single JSON string in the deploy values, which
-  becomes hard to read and review in PRs
-- JSON cannot express Python-native types like `None` or call functions
-  like `is_truthy()` -- only plain JSON types (`null`, `false`, etc.)
-- Adding or removing a plugin means editing a long inline JSON blob
-
-### Future Improvement: Per-Plugin Config Files
-
-A cleaner approach for deployments with many plugins is to store each
-plugin's configuration as a separate JSON file in the deploy repo,
-managed via a Kustomize `configMapGenerator`, and mounted into the pod
-as a directory. The `nautobot_config.py` would then glob that directory
-and load each file into `PLUGINS_CONFIG`.
-
-Example structure in the deploy repo:
-
-```text
-<site>/nautobot/plugin-configs/
-  nautobot_golden_config.json
-  my_custom_plugin.json
-  vni_custom_model.json
-```
-
-Each file contains the plugin's config as a JSON object:
-
-```json title="my_custom_plugin.json"
-{
-  "API_KEY": "${MY_API_KEY}",
-  "TIMEOUT": 30
-}
-```
-
-A Kustomize `configMapGenerator` creates a ConfigMap from the directory:
-
-```yaml title="kustomization.yaml"
-configMapGenerator:
-  - name: nautobot-plugin-configs
-    files:
-      - plugin-configs/nautobot_golden_config.json
-      - plugin-configs/my_custom_plugin.json
-    options:
-      disableNameSuffixHash: true
-```
-
-The deploy values mount it as a volume:
-
-```yaml
-nautobot:
-  extraVolumes:
-    - name: plugin-configs
-      configMap:
-        name: nautobot-plugin-configs
-  extraVolumeMounts:
-    - name: plugin-configs
-      mountPath: /etc/nautobot/plugin-configs
-      readOnly: true
-```
-
-And the `nautobot_config.py` loads all files from the directory:
-
-```python
-import glob, json, os, re
-
-def _interpolate_env(obj):
-    if isinstance(obj, str):
-        return re.sub(r"\$\{(\w+)\}", lambda m: os.environ.get(m.group(1), ""), obj)
-    if isinstance(obj, dict):
-        return {k: _interpolate_env(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_interpolate_env(v) for v in obj]
-    return obj
-
-for _path in sorted(glob.glob("/etc/nautobot/plugin-configs/*.json")):
-    _name = os.path.splitext(os.path.basename(_path))[0]
-    with open(_path) as _f:
-        PLUGINS_CONFIG[_name] = _interpolate_env(json.load(_f))
-```
-
-This gives each plugin its own readable file, makes PRs easy to review,
-and keeps the `${ENV_VAR}` interpolation for secrets. It can be
-implemented alongside the current env var approach without breaking
-existing deployments.
+!!! important "Plugin changes go in the deploy repo config"
+    For private deployments, all plugin configuration is managed in the
+    shared deploy config at `$deploy/apps/nautobot-config/nautobot_config.py`.
+    The public config does not have any plugin loading mechanism -- it only
+    has a static `PLUGINS_CONFIG` entry for `vni_custom_model`. Do not add
+    plugins or plugin config to the public config.
 
 ## Nautobot Django shell
 


### PR DESCRIPTION
allow alternative nautobot config to be supplied Allows for a different nautobot config file to be stored in the deploy repo and supplied to Nautobot.