### PR TITLE
fix(ansible): keystone domain/project using wrong var syntax

### DIFF
--- a/ansible/roles/keystone_domains_projects/tasks/main.yml
+++ b/ansible/roles/keystone_domains_projects/tasks/main.yml
@@ -13,18 +13,22 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: "Create domain {{ item.domain_name }}"
+- name: "Create keystone domain"
   openstack.cloud.identity_domain:
-    name: "{{ item.domain_name }}"
-    description: "{{ item.description }}"
+    name: "{{ domain_item.domain_name }}"
+    description: "{{ domain_item.description }}"
     state: present
   loop: "{{ keystone_domains_projects_list }}"
+  loop_control:
+    loop_var: domain_item
+    label: "{{ domain_item.domain_name }}"
 
-- name: "Create projects for domain {{ domain_item.domain_name }}"
+- name: "Create projects for domain"
   ansible.builtin.include_tasks: projects.yml
   vars:
     domain: "{{ domain_item }}"
   loop: "{{ keystone_domains_projects_list }}"
   loop_control:
     loop_var: domain_item
+    label: "{{ domain_item.domain_name }}"
   when: domain_item.projects is defined and domain_item.projects | length > 0

--- a/ansible/roles/keystone_domains_projects/tasks/projects.yml
+++ b/ansible/roles/keystone_domains_projects/tasks/projects.yml
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: "Create project {{ project_item.project_name }}"
+- name: "Create keystone project"
   openstack.cloud.project:
     name: "{{ project_item.project_name }}"
     domain: "{{ domain.domain_name }}"
@@ -22,3 +22,4 @@
   loop: "{{ domain.projects }}"
   loop_control:
     loop_var: project_item
+    label: "{{ domain.domain_name }}:{{ project_item.project_name }}"


### PR DESCRIPTION
You cannot use the loop variable in the name despite what Claude and
Codex both tell you.
