### PR TITLE
chore: upgrade to latest dex container

### DIFF
--- a/components/dex/values.yaml
+++ b/components/dex/values.yaml
@@ -3,7 +3,8 @@
 #
 
 image:
-  tag: v2.44.0
+  # renovate: datasource=docker depName=ghcr.io/dexidp/dex versioning=docker
+  tag: v2.45.1
 
 replicaCount: 1
 config:


### PR DESCRIPTION
Upgrade to the latest dex container and add comment so that Renovate can
track this for us. fixes PUC-1673
