### PR TITLE
fix(image-upload): Harden the image-upload ansible against upload failures and restarts

### DIFF
--- a/ansible/roles/openstack_glance_image_upload/tasks/main.yml
+++ b/ansible/roles/openstack_glance_image_upload/tasks/main.yml
@@ -45,17 +45,29 @@
     - understack_images | length > 0
     - item.images | length == 0
 
-- name: Build list of images that were successfully reserved (newly created)
+- name: Build list of images that need data upload (newly reserved or incomplete)
   ansible.builtin.set_fact:
     _reserved_image_uuids: >-
-      {{ reserve_result.results
+      {{
+        (reserve_result.results
          | default([])
          | selectattr('changed', 'defined')
          | selectattr('changed')
          | map(attribute='item')
          | map(attribute='item')
          | map(attribute='uuid')
-         | list }}
+         | list)
+        +
+        (existing_image_info.results
+         | default([])
+         | selectattr('images', 'defined')
+         | selectattr('images')
+         | map(attribute='images')
+         | map('first')
+         | selectattr('status', 'in', ['queued', 'uploading'])
+         | map(attribute='id')
+         | list)
+      }}
 
 - name: Download images that still need data upload
   ansible.builtin.get_url:
@@ -83,7 +95,7 @@
     - understack_images | length > 0
     - item.uuid in _reserved_image_uuids
 
-- name: Upload image data to queued Glance images
+- name: Upload image data to queued or uploading Glance images
   openstack.cloud.image:
     cloud: "{{ openstack_cloud | default(omit) }}"
     name: "{{ item.images[0].name }}"
@@ -100,7 +112,20 @@
     - understack_images | length > 0
     - item is not skipped
     - item.images | length > 0
-    - item.images[0].status == 'queued'
+    - item.images[0].status in ['queued', 'uploading']
+
+- name: Look up target Glance images after uploading data
+  openstack.cloud.image_info:
+    cloud: "{{ openstack_cloud | default(omit) }}"
+    filters:
+      id: "{{ item.uuid }}"
+  register: target_image_info_2
+  loop: "{{ understack_images }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - understack_images | length > 0
+    - item.uuid in _reserved_image_uuids
 
 - name: Tell Glance to import the image data (using use_import and glance-direct)
   openstack.cloud.image:
@@ -110,7 +135,7 @@
     use_import: true
     state: present
     wait: true
-  loop: "{{ target_image_info.results | default([]) }}"
+  loop: "{{ target_image_info_2.results | default([]) }}"
   loop_control:
     label: "{{ item.item.name }}"
   when:

--- a/components/glance/glance-staging-perms.yaml
+++ b/components/glance/glance-staging-perms.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glance-staging-perms
+  namespace: openstack
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-options: Force=true
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: glance-staging-perms
+          image: busybox:stable
+          command:
+            - chown
+            - -R
+            - "42424:"
+            - /var/lib/glance/tmp
+          volumeMounts:
+            - name: glance-staging
+              mountPath: /var/lib/glance/tmp
+      volumes:
+        - name: glance-staging
+          persistentVolumeClaim:
+            claimName: glance-staging

--- a/components/glance/glance-staging-pvc.yaml
+++ b/components/glance/glance-staging-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    undercloud.local/purpose: glance-staging
+  name: glance-staging
+  namespace: openstack
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ceph-fs-ec
+  resources:
+    requests:
+      storage: 20Gi

--- a/components/glance/kustomization.yaml
+++ b/components/glance/kustomization.yaml
@@ -5,3 +5,5 @@ kind: Kustomization
 resources:
   - glance-mariadb-db.yaml
   - glance-rabbitmq-queue.yaml
+  - glance-staging-pvc.yaml
+  - glance-staging-perms.yaml

--- a/components/glance/values.yaml
+++ b/components/glance/values.yaml
@@ -78,12 +78,17 @@ pod:
           - name: glance-etc-snippets
             mountPath: /etc/glance/glance.conf.d/
             readOnly: true
+          - name: glance-staging
+            mountPath: /var/lib/glance/tmp/
         volumes:
           - name: glance-etc-snippets
             projected:
               sources:
                 - secret:
                     name: glance-ks-etc
+          - name: glance-staging
+            persistentVolumeClaim:
+              claimName: glance-staging
   lifecycle:
     disruption_budget:
       api:


### PR DESCRIPTION
2 small issues:
* after reserving and uploading we need the grab the status again as it changes from 'queued' to 'uploading', so it also needs to handle uploading status.
* adds better idempotent handling if we need to re-run the playbook, so we can pick up in the middle of reservation or uploading.
