### PR TITLE
fix: nautobot napalm enforcing ssh

### DIFF
--- a/containers/nautobot/nautobot_config.py
+++ b/containers/nautobot/nautobot_config.py
@@ -192,6 +192,11 @@ PLUGINS_CONFIG = {
                 },
             },
         },
+        "network_driver_mappings": {
+            "napalm": {
+                "cisco_nxos": "nxos_ssh",
+            },
+        },
     },
     "nautobot_golden_config": {
         "per_feature_bar_width": 0.15,


### PR DESCRIPTION
Setting cisco_nxos to reflect the nxos_ssh proper mapping that was failing with remote workers. 
