### PR TITLE
chore: improve env vars and stopping openstack-admin-client

### DIFF
--- a/components/openstack-admin-client/openstack-admin-client.yaml
+++ b/components/openstack-admin-client/openstack-admin-client.yaml
@@ -6,12 +6,19 @@ metadata:
 spec:
   restartPolicy: Always
   containers:
-    - name: "image-ks-service-registration"
+    - name: client
       image: ghcr.io/rackerlabs/understack/openstack-client:2025.2
       imagePullPolicy: IfNotPresent
       command:
-        - sleep
-        - "infinity"
+        - /bin/sh
+        - -c
+        - |
+          trap 'echo "Received signal, shutting down..."; exit 0' TERM INT
+          echo "OpenStack admin client pod starting..."
+          while true; do
+            sleep 30 &
+            wait $!
+          done
       resources:
         limits:
           cpu: "1"
@@ -22,60 +29,9 @@ spec:
       env:
         - name: OS_IDENTITY_API_VERSION
           value: "3"
-        - name: OS_AUTH_URL
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_AUTH_URL
-        - name: OS_REGION_NAME
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_REGION_NAME
-        - name: OS_INTERFACE
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_INTERFACE
-        - name: OS_ENDPOINT_TYPE
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_INTERFACE
-        - name: OS_PROJECT_DOMAIN_NAME
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_PROJECT_DOMAIN_NAME
-        - name: OS_PROJECT_NAME
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_PROJECT_NAME
-        - name: OS_USER_DOMAIN_NAME
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_USER_DOMAIN_NAME
-        - name: OS_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_USERNAME
-        - name: OS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_PASSWORD
-        - name: OS_DEFAULT_DOMAIN
-          valueFrom:
-            secretKeyRef:
-              name: keystone-keystone-admin
-              key: OS_DEFAULT_DOMAIN
-        - name: OS_SERVICE_NAME
-          value: "keystone"
-        - name: OS_SERVICE_TYPE
-          value: "image"
+      envFrom:
+        - secretRef:
+            name: keystone-keystone-admin
   volumes:
     - name: pod-tmp
       emptyDir: {}


### PR DESCRIPTION
Update the configuration of the openstack-admin-client pod to shutdown
quicker and to just load all the environment variables from a secret
instead of specifying them all individually. Remove some of the naming
that made it look like a service creation pod.
