### PR TITLE
chore(argocd-understack): remove unnecessary ref in multi-source app

### DIFF
--- a/charts/argocd-understack/templates/application-argo-workflows.yaml
+++ b/charts/argocd-understack/templates/application-argo-workflows.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack
   sources:
   - path: {{ include "understack.deploy_path" $ }}/argo-workflows
-    ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-chrony.yaml
+++ b/charts/argocd-understack/templates/application-chrony.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack
   sources:
   - path: components/chrony
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-cilium.yaml
+++ b/charts/argocd-understack/templates/application-cilium.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack-infra
   sources:
   - path: {{ include "understack.deploy_path" $ }}/cilium
-    ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-mariadb-operator.yaml
+++ b/charts/argocd-understack/templates/application-mariadb-operator.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack-operators
   sources:
   - path: operators/mariadb-operator
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-openstack-resource-controller.yaml
+++ b/charts/argocd-understack/templates/application-openstack-resource-controller.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack-operators
   sources:
   - path: operators/openstack-resource-controller
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-otel-collector.yaml
+++ b/charts/argocd-understack/templates/application-otel-collector.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack
   sources:
   - path: {{ include "understack.deploy_path" $ }}/otel-collector
-    ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-rabbitmq-system.yaml
+++ b/charts/argocd-understack/templates/application-rabbitmq-system.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack-operators
   sources:
   - path: operators/rabbitmq-system
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-sealed-secrets.yaml
+++ b/charts/argocd-understack/templates/application-sealed-secrets.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack-infra
   sources:
   - path: bootstrap/sealed-secrets
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   syncPolicy:


### PR DESCRIPTION
This ref causes ArgoCD to crash with a runtime exception due to
argoproj/argo-cd#25460 and the fix not being backported to any release
branch yet.
