### PR TITLE
feat(nautobot): PostgreSQL upgrade

### DIFF
--- a/components/nautobot/cloudnative-postgres-nautobot.yaml
+++ b/components/nautobot/cloudnative-postgres-nautobot.yaml
@@ -7,7 +7,7 @@ metadata:
     # do not allow ArgoCD to delete our DB
     argocd.argoproj.io/sync-options: Delete=false
 spec:
-  imageName: ghcr.io/cloudnative-pg/postgresql:15.5
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.9-system-bullseye
   instances: 3
   storage:
     size: 20Gi

--- a/docs/deploy-guide/components/nautobot-worker.md
+++ b/docs/deploy-guide/components/nautobot-worker.md
@@ -442,6 +442,7 @@ operator guide.
 | Variable | Where Set | Purpose |
 |---|---|---|
 | `NAUTOBOT_DB_SSLMODE` | Both global and site values | Controls PostgreSQL SSL mode. Set to `verify-ca` for mTLS on all pods. |
+| `NAUTOBOT_DB_SSLNEGOTIATION` | Optional in global and site values | If set to `direct`, starts the TLS handshake immediately after TCP connect. Requires PostgreSQL/libpq 17+ and `NAUTOBOT_DB_SSLMODE=require` or stronger. |
 | `NAUTOBOT_DB_SSLCERT` | Optional override | Path to client cert for PG (default: `/etc/nautobot/mtls/tls.crt`) |
 | `NAUTOBOT_DB_SSLKEY` | Optional override | Path to client key for PG (default: `/etc/nautobot/mtls/tls.key`) |
 | `NAUTOBOT_DB_SSLROOTCERT` | Optional override | Path to CA cert for PG (default: `/etc/nautobot/mtls/ca.crt`) |

--- a/docs/operator-guide/nautobot.md
+++ b/docs/operator-guide/nautobot.md
@@ -110,6 +110,10 @@ All pods (global and site) must set `NAUTOBOT_DB_SSLMODE=verify-ca` in
 their `extraEnvVars` and have the mTLS client cert volume mounted at
 `/etc/nautobot/mtls/`.
 
+`NAUTOBOT_DB_SSLNEGOTIATION` is optional. If set to `direct`, the shared
+config passes `sslnegotiation=direct` to libpq. This requires
+PostgreSQL/libpq 17+ and `NAUTOBOT_DB_SSLMODE=require` or stronger.
+
 ### Verifying the Certificate Chain
 
 To confirm the CNPG cluster is using the correct CA for client cert


### PR DESCRIPTION
- Target image is `ghcr.io/cloudnative-pg/postgresql:17.9-system-bullseye`
- `bullseye` is intentional because CNPG in-place major upgrades must keep the same OS distribution lineage
- `system` is still required here because this cluster still uses native `barmanObjectStore`