### PR TITLE
chore: fix local docs rendering to livereload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ docs: $(ACTIVATE) wftmpls component-docs-check ## Builds the documentation
 
 .PHONY: docs-local
 docs-local: $(ACTIVATE) wftmpls component-docs-check ## Build and locally host the documentation
-	$(MKDOCS) serve --strict
+	$(MKDOCS) serve --strict --livereload


### PR DESCRIPTION
Due to a change in the click package, the argument reports that it
defaults to on but it does not. mkdocs isn't maintained so is not
getting a new release to fix that. So this is the quickest fix.
