### PR TITLE
chore: Disable NTP on iDRAC -  it clashes with Ironic "verify_bmc_clock"

### DIFF
--- a/python/understack-workflows/understack_workflows/bmc_settings.py
+++ b/python/understack-workflows/understack_workflows/bmc_settings.py
@@ -11,12 +11,10 @@ REQUIRED_VALUES = {
     "SNMP.1.AgentCommunity": "public",
     "SNMP.1.AlertPort": 161,
     "SwitchConnectionView.1.Enable": "Enabled",
-    "NTPConfigGroup.1.NTPEnable": "Enabled",
+    "NTPConfigGroup.1.NTPEnable": "Disabled",
     "Time.1.Timezone": "UTC",
     "IPv4.1.DNS1": os.getenv("DNS_SERVER_IPV4_ADDR_1"),
     "IPv4.1.DNS2": os.getenv("DNS_SERVER_IPV4_ADDR_2"),
-    "NTPConfigGroup.1.NTP1": os.getenv("NTP_SERVER_IPV4_ADDR_1"),
-    "NTPConfigGroup.1.NTP2": os.getenv("NTP_SERVER_IPV4_ADDR_2"),
 }
 
 # When we GET Enum-type keys we can expect a string like "Enabled".


### PR DESCRIPTION
NTP keeps the clock right, but we enabled an Ironic feature that attempts to step the BMC clock during "verify" (enrolment).

With NTP enabled, iDRAC refuses to allow clock changes, which causes the verify_bmc_clock step to fail, and therefore the node can never transition from enrol state to manageable state.

Doug wanted the verify_bmc_clock step to stay switched on, so I'm disabling NTP.