### PR TITLE
fix(nautobot-worker): Adds nautobot-custom-env settings

### DIFF
--- a/components/nautobot-worker/values.yaml
+++ b/components/nautobot-worker/values.yaml
@@ -42,6 +42,7 @@ celery:
     - cluster-data
   extraEnvVarsSecret:
     - nautobot-django
+    - nautobot-custom-env
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 120


### PR DESCRIPTION
Nautobot's celery worker should include the same env settings we use in nautobot-server as it can contain credentials and other settings that should be the same the for the entire nautobot install and all apps/workers.