### PR TITLE
fix(understack-workflows): Nautobot requires a prefix or namespace when creating IPs.

### DIFF
--- a/python/understack-workflows/tests/test_nautobot_device_interface_sync.py
+++ b/python/understack-workflows/tests/test_nautobot_device_interface_sync.py
@@ -427,6 +427,7 @@ class TestAssignIpToInterface:
 
         mock_nautobot.ipam.ip_addresses.create.assert_called_once_with(
             address=ip_address,
+            namespace="Rackspace",
             status="Active",
         )
         mock_nautobot.ipam.ip_address_to_interface.create.assert_called_once()

--- a/python/understack-workflows/understack_workflows/oslo_event/nautobot_device_interface_sync.py
+++ b/python/understack-workflows/understack_workflows/oslo_event/nautobot_device_interface_sync.py
@@ -159,6 +159,7 @@ def _assign_ip_to_interface(
         try:
             new_ip = nautobot_client.ipam.ip_addresses.create(
                 address=ip_address,
+                namespace="Rackspace",
                 status="Active",
             )
             ip_id = getattr(new_ip, "id", None)


### PR DESCRIPTION
```
2026-04-21 12:43:37 +0000 - understack_workflows.oslo_event.nautobot_device_interface_sync - WARNING - Failed to create IP address 10.46.96.168: The request failed with code 400 Bad Request: {'__all__': ['One of parent or namespace must be provided']}
```