### PR TITLE
fix(ironic): restrict required anti-affinity to conductors only

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -289,7 +289,8 @@ pod:
   affinity:
     anti:
       type:
-        default: requiredDuringSchedulingIgnoredDuringExecution
+        default: preferredDuringSchedulingIgnoredDuringExecution
+        conductor: requiredDuringSchedulingIgnoredDuringExecution
       topologyKey:
         default: kubernetes.io/hostname
 


### PR DESCRIPTION
Conductors use host networking and bind a fixed port, so two conductor pods cannot run on the same host. The API has no such constraint and should use preferred anti-affinity to avoid unnecessary scheduling failures.

