### PR TITLE
chore(nautobot): upgrade helm chart to 3.1.2

### DIFF
--- a/charts/argocd-understack/templates/application-nautobot-worker.yaml
+++ b/charts/argocd-understack/templates/application-nautobot-worker.yaml
@@ -35,7 +35,7 @@ spec:
             taskQueues: {{ . | quote }}
       {{- end }}
     repoURL: https://nautobot.github.io/helm-charts/
-    targetRevision: 2.5.6
+    targetRevision: 3.1.2
 
   - path: components/nautobot-worker
     ref: understack

--- a/charts/argocd-understack/templates/application-nautobot.yaml
+++ b/charts/argocd-understack/templates/application-nautobot.yaml
@@ -27,7 +27,7 @@ spec:
       - $understack/components/nautobot/values.yaml
       - $deploy/{{ include "understack.deploy_path" $ }}/nautobot/values.yaml
     repoURL: https://nautobot.github.io/helm-charts/
-    targetRevision: 2.5.6
+    targetRevision: 3.1.2
   - path: components/nautobot
     ref: understack
     repoURL: {{ include "understack.understack_url" $ }}


### PR DESCRIPTION
Relevant release notes:

https://docs.nautobot.com/projects/helm-charts/en/stable/operations/upgrading/#to-3x

I don't see anything that would materially affect our deployments. The diff in dev also suggests it's going to be fine.