### PR TITLE
fix(nautobot): envoy's TLS passthrough incompatibility with postgres TLS ClientHello

### DIFF
--- a/components/envoy-configs/templates/gw-external.yaml.tpl
+++ b/components/envoy-configs/templates/gw-external.yaml.tpl
@@ -50,6 +50,21 @@ spec:
           from: {{ .from | default "All" }}
           {{- end }}
     {{- end }}
+    {{- range .Values.routes.tcp }}
+    {{- $listenerName := .name | default (index (splitList "." .fqdn) 0) }}
+    - name: {{ $listenerName }}
+      port: {{ .gatewayPort | default ($.Values.gateways.external.port | default 443) }}
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          {{- if .selector }}
+          from: Selector
+          selector:
+            {{- .selector | toYaml | nindent 12 }}
+          {{- else }}
+          from: {{ .from | default "All" }}
+          {{- end }}
+    {{- end }}
 
   {{- if .Values.gateways.external.serviceAnnotations }}
   infrastructure:

--- a/components/envoy-configs/templates/tcproute.yaml.tpl
+++ b/components/envoy-configs/templates/tcproute.yaml.tpl
@@ -1,0 +1,23 @@
+{{- range .Values.routes.tcp }}
+{{- $listenerName := .name | default (index (splitList "." .fqdn) 0) }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: {{ $listenerName }}
+  namespace: {{ .namespace | default "envoy-gateway" }}
+  labels:
+    {{- include "envoy-configs.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $.Values.gateways.external.name }}
+      namespace: {{ $.Values.gateways.external.namespace }}
+      sectionName: {{ $listenerName }}
+  rules:
+    - backendRefs:
+        - name: {{ .service.name }}
+          {{- with .namespace }}
+          namespace: {{ . }}
+          {{- end }}
+          port: {{ .service.port }}
+{{- end }}

--- a/components/envoy-configs/values.schema.json
+++ b/components/envoy-configs/values.schema.json
@@ -69,7 +69,7 @@
     },
     "routes": {
       "type": "object",
-      "description": "HTTP and TLS routes configurations for Understack services",
+      "description": "HTTP, TCP, and TLS route configurations for Understack services",
       "properties": {
         "http": {
           "type": "array",
@@ -154,6 +154,74 @@
               "alsoInternal": {
                 "type": "boolean",
                 "description": "Also attach this route to the internal (plain HTTP) gateway. Useful for clients that do not support HTTP/2 or TLS 1.3."
+              }
+            },
+            "required": [
+              "fqdn",
+              "service"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "tcp": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "fqdn": {
+                "type": "string",
+                "description": "Fully qualified domain name for the route. Used for operator context and naming, but not rendered into the TCPRoute."
+              },
+              "name": {
+                "type": "string",
+                "description": "Name identifier for the route. If not defined, first part of fqdn is used."
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Namespace where the tcproute will be installed (same as backend service)"
+              },
+              "gatewayPort": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535,
+                "description": "Port exposed on the gateway for this TCP listener. Defaults to the external gateway port (443) if not specified."
+              },
+              "service": {
+                "type": "object",
+                "description": "Kubernetes service backend configuration for the route",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the Kubernetes service"
+                  },
+                  "port": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Numeric port of the service (not target port)"
+                  }
+                },
+                "required": [
+                  "name",
+                  "port"
+                ],
+                "additionalProperties": false
+              },
+              "selector": {
+                "type": "object",
+                "description": "Kubernetes-style label selector (key-value pairs)",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "from": {
+                "type": "string",
+                "enum": [
+                  "Same",
+                  "All",
+                  "Selector"
+                ],
+                "description": "Specifies where traffic can originate from"
               }
             },
             "required": [

--- a/components/envoy-configs/values.yaml
+++ b/components/envoy-configs/values.yaml
@@ -1,4 +1,5 @@
 gateways: {}
 routes:
   http: []
+  tcp: []
   tls: []

--- a/docs/deploy-guide/components/envoy-configs.md
+++ b/docs/deploy-guide/components/envoy-configs.md
@@ -42,6 +42,10 @@ site:
 Required or commonly required items:
 
 - `values.yaml`: Provide the configuration values consumed by the shared Envoy config base.
+  The shared chart supports `routes.http`, `routes.tls`, and `routes.tcp`.
+  Use `routes.tls` for direct TLS passthrough backends that send a TLS
+  ClientHello immediately, and `routes.tcp` for raw TCP protocols such
+  as PostgreSQL STARTTLS on dedicated ports.
 - `kustomization.yaml`: Add any extra Gateway API, EnvoyPatchPolicy, or ConfigMap resources that your environment requires.
 
 Optional additions:

--- a/docs/deploy-guide/components/nautobot-worker.md
+++ b/docs/deploy-guide/components/nautobot-worker.md
@@ -143,9 +143,11 @@ mounted, Redis SSL is configured automatically.
 
 ### Envoy Gateway
 
-Both PostgreSQL (port 5432) and Redis (port 6379) use `routes.tls`
-entries with TLS passthrough mode. The gateway routes traffic based on
-SNI hostname without terminating TLS, preserving end-to-end mTLS.
+PostgreSQL (port 5432) uses a `routes.tcp` entry so Envoy forwards raw
+TCP and PostgreSQL can complete its STARTTLS negotiation normally.
+Redis (port 6379) uses a `routes.tls` entry with TLS passthrough mode,
+because Redis sends a TLS ClientHello immediately and can be routed by
+SNI without terminating TLS. Both paths preserve end-to-end mTLS.
 
 ## Certificate Infrastructure
 
@@ -471,9 +473,10 @@ operator guide.
   provides the streaming replication client cert so CNPG does not need
   the CA private key in `clientCASecret`.
 
-- The `routes.tls` type in the Envoy Gateway template uses a
-  `gatewayPort` field to support non-443 ports for TLS passthrough.
-  PostgreSQL (5432) and Redis (6379) both use this route type.
+- The Envoy Gateway templates use a `gatewayPort` field on both
+  `routes.tls` and `routes.tcp` to support dedicated non-443 listeners.
+  Redis (6379) uses `routes.tls`; PostgreSQL (5432) uses `routes.tcp`
+  because PostgreSQL STARTTLS is incompatible with `TLSRoute`.
 
 - The `pg_hba cert` method with CN-to-user mapping means the client
   certificate CN (e.g. `app`) maps directly to the PostgreSQL user, so
@@ -668,10 +671,12 @@ backend:
 # Check gateway status
 kubectl get gateway -n envoy-gateway -o yaml
 
-# Check TLSRoute status
+# Check route status
 kubectl get tlsroute -n nautobot -o yaml
+kubectl get tcproute -n nautobot -o yaml
 ```
 
-Verify the `fqdn` in the TLS route matches the SNI hostname the client
-is connecting to. For PostgreSQL, the `nautobot.db.host` in the worker
-values must match the `fqdn` in the envoy-configs route.
+Verify the route type matches the backend protocol. Redis should appear
+as a `TLSRoute`, and PostgreSQL should appear as a `TCPRoute`. The
+`nautobot.db.host` and `nautobot.redis.host` values in the worker
+configuration must still match the route FQDNs used for DNS.

--- a/docs/operator-guide/gateway-api.md
+++ b/docs/operator-guide/gateway-api.md
@@ -107,7 +107,7 @@ UnderStack deploys two shared Gateways in the `envoy-gateway` namespace:
 
 ### Route Configuration
 
-Routes are managed through the `envoy-configs` Helm chart, which generates HTTPRoute and TLSRoute resources based on declarative configuration.
+Routes are managed through the `envoy-configs` Helm chart, which generates HTTPRoute, TLSRoute, and TCPRoute resources based on declarative configuration.
 
 #### HTTP Routes
 
@@ -146,6 +146,27 @@ routes:
 ```
 
 Used when the backend service handles TLS itself (like Argo Workflows with HTTPS).
+
+#### TCP Routes
+
+TCP routes forward raw TCP streams without TLS inspection or
+termination:
+
+```yaml
+routes:
+  tcp:
+    - name: nautobot-db
+      fqdn: nautobot-db.example.com
+      namespace: nautobot
+      gatewayPort: 5432
+      service:
+        name: nautobot-cluster-rw
+        port: 5432
+```
+
+Use this for protocols such as PostgreSQL that do not start with a TLS
+ClientHello and therefore cannot be routed correctly by `TLSRoute`
+passthrough.
 
 #### HTTPS Backends
 
@@ -266,6 +287,20 @@ routes:
         name: argo-server
         port: 2746
         backendType: tls
+  tcp:
+    - fqdn: nautobot-db.example.com
+      namespace: nautobot
+      gatewayPort: 5432
+      service:
+        name: nautobot-cluster-rw
+        port: 5432
+  tls:
+    - fqdn: nautobot-redis.example.com
+      namespace: nautobot
+      gatewayPort: 6379
+      service:
+        name: nautobot-redis-master
+        port: 6379
 ```
 
 Create empty `envoy-configs/kustomization.yaml`:
@@ -511,6 +546,16 @@ routes:
     - name: string              # Route name (optional)
       fqdn: string              # Fully qualified domain name
       namespace: string         # Namespace for the TLSRoute resource
+      gatewayPort: integer      # Optional: gateway listener port for passthrough traffic
+      service:
+        name: string            # Backend service name
+        port: integer           # Backend service port
+
+  tcp:
+    - name: string              # Route name (optional)
+      fqdn: string              # Fully qualified domain name used for naming and DNS
+      namespace: string         # Namespace for the TCPRoute resource
+      gatewayPort: integer      # Optional: gateway listener port for raw TCP traffic
       service:
         name: string            # Backend service name
         port: integer           # Backend service port


### PR DESCRIPTION
# PostgreSQL STARTTLS and Envoy `TCPRoute`

This PR is to fix a specific issue that affected Nautobot site workers
connecting from site clusters back to the global PostgreSQL service
through Envoy Gateway.

## Problem

PostgreSQL does not begin a connection with a TLS ClientHello. It first
sends a plaintext `SSLRequest` and only then upgrades to TLS
(`STARTTLS`).

Envoy `TLSRoute` passthrough expects to see a TLS ClientHello
immediately so it can inspect SNI and choose a backend. That works for
Redis and HTTPS, but not for PostgreSQL:

- Redis: direct TLS from the first packet, so `TLSRoute` works
- PostgreSQL: plaintext `SSLRequest` first, so `TLSRoute` cannot route
  correctly and the connection hangs or is closed

This was the reason site Nautobot Celery workers could reach Redis but
could not reliably connect to PostgreSQL through the external gateway on
port `5432`.

## Implemented Solution

We changed the Envoy configuration for PostgreSQL from `TLSRoute` to
`TCPRoute`.

That means:

- the gateway listener on port `5432` now uses `protocol: TCP`
- the PostgreSQL route is now a `TCPRoute`
- Envoy forwards raw bytes without trying to inspect TLS
- PostgreSQL still performs its normal STARTTLS negotiation end-to-end
- PostgreSQL still enforces client certificate authentication with
  `pg_hba ... cert`

This is not a downgrade in authentication or encryption. The gateway is
no longer relying on SNI for PostgreSQL, but PostgreSQL traffic is still
encrypted and still requires a valid client certificate.

## Why `TCPRoute` Is Correct

`TCPRoute` is appropriate when a protocol does not start with a TLS
ClientHello, or when a dedicated port already maps to a single backend
and SNI-based routing adds no value.

That is exactly the case for the Nautobot PostgreSQL endpoint:

- dedicated listener: `5432`
- single backend: `nautobot-cluster-rw`
- protocol behavior: PostgreSQL STARTTLS

## Validation

After deploying the route change, validate from a site worker pod.

### 1. PostgreSQL connection

```bash
kubectl exec -n nautobot <pod> -- python3 -c "
import os, psycopg2
conn = psycopg2.connect(
    host='nautobot-db.<env>.example.com',
    port='5432', dbname='app', user='app',
    password=os.environ.get('NAUTOBOT_DB_PASSWORD', ''),
    sslmode='verify-ca',
    sslcert='/etc/nautobot/mtls/tls.crt',
    sslkey='/etc/nautobot/mtls/tls.key',
    sslrootcert='/etc/nautobot/mtls/ca.crt',
    connect_timeout=10)
print('DB CONNECTION OK - SSL:', conn.info.ssl_in_use)
conn.close()
"
```

Expected:

```text
DB CONNECTION OK - SSL: True
```

### 2. Celery worker control ping

Use the Nautobot wrapper, not `celery -A nautobot.celery`, because this
image exposes Celery through `nautobot-server`:

```bash
kubectl exec -n nautobot deploy/nautobot-worker-celery-<partition> -- sh -lc \
'nautobot-server celery inspect ping --destination "celery@$HOSTNAME"'
```

Expected:

```text
->  celery@<pod-name>: OK
        pong

1 node online.
```

### 3. Worker logs

```bash
kubectl logs -n nautobot deploy/nautobot-worker-celery-<partition> --tail=200
```

Expected log lines include:

```text
Connected to rediss://...
mingle: sync complete
celery@<pod-name> ready.
```

