### PR TITLE
feat(nautobot-cnpg): Migrating to Barman Cloud Plugin from built-in CloudNativePG Backup 

### DIFF
--- a/components/nautobot/cloudnative-postgres-nautobot.yaml
+++ b/components/nautobot/cloudnative-postgres-nautobot.yaml
@@ -24,5 +24,8 @@ metadata:
 spec:
   schedule: "0 0 0 * * *"
   backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   cluster:
     name: nautobot-cluster

--- a/operators/cnpg-system/kustomization.yaml
+++ b/operators/cnpg-system/kustomization.yaml
@@ -20,3 +20,9 @@ helmCharts:
   releaseName: cloudnative-pg
   version: 0.27.1
   repo: https://cloudnative-pg.github.io/charts
+- name: plugin-barman-cloud
+  includeCRDs: true
+  namespace: cnpg-system
+  releaseName: plugin-barman-cloud
+  version: 0.6.0
+  repo: https://cloudnative-pg.github.io/charts

--- a/operators/cnpg-system/rule-backups-too-old.yaml
+++ b/operators/cnpg-system/rule-backups-too-old.yaml
@@ -9,7 +9,7 @@ spec:
         - alert: CnpgLastBackupTooOld
           expr: |
             (time() - sum by (namespace) (
-              cnpg_collector_last_available_backup_timestamp{pod=~"nautobot-cluster-([1-9][0-9]*)$"}
+              barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{pod=~"nautobot-cluster-([1-9][0-9]*)$"}
             )) / 3600 > 24
           for: 0s
           labels:


### PR DESCRIPTION
Migrating from built-in Barman Cloud integration to new plugin-based architecture using the Barman Cloud Plugin.

The in-tree support for Barman Cloud in CloudNativePG is deprecated starting from version 1.26 and will be removed in a future release.
https://cloudnative-pg.io/plugin-barman-cloud/docs/migration/