### PR TITLE
fix(ipa-image): Adds util-linux-extra package for hwclock utility to ironic IPA image.

### DIFF
--- a/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
+++ b/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
@@ -3,3 +3,4 @@ inetutils-telnet:
 mtr-tiny:
 tcpdump:
 bind9-dnsutils:
+util-linux-extra:


### PR DESCRIPTION
Fix for missing hwclock:

<img width="1261" height="920" alt="image-20260528-165103" src="https://github.com/user-attachments/assets/60f9aa91-269c-4fc2-a402-81a36e603422" />
