### PR TITLE
fix(ironic-hook): Fix typo in chassis model hook and enable it in ironic

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -99,11 +99,11 @@ conf:
       add_ports: "all"
       extra_kernel_params: ipa-collect-lldp=1
       # Agent inspection hooks run after inspecting in-band using the IPA image:
-      hooks: "ramdisk-error,validate-interfaces,architecture,pci-devices,parse-lldp,update-baremetal-port"
+      hooks: "ramdisk-error,validate-interfaces,architecture,pci-devices,parse-lldp,update-baremetal-port,chassis_model"
       keep_ports: "present"
     redfish:
       # Redfish inspection hooks run after inspecting out-of-band using the BMC:
-      inspection_hooks: "validate-interfaces,ports,port-bios-name,architecture,pci-devices,resource-class"
+      inspection_hooks: "validate-interfaces,ports,port-bios-name,architecture,pci-devices,resource-class,chassis_model"
       # To avoid SSL issues due to the system clock differing, have the conductor
       # set the system clock to its time whenever we go to boot the machine into
       # IPA

--- a/python/ironic-understack/ironic_understack/inspect_hook_chassis_model.py
+++ b/python/ironic-understack/ironic_understack/inspect_hook_chassis_model.py
@@ -75,4 +75,4 @@ def _extract_manufacturer(node, inventory: dict) -> str:
 
 def _trait_name(manufacturer: str, chassis_model: str) -> str:
     """The node trait that should be present on this node."""
-    return f"{manufacturer}_#{chassis_model}".upper().replace(" ", "_")
+    return f"{manufacturer}_{chassis_model}".upper().replace(" ", "_")


### PR DESCRIPTION
Fixes a typo in the trait name and enables the hook in ironic.