### PR TITLE
fix(ansible): keystone domain/project definitions stumbled over var

### DIFF
--- a/ansible/roles/keystone_domains_projects/tasks/main.yml
+++ b/ansible/roles/keystone_domains_projects/tasks/main.yml
@@ -20,9 +20,11 @@
     state: present
   loop: "{{ keystone_domains_projects_list }}"
 
-- name: "Create projects for domain {{ item.domain_name }}"
+- name: "Create projects for domain {{ domain_item.domain_name }}"
   ansible.builtin.include_tasks: projects.yml
   vars:
-    domain: "{{ item }}"
+    domain: "{{ domain_item }}"
   loop: "{{ keystone_domains_projects_list }}"
-  when: item.projects is defined and item.projects | length > 0
+  loop_control:
+    loop_var: domain_item
+  when: domain_item.projects is defined and domain_item.projects | length > 0

--- a/ansible/roles/keystone_domains_projects/tasks/projects.yml
+++ b/ansible/roles/keystone_domains_projects/tasks/projects.yml
@@ -13,10 +13,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: "Create project {{ item.project_name }}"
+- name: "Create project {{ project_item.project_name }}"
   openstack.cloud.project:
-    name: "{{ item.project_name }}"
+    name: "{{ project_item.project_name }}"
     domain: "{{ domain.domain_name }}"
-    description: "{{ item.description }}"
+    description: "{{ project_item.description }}"
     state: present
   loop: "{{ domain.projects }}"
+  loop_control:
+    loop_var: project_item


### PR DESCRIPTION
Both tasks used the same variable of 'item' and they stumbled over each
other resulting in an error on execution.
