### PR TITLE
chore: switch to git installed ansible-collections-openstack

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -2,6 +2,9 @@ collections:
   - name: community.general
     version: "==12.2.0"
   - name: openstack.cloud
-    version: "==2.5.0"
+    # releases are not happening at a cadence we need for fixes so install from source
+    source: https://opendev.org/openstack/ansible-collections-openstack.git
+    type: git
+    version: "2.5.0-36-gbcac650"
   - name: networktocode.nautobot
     version: "==6.1.1"


### PR DESCRIPTION
The upstream project is slow to make releases into ansible galaxy and we
need a number of fixes that have been committed. Switch to installing a
specific version from git that has landed a number of fixes we want.
