### PR TITLE
feat: storage_interface_details creation

### DIFF
--- a/ansible/roles/custom_fields/tasks/main.yml
+++ b/ansible/roles/custom_fields/tasks/main.yml
@@ -69,3 +69,18 @@
     weight: 100
     content_types: dcim.device
     filter_logic: exact
+
+- name: Create Custom Field Interface Extras
+  networktocode.nautobot.custom_field:
+    state: present
+    url: "{{ nautobot_url }}"
+    token: "{{ nautobot_token }}"
+    description: Field to account for j2 items not indexed in NB by default
+    label: interface details
+    key: interface_config_items
+    type: json
+    required: false
+    weight: 100
+    content_types:
+      - dcim.interface
+    filter_logic: exact


### PR DESCRIPTION
Adding in storage_interface_details to support storage jinja templating, allowing for custom configuration components to be read into the templates. 
This also enforces a rules that allows for uplink interaces to be ignored when apply configuration components to other interfaces
