### PR TITLE
feat: neutron mech - change tenant_id for project_id

### DIFF
--- a/python/neutron-understack/neutron_understack/utils.py
+++ b/python/neutron-understack/neutron_understack/utils.py
@@ -47,7 +47,7 @@ def create_neutron_port_for_segment(
             "device_id": "",
             "fixed_ips": [],
             "admin_state_up": True,
-            "tenant_id": "",
+            "project_id": "",
         }
     }
     if not core_plugin:


### PR DESCRIPTION
This PR fixes the error seen on 2026.1 neutron version, where we create a port with tenant_id, however 2026.1 expects project_id.

Error from the logs:

```2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers [None req-e21fb3d8-f93c-4717-96ff-56b15a4f659e 2fa7b6b584cb7b7aeb018ec5768b148f6d9576486b083808a2351c0256c6ecb4 937c44590d5a4960833c3322003cc240 - - 8b6128d06a334765a0c2064c786167c6 45cdfb41399a46d39a5e3c3dd7ec9b40] Mechanism driver 'understack' failed in create_port_postcommit: KeyError: 'project_id'
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers Traceback (most recent call last):
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/plugins/ml2/managers.py", line 500, in _call_on_drivers
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     getattr(driver.obj, method_name)(context)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_understack/neutron_understack_mech.py", line 153, in create_port_postcommit
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     routers.create_port_postcommit(context)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_understack/routers.py", line 60, in create_port_postcommit
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     shared_port = utils.create_neutron_port_for_segment(segment, context)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_understack/utils.py", line 56, in create_neutron_port_for_segment
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     return core_plugin.create_port(context.plugin_context, port)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/common/utils.py", line 710, in inner
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     return f(*args, **kwargs)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers            ^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_lib/db/api.py", line 223, in wrapped
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     return f_with_retry(*args, **kwargs,
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_lib/db/api.py", line 137, in wrapped
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     with excutils.save_and_reraise_exception():
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 271, in __exit__
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     self.force_reraise()
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 233, in force_reraise
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     raise self.value
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_lib/db/api.py", line 135, in wrapped
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     return f(*args, **kwargs)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers            ^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_db/api.py", line 144, in wrapper
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     with excutils.save_and_reraise_exception() as ectxt:
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 271, in __exit__
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     self.force_reraise()
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 233, in force_reraise
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     raise self.value
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_db/api.py", line 142, in wrapper
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     return f(*args, **kwargs)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers            ^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_lib/db/api.py", line 183, in wrapped
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     with excutils.save_and_reraise_exception():
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 271, in __exit__
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     self.force_reraise()
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/oslo_utils/excutils.py", line 233, in force_reraise
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     raise self.value
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_lib/db/api.py", line 181, in wrapped
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     return f(*dup_args, **dup_kwargs)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers            ^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/plugins/ml2/plugin.py", line 1671, in create_port
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     result, mech_context = self._create_port_db(context, port)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/plugins/ml2/plugin.py", line 1636, in _create_port_db
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     port_db = self.create_port_db(context, port)
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/db/db_base_plugin_v2.py", line 1561, in create_port_db
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers     project_id = p['project_id']
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers                  ~^^^^^^^^^^^^^^
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers KeyError: 'project_id'
2026-06-09 15:03:49.410 7 ERROR neutron.plugins.ml2.managers
```