### PR TITLE
chore: Enrol can clear bios jobs

### DIFF
--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -202,8 +202,12 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
     ]
     fake_ironic, created_node = make_ironic_client(
         node_name="Dell-ABC123",
-        # OOB inspect, agent inspect, OOB inspect (post-RAID).
-        inspect_interfaces=["idrac-redfish", "idrac-redfish", "idrac-redfish"],
+        inspect_interfaces=[
+            "idrac-redfish",
+            "idrac-redfish",
+            "idrac-redfish",
+            "idrac-redfish",
+        ],
         inventory=inventory,
         ports=ports,
     )
@@ -216,7 +220,7 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
     )
     bmc_set_hostname = mocker.patch.object(enroll_server, "bmc_set_hostname")
     update_dell_bios_settings = mocker.patch.object(
-        enroll_server, "update_dell_bios_settings"
+        enroll_server, "update_dell_bios_settings", return_value={"changed": True}
     )
     mocker.patch(
         "understack_workflows.ironic.client.get_ironic_client",
@@ -300,6 +304,20 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
             call(
                 created_node.uuid,
                 "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                created_node.uuid,
+                "inspect",  # second agent inspect to apply BIOS changes
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                created_node.uuid,
+                "clean",
                 cleansteps=[
                     {"interface": "raid", "step": "delete_configuration"},
                     {"interface": "raid", "step": "create_configuration"},
@@ -331,6 +349,9 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
     expected_agent = [{"op": "add", "path": "/inspect_interface", "value": "agent"}]
     assert fake_ironic.node.update.call_args_list == [
         call(created_node.uuid, expected_reset),  # OOB inspect prep
+        call(created_node.uuid, expected_ipxe_boot),
+        call(created_node.uuid, expected_agent),
+        call(created_node.uuid, expected_ipxe_boot),
         call(created_node.uuid, expected_ipxe_boot),
         call(created_node.uuid, expected_agent),
         call(created_node.uuid, expected_ipxe_boot),
@@ -371,7 +392,9 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
     mocker.patch.object(enroll_server, "set_bmc_password")
     mocker.patch.object(enroll_server, "update_dell_drac_settings")
     mocker.patch.object(enroll_server, "bmc_set_hostname")
-    mocker.patch.object(enroll_server, "update_dell_bios_settings")
+    mocker.patch.object(
+        enroll_server, "update_dell_bios_settings", return_value={"changed": True}
+    )
     mocker.patch(
         "understack_workflows.ironic.client.get_ironic_client",
         return_value=fake_ironic,
@@ -406,6 +429,20 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
             call(
                 existing_node.uuid,
                 "inspect",  # Agent inspect via virtual media
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                existing_node.uuid,
+                "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                existing_node.uuid,
+                "inspect",  # second agent inspect to apply BIOS changes
                 cleansteps=None,
                 runbook=None,
                 disable_ramdisk=None,

--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -289,6 +289,13 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
             ),
             call(
                 created_node.uuid,
+                "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                created_node.uuid,
                 "inspect",  # OOB redfish inspect for bios_name / basic info
                 cleansteps=None,
                 runbook=None,
@@ -296,17 +303,10 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
             ),
             call(
                 created_node.uuid,
-                "inspect",  # agent inspect via virtual media
+                "inspect",  # agent inspect
                 cleansteps=None,
                 runbook=None,
                 disable_ramdisk=None,
-            ),
-            call(
-                created_node.uuid,
-                "clean",
-                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
-                runbook=None,
-                disable_ramdisk=True,
             ),
             call(
                 created_node.uuid,
@@ -421,6 +421,13 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
             ),
             call(
                 existing_node.uuid,
+                "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                existing_node.uuid,
                 "inspect",  # OOB inspect
                 cleansteps=None,
                 runbook=None,
@@ -428,17 +435,10 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
             ),
             call(
                 existing_node.uuid,
-                "inspect",  # Agent inspect via virtual media
+                "inspect",  # Agent inspect
                 cleansteps=None,
                 runbook=None,
                 disable_ramdisk=None,
-            ),
-            call(
-                existing_node.uuid,
-                "clean",
-                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
-                runbook=None,
-                disable_ramdisk=True,
             ),
             call(
                 existing_node.uuid,

--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -300,6 +300,13 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
             ),
             call(
                 created_node.uuid,
+                "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                created_node.uuid,
                 "inspect",  # OOB redfish inspect for bios_name / basic info
                 cleansteps=None,
                 runbook=None,
@@ -307,17 +314,10 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
             ),
             call(
                 created_node.uuid,
-                "inspect",  # agent inspect via virtual media
+                "inspect",  # agent inspect
                 cleansteps=None,
                 runbook=None,
                 disable_ramdisk=None,
-            ),
-            call(
-                created_node.uuid,
-                "clean",
-                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
-                runbook=None,
-                disable_ramdisk=True,
             ),
             call(
                 created_node.uuid,
@@ -432,6 +432,13 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
             ),
             call(
                 existing_node.uuid,
+                "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                existing_node.uuid,
                 "inspect",  # OOB inspect
                 cleansteps=None,
                 runbook=None,
@@ -439,17 +446,10 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
             ),
             call(
                 existing_node.uuid,
-                "inspect",  # Agent inspect via virtual media
+                "inspect",  # Agent inspect
                 cleansteps=None,
                 runbook=None,
                 disable_ramdisk=None,
-            ),
-            call(
-                existing_node.uuid,
-                "clean",
-                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
-                runbook=None,
-                disable_ramdisk=True,
             ),
             call(
                 existing_node.uuid,

--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -213,8 +213,12 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
     ]
     fake_ironic, created_node = make_ironic_client(
         node_name="Dell-ABC123",
-        # OOB inspect, agent inspect, OOB inspect (post-RAID).
-        inspect_interfaces=["idrac-redfish", "idrac-redfish", "idrac-redfish"],
+        inspect_interfaces=[
+            "idrac-redfish",
+            "idrac-redfish",
+            "idrac-redfish",
+            "idrac-redfish",
+        ],
         inventory=inventory,
         ports=ports,
     )
@@ -227,7 +231,7 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
     )
     bmc_set_hostname = mocker.patch.object(enroll_server, "bmc_set_hostname")
     update_dell_bios_settings = mocker.patch.object(
-        enroll_server, "update_dell_bios_settings"
+        enroll_server, "update_dell_bios_settings", return_value={"changed": True}
     )
     mocker.patch(
         "understack_workflows.ironic.client.get_ironic_client",
@@ -311,6 +315,20 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
             call(
                 created_node.uuid,
                 "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                created_node.uuid,
+                "inspect",  # second agent inspect to apply BIOS changes
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                created_node.uuid,
+                "clean",
                 cleansteps=[
                     {"interface": "raid", "step": "delete_configuration"},
                     {"interface": "raid", "step": "create_configuration"},
@@ -342,6 +360,9 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
     expected_agent = [{"op": "add", "path": "/inspect_interface", "value": "agent"}]
     assert fake_ironic.node.update.call_args_list == [
         call(created_node.uuid, expected_reset),  # OOB inspect prep
+        call(created_node.uuid, expected_ipxe_boot),
+        call(created_node.uuid, expected_agent),
+        call(created_node.uuid, expected_ipxe_boot),
         call(created_node.uuid, expected_ipxe_boot),
         call(created_node.uuid, expected_agent),
         call(created_node.uuid, expected_ipxe_boot),
@@ -382,7 +403,9 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
     mocker.patch.object(enroll_server, "set_bmc_password")
     mocker.patch.object(enroll_server, "update_dell_drac_settings")
     mocker.patch.object(enroll_server, "bmc_set_hostname")
-    mocker.patch.object(enroll_server, "update_dell_bios_settings")
+    mocker.patch.object(
+        enroll_server, "update_dell_bios_settings", return_value={"changed": True}
+    )
     mocker.patch(
         "understack_workflows.ironic.client.get_ironic_client",
         return_value=fake_ironic,
@@ -417,6 +440,20 @@ def test_enrol_existing_failed_node_recovers_and_updates(mocker):
             call(
                 existing_node.uuid,
                 "inspect",  # Agent inspect via virtual media
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                existing_node.uuid,
+                "clean",
+                cleansteps=[{"interface": "management", "step": "clear_job_queue"}],
+                runbook=None,
+                disable_ramdisk=True,
+            ),
+            call(
+                existing_node.uuid,
+                "inspect",  # second agent inspect to apply BIOS changes
                 cleansteps=None,
                 runbook=None,
                 disable_ramdisk=None,

--- a/python/understack-workflows/understack_workflows/bmc_bios.py
+++ b/python/understack-workflows/understack_workflows/bmc_bios.py
@@ -24,6 +24,9 @@ def required_bios_settings(pxe_interface: str) -> dict[str, str]:
         "IPMILan.1.Enable": "Disabled",
         # PXE is enabled by default on DELL, but we don't use it:
         "PxeDev1EnDis": "Disabled",
+        "PxeDev2EnDis": "Disabled",
+        "PxeDev3EnDis": "Disabled",
+        "PxeDev4EnDis": "Disabled",
         # Configure exactly one HTTP port for booting:
         "HttpDev1Interface": pxe_interface,
         "HttpDev1EnDis": "Enabled",

--- a/python/understack-workflows/understack_workflows/bmc_bios.py
+++ b/python/understack-workflows/understack_workflows/bmc_bios.py
@@ -26,6 +26,10 @@ def required_bios_settings(pxe_interface: str | None) -> dict[str, str]:
         "SecureBoot": "Disabled",
         # PXE is enabled by default on DELL, but we don't use it:
         "PxeDev1EnDis": "Disabled",
+        "PxeDev2EnDis": "Disabled",
+        "PxeDev3EnDis": "Disabled",
+        "PxeDev4EnDis": "Disabled",
+        # Enable one HTTP port for booting:
         "HttpDev1EnDis": "Enabled",
         "HttpDev2EnDis": "Disabled",
         "HttpDev3EnDis": "Disabled",

--- a/python/understack-workflows/understack_workflows/ironic_node.py
+++ b/python/understack-workflows/understack_workflows/ironic_node.py
@@ -162,6 +162,17 @@ def create_ironic_node(
     return client.create_node(node_data)
 
 
+def clear_pending_idrac_jobs(node: Node):
+    logger.info("%s performing clear_job_queue clean step", node.uuid)
+    transition(
+        node,
+        target_state="clean",
+        expected_state="manageable",
+        clean_steps=[{"interface": "management", "step": "clear_job_queue"}],
+        disable_ramdisk=True,
+    )
+
+
 def _driver_for(manufacturer: str) -> tuple[str, str]:
     """Answer the (driver, inspect_interface) for this server."""
     if manufacturer.startswith("Dell"):

--- a/python/understack-workflows/understack_workflows/ironic_node.py
+++ b/python/understack-workflows/understack_workflows/ironic_node.py
@@ -173,6 +173,17 @@ def clear_pending_idrac_jobs(node: Node):
     )
 
 
+def reset_idrac_to_known_good_state(node: Node):
+    logger.info("%s performing known_good_state clean step", node.uuid)
+    transition(
+        node,
+        target_state="clean",
+        expected_state="manageable",
+        clean_steps=[{"interface": "management", "step": "known_good_state"}],
+        disable_ramdisk=True,
+    )
+
+
 def _driver_for(manufacturer: str) -> tuple[str, str]:
     """Answer the (driver, inspect_interface) for this server."""
     if manufacturer.startswith("Dell"):

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -65,6 +65,7 @@ def main() -> None:
         firmware_update=args.firmware_update,
         raid_configure=args.raid_configure,
         external_cmdb_id=args.external_cmdb_id,
+        reset_idrac=args.reset_idrac,
     )
 
 
@@ -74,6 +75,7 @@ def enroll(
     raid_configure: bool,
     old_password: str | None,
     external_cmdb_id: str | None = None,
+    reset_idrac: bool = False,
 ) -> None:
     logger.info("Starting enroll workflow for bmc_ip_address=%s", ip_address)
 
@@ -89,6 +91,13 @@ def enroll(
         manufacturer=device_info.manufacturer,
         external_cmdb_id=external_cmdb_id,
     )
+
+    # Clear stale iDRAC jobs before virtual-media inspection, or optionally
+    # reset the controller to a broader known-good state.
+    if reset_idrac:
+        ironic_node.reset_idrac_to_known_good_state(node)
+    else:
+        ironic_node.clear_pending_idrac_jobs(node)
 
     # Out-of-band redfish inspection populates data including baremetal ports.
     #
@@ -119,9 +128,6 @@ def enroll(
             "cannot configure HTTP boot."
         )
     logger.info("[node:%s] Selected PXE interface %s", node.uuid, pxe_interface)
-
-    # Clear the job queue - stale jobs can conflict with the ones we create:
-    ironic_node.clear_pending_idrac_jobs(node)
 
     # This sets the boot device to use for all future HTTP boots:
     if update_dell_bios_settings(bmc, pxe_interface=pxe_interface):
@@ -277,6 +283,12 @@ def argument_parser():
         type=parse_bool,
         default=True,
         help="Configure RAID before inspection",
+    )
+    parser.add_argument(
+        "--reset-idrac",
+        type=parse_bool,
+        default=False,
+        help="Reset iDRAC to known_good_state instead of clear_job_queue",
     )
     parser.add_argument(
         "--external-cmdb-id",

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -109,7 +109,6 @@ def enroll(
     # Therefore, we only use virtual media during our "enroll" phase, when the
     # port data is set up in a manner that suits the Neutron algorithm.  If a
     # normal PXE/HTTP port is available then we use it instead:
-
     virtual_media = not bool(ironic_node.pxe_enabled_bios_name(node))
     agent_inspection(node, virtual_media=virtual_media)
 
@@ -120,6 +119,9 @@ def enroll(
             "cannot configure HTTP boot."
         )
     logger.info("[node:%s] Selected PXE interface %s", node.uuid, pxe_interface)
+
+    # Clear the job queue - stale jobs can conflict with the ones we create:
+    ironic_node.clear_pending_idrac_jobs(node)
 
     # This sets the boot device to use for all future HTTP boots:
     if update_dell_bios_settings(bmc, pxe_interface=pxe_interface):

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -121,7 +121,10 @@ def enroll(
         )
     logger.info("[node:%s] Selected PXE interface %s", node.uuid, pxe_interface)
 
-    update_dell_bios_settings(bmc, pxe_interface=pxe_interface)
+    # This sets the boot device to use for all future HTTP boots:
+    if update_dell_bios_settings(bmc, pxe_interface=pxe_interface):
+        logger.info("%s performing second inspection write BIOS settings", node.uuid)
+        agent_inspection(node)
 
     if raid_configure:
         configure_raid(node, bmc)

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -124,7 +124,10 @@ def enroll(
         )
     logger.info("[node:%s] Selected PXE interface %s", node.uuid, pxe_interface)
 
-    update_dell_bios_settings(bmc, pxe_interface=pxe_interface)
+    # This sets the boot device to use for all future HTTP boots:
+    if update_dell_bios_settings(bmc, pxe_interface=pxe_interface):
+        logger.info("%s performing second inspection write BIOS settings", node.uuid)
+        agent_inspection(node)
 
     if raid_configure:
         configure_raid(node, inventory)

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -124,6 +124,9 @@ def enroll(
         )
     logger.info("[node:%s] Selected PXE interface %s", node.uuid, pxe_interface)
 
+    # Clear the job queue - stale jobs can conflict with the ones we create:
+    ironic_node.clear_pending_idrac_jobs(node)
+
     # This sets the boot device to use for all future HTTP boots:
     if update_dell_bios_settings(bmc, pxe_interface=pxe_interface):
         logger.info("%s performing second inspection write BIOS settings", node.uuid)

--- a/python/understack-workflows/understack_workflows/main/enroll_server.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_server.py
@@ -66,6 +66,7 @@ def main() -> None:
         firmware_update=args.firmware_update,
         raid_configure=args.raid_configure,
         external_cmdb_id=args.external_cmdb_id,
+        reset_idrac=args.reset_idrac,
     )
 
 
@@ -75,6 +76,7 @@ def enroll(
     raid_configure: bool,
     old_password: str | None,
     external_cmdb_id: str | None = None,
+    reset_idrac: bool = False,
 ) -> None:
     logger.info("Starting enroll workflow for bmc_ip_address=%s", ip_address)
 
@@ -90,6 +92,13 @@ def enroll(
         manufacturer=device_info.manufacturer,
         external_cmdb_id=external_cmdb_id,
     )
+
+    # Clear stale iDRAC jobs before virtual-media inspection, or optionally
+    # reset the controller to a broader known-good state.
+    if reset_idrac:
+        ironic_node.reset_idrac_to_known_good_state(node)
+    else:
+        ironic_node.clear_pending_idrac_jobs(node)
 
     # Out-of-band redfish inspection populates data including baremetal ports.
     #
@@ -123,9 +132,6 @@ def enroll(
             "cannot configure HTTP boot."
         )
     logger.info("[node:%s] Selected PXE interface %s", node.uuid, pxe_interface)
-
-    # Clear the job queue - stale jobs can conflict with the ones we create:
-    ironic_node.clear_pending_idrac_jobs(node)
 
     # This sets the boot device to use for all future HTTP boots:
     if update_dell_bios_settings(bmc, pxe_interface=pxe_interface):
@@ -224,6 +230,12 @@ def argument_parser():
         type=parse_bool,
         default=True,
         help="Configure RAID before inspection",
+    )
+    parser.add_argument(
+        "--reset-idrac",
+        type=parse_bool,
+        default=False,
+        help="Reset iDRAC to known_good_state instead of clear_job_queue",
     )
     parser.add_argument(
         "--external-cmdb-id",


### PR DESCRIPTION
(1) It's quite easy to create "conflicting" jobs, so that a stale job that was left behind prevents any progress because the new job can't be created until the old one is deleted.

This just clears all jobs on startup.  I know there is an ironic hook that ships with ironic and therefore is superior to adding code here, but running it here makes it run at the right time, when we need it to.

We also add an option to call the ironic "known_good_state" which reboots the idrac, just to make sure.   Unfortunately this is broken in our Ironic because it relies on the "ping" binary (like we are still in 2006) that is not present in our container.   It still resets the drac but then it errors out, forcing the user to unset maintenance mode, wait a while, and try again.

(2) If we are to update BIOS settings, we go ahead and take a second reboot, to ensure the BIOS settings change gets committed before we take on anything else.  This takes a very long time, but trying to stack the bios update alongside other updates seems to result in failures.  This change makes the process slower, but more likely to work first time.

(3) disable some more PXE devices - these can get left enabled by prior processes and confuse the boot process output.  We're not using PXE so disable it, period.