### PR TITLE
fix: backport redfish sensor data crash when redfish_system_id is None

### DIFF
--- a/containers/ironic/Dockerfile
+++ b/containers/ironic/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # renovate: name=openstack/ironic repo=https://github.com/rackerlabs/ironic.git branch=understack/2026.1
-ARG IRONIC_GIT_REF=b804ca2f641a6d0e8b2235b5a07725909c4667ed
+ARG IRONIC_GIT_REF=e348a5f8bb2895c8304b06beef7835a85805b497
 ADD --keep-git-dir=true https://github.com/rackerlabs/ironic.git#${IRONIC_GIT_REF} /src/ironic
 RUN git -C /src/ironic fetch --unshallow --tags
 


### PR DESCRIPTION
Related path PR : https://github.com/rackerlabs/ironic/pull/6
 Fix redfish sensor data crash when redfish_system_id is None
`ironic on  backport/fix-redfish-sensors-none-system-id via 🐍 v3.13.12 🐍 base
❯ git fetch rackerlabs understack/2026.1
From https://github.com/rackerlabs/ironic
 * branch                understack/2026.1 -> FETCH_HEAD

ironic on  backport/fix-redfish-sensors-none-system-id via 🐍 v3.13.12 🐍 base
❯ git rev-parse rackerlabs/understack/2026.1
e348a5f8bb2895c8304b06beef7835a85805b497
`