### PR TITLE
fix: reclean sensor parameter mismatch prevents automated recovery of…

### DIFF
--- a/workflows/argo-events/workflowtemplates/reclean-server.yaml
+++ b/workflows/argo-events/workflowtemplates/reclean-server.yaml
@@ -18,7 +18,7 @@ spec:
             path: clouds.yaml
   arguments:
     parameters:
-      - name: device_id
+      - name: device_uuid
   templates:
     - name: main
       steps:
@@ -28,28 +28,28 @@ spec:
               parameters:
                 - name: operation
                   value: "manage"
-                - name: device_id
-                  value: "{{workflow.parameters.device_id}}"
+                - name: device_uuid
+                  value: "{{workflow.parameters.device_uuid}}"
         - - name: server-manage-state
             template: openstack-state-cmd
             arguments:
               parameters:
-                - name: device_id
-                  value: "{{workflow.parameters.device_id}}"
+                - name: device_uuid
+                  value: "{{workflow.parameters.device_uuid}}"
         - - name: avail-server
             template: openstack-wait-cmd
             arguments:
               parameters:
                 - name: operation
                   value: "provide"
-                - name: device_id
-                  value: "{{workflow.parameters.device_id}}"
+                - name: device_uuid
+                  value: "{{workflow.parameters.device_uuid}}"
             when: "{{steps.server-manage-state.outputs.result}} == manageable"
     - name: openstack-wait-cmd
       inputs:
         parameters:
           - name: operation
-          - name: device_id
+          - name: device_uuid
       container:
         image: ghcr.io/rackerlabs/understack/openstack-client:2025.2
         command:
@@ -60,7 +60,7 @@ spec:
           - "{{inputs.parameters.operation}}"
           - --wait
           - "0"
-          - "{{inputs.parameters.device_id}}"
+          - "{{inputs.parameters.device_uuid}}"
         env:
           - name: OS_CLOUD
             value: understack
@@ -71,7 +71,7 @@ spec:
     - name: openstack-state-cmd
       inputs:
         parameters:
-          - name: device_id
+          - name: device_uuid
       container:
         image: ghcr.io/rackerlabs/understack/openstack-client:2025.2
         command:
@@ -84,7 +84,7 @@ spec:
           - value
           - "-c"
           - provision_state
-          - "{{inputs.parameters.device_id}}"
+          - "{{inputs.parameters.device_uuid}}"
         env:
           - name: OS_CLOUD
             value: understack


### PR DESCRIPTION
The reclean sensor and reclean-server WorkflowTemplate have had a parameter name mismatchThe sensor passes the node UUID as device_uuid, but the WorkflowTemplate declares the parameter as device_id. Argo rejects the workflow at submission every time with
https://github.com/rackerlabs/understack/blob/196dc19c0d135efec6fd9506b5caeb8d63885a3a/charts/site-workflows/templates/sensor-ironic-node-reclean.yaml#L59 have device_uuid . 
and https://github.com/rackerlabs/understack/blob/196dc19c0d135efec6fd9506b5caeb8d63885a3a/workflows/argo-events/workflowtemplates/reclean-server.yaml#L21 device_id

spec.arguments.device_id.value or spec.arguments.device_id.valueFrom is required

```
{"level":"info","ts":"2026-04-14T09:15:20.104041728Z","logger":"argo-events.sensor","caller":"sensors/listener.go:327","msg":"EventBus connection lost, reconnecting...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean"}
{"level":"info","ts":"2026-04-14T09:15:20.104136338Z","logger":"argo-events.sensor","caller":"base/stan.go:49","msg":"NATS auth strategy: Token","sensorName":"ironic-node-reclean","clientID":"client-2476801822-63"}
{"level":"error","ts":"2026-04-14T09:15:20.104794091Z","logger":"argo-events.sensor","caller":"base/stan.go:68","msg":"NATS streaming connection lost","sensorName":"ironic-node-reclean","clientID":"client-2476801822-29","stacktrace":"github.com/argoproj/argo-events/pkg/eventbus/stan/base.(*STAN).MakeConnection.func3\n\t/home/runner/work/argo-events/argo-events/pkg/eventbus/stan/base/stan.go:68"}
{"level":"info","ts":"2026-04-14T09:15:20.106016477Z","logger":"argo-events.sensor","caller":"base/stan.go:61","msg":"Connected to NATS server.","sensorName":"ironic-node-reclean","clientID":"client-2476801822-63"}
{"level":"info","ts":"2026-04-14T09:15:20.107576363Z","logger":"argo-events.sensor","caller":"base/stan.go:74","msg":"Connected to NATS streaming server.","sensorName":"ironic-node-reclean","clientID":"client-2476801822-63"}
{"level":"info","ts":"2026-04-14T09:15:20.107632329Z","logger":"argo-events.sensor","caller":"sensors/listener.go:333","msg":"reconnected to EventBus.","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","connection":"STANTriggerConn{ClientID:client-2476801822-63,Sensor:ironic-node-reclean,Trigger:ironic-reclean}"}
{"level":"info","ts":"2026-04-14T09:15:20.107661502Z","logger":"argo-events.sensor","caller":"sensor/trigger_conn.go:153","msg":"closing subscription...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","clientID":"client-2476801822-29"}
{"level":"info","ts":"2026-04-14T09:15:20.107673557Z","logger":"argo-events.sensor","caller":"sensor/trigger_conn.go:155","msg":"subscription on subject eventbus-openstack closed","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","clientID":"client-2476801822-29"}
{"level":"info","ts":"2026-04-14T09:15:20.107684188Z","logger":"argo-events.sensor","caller":"sensor/trigger_conn.go:120","msg":"exiting ExactOnce cache clean up daemon...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","clientID":"client-2476801822-29"}
{"level":"info","ts":"2026-04-14T09:15:22.108449866Z","logger":"argo-events.sensor","caller":"sensors/listener.go:302","msg":"started subscribing to events for trigger ironic-reclean with client connection STANTriggerConn{ClientID:client-2476801822-63,Sensor:ironic-node-reclean,Trigger:ironic-reclean}","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean"}
{"level":"info","ts":"2026-04-14T09:15:22.11027334Z","logger":"argo-events.sensor","caller":"sensor/trigger_conn.go:106","msg":"Subscribed to subject eventbus-openstack using durable name client-2476801822","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","clientID":"client-2476801822-63"}
{"level":"info","ts":"2026-04-14T09:15:22.110311227Z","logger":"argo-events.sensor","caller":"sensor/trigger_conn.go:114","msg":"starting ExactOnce cache clean up daemon ...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","clientID":"client-2476801822-63"}
{"level":"info","ts":"2026-04-14T13:38:20.274545075Z","logger":"argo-events.sensor","caller":"standard-k8s/standard-k8s.go:157","msg":"creating the object...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes"}
{"level":"info","ts":"2026-04-14T13:38:20.293399376Z","logger":"argo-events.sensor","caller":"sensors/listener.go:449","msg":"Successfully processed trigger 'ironic-reclean'","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes","triggeredBy":["ironic-dep"],"triggeredByEvents":["123efa1f88444036a8edc7e59d464863"]}
{"level":"info","ts":"2026-04-19T13:24:43.481539152Z","logger":"argo-events.sensor","caller":"standard-k8s/standard-k8s.go:157","msg":"creating the object...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes"}
{"level":"info","ts":"2026-04-19T13:24:43.502757091Z","logger":"argo-events.sensor","caller":"sensors/listener.go:449","msg":"Successfully processed trigger 'ironic-reclean'","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes","triggeredBy":["ironic-dep"],"triggeredByEvents":["dc015ed269094841991a7adc587a3adb"]}
{"level":"info","ts":"2026-04-20T12:35:27.240995563Z","logger":"argo-events.sensor","caller":"standard-k8s/standard-k8s.go:157","msg":"creating the object...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes"}
{"level":"info","ts":"2026-04-20T12:35:27.259647962Z","logger":"argo-events.sensor","caller":"sensors/listener.go:449","msg":"Successfully processed trigger 'ironic-reclean'","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes","triggeredBy":["ironic-dep"],"triggeredByEvents":["7081ca4f39814daf9ea3b8ef666a2231"]}
{"level":"info","ts":"2026-04-20T15:31:31.764689675Z","logger":"argo-events.sensor","caller":"standard-k8s/standard-k8s.go:157","msg":"creating the object...","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes"}
{"level":"info","ts":"2026-04-20T15:31:31.783630427Z","logger":"argo-events.sensor","caller":"sensors/listener.go:449","msg":"Successfully processed trigger 'ironic-reclean'","sensorName":"ironic-node-reclean","triggerName":"ironic-reclean","triggerType":"Kubernetes","triggeredBy":["ironic-dep"],"triggeredByEvents":["4ac64fd1df934707acfbbf69d61e1a85"]}

```
