### PR TITLE
fix: PUC-1722 Ironic conductor performance issues

### DIFF
--- a/components/ironic/dnsmasq-pvc.yaml
+++ b/components/ironic/dnsmasq-pvc.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: openstack
 spec:
   accessModes:
-  - ReadWriteOnce
+  - ReadWriteMany
+  storageClassName: ceph-fs-ec
   resources:
     requests:
       storage: 16Mi
@@ -21,7 +22,8 @@ metadata:
   namespace: openstack
 spec:
   accessModes:
-  - ReadWriteOnce
+  - ReadWriteMany
+  storageClassName: ceph-fs-ec
   resources:
     requests:
       storage: 16Mi

--- a/components/ironic/dnsmasq-ss.yaml
+++ b/components/ironic/dnsmasq-ss.yaml
@@ -34,16 +34,7 @@ spec:
         application: ironic-dnsmasq
     spec:
       nodeSelector:
-        ironic_role: conductor
-
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  application: ironic
-                  component: conductor
+        dhcp_role: server
       hostNetwork: true
       containers:
         - name: dnsmasq

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -82,7 +82,8 @@ conf:
       verify_step_priority_override: management.clear_job_queue:90
       # (nicholas.kuechler) tuning for idrac hardware type
       # https://docs.openstack.org/ironic/latest/admin/drivers/idrac.html#nodes-go-into-maintenance-mode
-      sync_power_state_interval: 70
+      sync_power_state_interval: 300
+      sync_power_state_workers: 20
     agent:
       # (nicholas.kuechler) tuning for idrac hardware type
       # https://docs.openstack.org/ironic/latest/admin/drivers/idrac.html#timeout-when-powering-off
@@ -284,7 +285,7 @@ pod:
         cpu: "100m"
       limits:
         memory: "2048Mi"
-        cpu: "1000m"
+        cpu: "8000m"
   affinity:
     anti:
       type:

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -285,6 +285,12 @@ pod:
       limits:
         memory: "2048Mi"
         cpu: "1000m"
+  affinity:
+    anti:
+      type:
+        default: requiredDuringSchedulingIgnoredDuringExecution
+      topologyKey:
+        default: kubernetes.io/hostname
 
 annotations:
   # we need to modify the annotations on OpenStack Helm


### PR DESCRIPTION
Overall this PR aims to resolve CPU throttling for Ironic conductors by adjusting existing, overly strict  CPU limits as well as horizontally scaling to multiple pods/nodes.


Summary of changes:
- Ironic and dnsmasq are no longer coupled to a single host. dnsmasq stays on a same single node, the Ironic conductor can now live on any non-network node (2 replicas in most clusters).
- the PVC needs to change the mode from ReadWriteOnce(RWO) to ReadWriteMany(RWX) so that it can be accessed by multiple hosts at the same time
- this results in a storage class change and affinity rules change




Unfortunately changing the storage class requires a per-environment migration. Here is rough plan (tested on dev environment)


This partially solves https://rackspace.atlassian.net/browse/PUC-1722, but requires changes in the deploy repo to increase the number of replicas to 2 for each of the environments. These are done in https://github.com/RSS-Engineering/undercloud-deploy/pull/1799



---
# RWO → RWX Volume Migration plan

## Prerequisites

- `pv-migrate` kubectl plugin installed
- The `ceph-fs-ec` storage class will be used, which supports RWX

---

## Overview

1. Disable ArgoCD to prevent reconciliation during migration
2. Scale down the `ironic-conductor` and `ironic-dnsmasq` StatefulSets
3. Back up existing PVC definitions to `/tmp`
4. Create temporary RWX PVCs (`dnsmasq-dhcp-new`, `dnsmasq-ironic-new`) on `ceph-fs-ec`
5. Migrate data from the old PVCs into the temporary ones using `pv-migrate`
6. Delete the old RWO PVCs
7. Recreate the PVCs with their original names on `ceph-fs-ec`
8. Migrate data from the temporary PVCs into the final ones
9. Delete the temporary PVCs
10. Scale StatefulSets back up and verify
11. Restore ArgoCD access

---

## Step 1: Disable ArgoCD

Before making any changes, disable ArgoCD on the cluster to prevent it from reconciling resources during the migration.

```bash
k get clusterrolebinding pvceng-argocd-is-cluster-admin -o yaml > /tmp/argocd-binding.yaml
k delete clusterrolebinding pvceng-argocd-is-cluster-admin
```

---

## Step 2: Scale Down StatefulSets

```bash
k scale statefulset ironic-conductor --replicas=0
k scale statefulset ironic-dnsmasq --replicas=0
```

---

## Step 3: Back Up Existing PVC Definitions

```bash
k get pvc dnsmasq-dhcp -n openstack -o yaml | tee /tmp/backup-dnsmasq-dhcp.yaml
k get pvc dnsmasq-ironic -n openstack -o yaml | tee /tmp/backup-dnsmasq-ironic.yaml
```

---

## Step 4: Create Temporary RWX PVCs

Since two PVCs cannot share the same name in the same namespace, use temporary names during migration.

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: dnsmasq-dhcp-new
  namespace: openstack
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: ceph-fs-ec
  resources:
    requests:
      storage: 16Mi
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: dnsmasq-ironic-new
  namespace: openstack
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: ceph-fs-ec
  resources:
    requests:
      storage: 16Mi
```

```bash
k apply -f temp-pvcs-rwx.yaml
```

---

## Step 5: Migrate Data with `pv-migrate`

```bash
kubectl pv-migrate  \
  --source dnsmasq-dhcp \
  --dest dnsmasq-dhcp-new \
  --source-namespace openstack \
  --dest-namespace openstack

kubectl pv-migrate  \
  --source dnsmasq-ironic \
  --dest dnsmasq-ironic-new \
  --source-namespace openstack \
  --dest-namespace openstack
```

`pv-migrate` will spin up the rsync job, stream progress logs, and clean up after itself automatically.

---

## Step 6: Delete the Old RWO PVCs

```bash
k delete pvc dnsmasq-dhcp -n openstack
k delete pvc dnsmasq-ironic -n openstack
```

---

## Step 7: Recreate the PVCs with Original Names as RWX

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: dnsmasq-dhcp
  namespace: openstack
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: ceph-fs-ec
  resources:
    requests:
      storage: 16Mi
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: dnsmasq-ironic
  namespace: openstack
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: ceph-fs-ec
  resources:
    requests:
      storage: 16Mi
```

```bash
k apply -f final-pvcs-rwx.yaml
```

---

## Step 8: Migrate Data into the Final PVCs

```bash
kubectl pv-migrate  \
  --source dnsmasq-dhcp-new \
  --dest dnsmasq-dhcp \
  --source-namespace openstack \
  --dest-namespace openstack

kubectl pv-migrate  \
  --source dnsmasq-ironic-new \
  --dest dnsmasq-ironic \
  --source-namespace openstack \
  --dest-namespace openstack
```

---

## Step 9: Delete the Temporary PVCs

```bash
k delete pvc dnsmasq-dhcp-new -n openstack
k delete pvc dnsmasq-ironic-new -n openstack
```

---

## Step 10: Scale Back Up and Verify

Your workload manifests require no changes since the PVC names are preserved.

```bash
k scale statefulset ironic-conductor --replicas=2
k scale statefulset ironic-dnsmasq --replicas=1
k get pods -n openstack
```

---

## Step 11: Restore ArgoCD Access

```bash
k create -f /tmp/argocd-binding.yaml
```