### PR TITLE
chore(argocd-understack): remove unnecessary ref in multi-source app

### DIFF
--- a/charts/argocd-understack/templates/application-cnpg-system.yaml
+++ b/charts/argocd-understack/templates/application-cnpg-system.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack-operators
   sources:
   - path: operators/cnpg-system
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   syncPolicy:


### PR DESCRIPTION
This ref causes ArgoCD to crash with a runtime exception due to
argoproj/argo-cd#25460 and the fix not being backported to any release
branch yet.
