### PR TITLE
feat(neutron-understack): require Keystone auth for Undersync

### DIFF
--- a/python/neutron-understack/neutron_understack/config.py
+++ b/python/neutron-understack/neutron_understack/config.py
@@ -19,23 +19,6 @@ mech_understack_opts = [
         "undersync_url",
         help="Undersync URL",
     ),
-    cfg.StrOpt(
-        "undersync_token",
-        help=(
-            "Undersync API token. If not provided, "
-            "the '/etc/undersync/token' will be read instead."
-        ),
-    ),
-    cfg.BoolOpt(
-        "undersync_use_keystone_auth",
-        default=False,
-        help=(
-            "Use Keystone authentication for Undersync. "
-            "If True, the driver will use the existing Neutron service token "
-            "from the [keystone_authtoken] config section instead of the "
-            "static JWT token."
-        ),
-    ),
     cfg.BoolOpt(
         "undersync_dry_run", default=True, help="Call Undersync with dry-run mode"
     ),

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -41,15 +41,8 @@ class UnderstackDriver(MechanismDriver):
         config.register_ml2_understack_opts(cfg.CONF)
         conf = cfg.CONF.ml2_understack
 
-        if conf.undersync_use_keystone_auth:
-            session = self._get_keystone_session()
-            self.undersync = Undersync(
-                session=session,
-                api_url=conf.undersync_url,
-                use_keystone_auth=True,
-            )
-        else:
-            self.undersync = Undersync(conf.undersync_token, conf.undersync_url)
+        session = self._get_keystone_session()
+        self.undersync = Undersync(session, conf.undersync_url)
 
         self.ironic_client = IronicClient()
         self.trunk_driver = UnderStackTrunkDriver.create(self)

--- a/python/neutron-understack/neutron_understack/tests/conftest.py
+++ b/python/neutron-understack/neutron_understack/tests/conftest.py
@@ -2,6 +2,7 @@ import copy
 import json
 import random
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 from neutron.db.models.segment import NetworkSegment
@@ -280,7 +281,9 @@ def ironic_client(mocker) -> IronicClient:
 @pytest.fixture
 def understack_driver(oslo_config, ironic_client) -> UnderstackDriver:
     driver = UnderstackDriver()
-    driver.undersync = Undersync("auth_token", "api_url", use_keystone_auth=False)
+    mock_session = MagicMock()
+    mock_session.get_token.return_value = "auth_token"
+    driver.undersync = Undersync(mock_session, "api_url")
     driver.ironic_client = ironic_client
     return driver
 

--- a/python/neutron-understack/neutron_understack/tests/test_keystone_token_refresh.py
+++ b/python/neutron-understack/neutron_understack/tests/test_keystone_token_refresh.py
@@ -7,7 +7,7 @@ from neutron_understack.neutron_understack_mech import UnderstackDriver
 class TestKeystoneTokenRefresh:
     """Test that Keystone tokens can be refreshed when they expire."""
 
-    def test_undersync_refreshes_expired_keystone_token(self, mocker, oslo_config):
+    def test_undersync_refreshes_expired_keystone_token(self, mocker):
         """Test that Undersync can handle token expiration by refreshing the token.
 
         This test simulates a scenario where:
@@ -18,11 +18,6 @@ class TestKeystoneTokenRefresh:
 
         This proves the session can refresh tokens automatically.
         """
-        oslo_config.config(
-            undersync_use_keystone_auth=True,
-            group="ml2_understack",
-        )
-
         # Mock the keystone session to simulate token refresh
         mock_session = Mock()
         # Use cycle to provide different tokens on each call (simulating refresh)

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -208,13 +208,8 @@ class TestCreateNetworkPostCommit:
 
 
 class TestKeystoneAuthentication:
-    def test_initialize_with_keystone_auth(self, mocker, oslo_config):
-        """Test that driver initializes with Keystone authentication when enabled."""
-        oslo_config.config(
-            undersync_use_keystone_auth=True,
-            group="ml2_understack",
-        )
-
+    def test_initialize_with_keystone_auth(self, mocker):
+        """Test that driver initializes with Keystone authentication."""
         mock_auth = mocker.patch("keystoneauth1.loading.load_auth_from_conf_options")
         mock_session_class = mocker.patch(
             "neutron_understack.neutron_understack_mech.ks_session.Session"
@@ -234,30 +229,4 @@ class TestKeystoneAuthentication:
         mock_auth.assert_called_once_with(cfg.CONF, "keystone_authtoken")
         mock_session_class.assert_called_once()
         mock_get_token.assert_called_once()
-        assert driver.undersync.use_keystone_auth is True
         assert driver.undersync.session == mock_session_instance
-
-    def test_initialize_with_jwt_auth(self, mocker, oslo_config):
-        """Test that driver initializes with JWT auth only."""
-        oslo_config.config(
-            undersync_use_keystone_auth=False,
-            undersync_token="test_jwt_token",
-            group="ml2_understack",
-        )
-
-        mock_auth = mocker.patch("keystoneauth1.loading.load_auth_from_conf_options")
-        mock_session = mocker.patch(
-            "keystoneauth1.loading.load_session_from_conf_options"
-        )
-
-        # Mock IronicClient to avoid config issues
-        mocker.patch("neutron_understack.neutron_understack_mech.IronicClient")
-
-        driver = UnderstackDriver()
-        driver.initialize()
-
-        # Should not call Keystone auth functions
-        mock_auth.assert_not_called()
-        mock_session.assert_not_called()
-        assert driver.undersync.use_keystone_auth is False
-        assert driver.undersync.token == "test_jwt_token"

--- a/python/neutron-understack/neutron_understack/tests/test_utils.py
+++ b/python/neutron-understack/neutron_understack/tests/test_utils.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
 
 from neutron_understack import utils
+from neutron_understack.undersync import Undersync
 
 
 class TestParentPortIsBound:
@@ -639,51 +640,14 @@ class TestFetchNetworkNodeTrunkId:
 
 class TestUndersyncAuthentication:
     def test_undersync_with_keystone_auth(self, mocker):
-        """Test that Undersync client uses X-Auth-Token header when enabled."""
-        from neutron_understack.undersync import Undersync
+        """Test that Undersync client uses X-Auth-Token header from session."""
+        mock_session = MagicMock()
+        mock_session.get_token.return_value = "test_token"
 
-        client = Undersync(
-            auth_token="test_token",
-            api_url="http://test.api",
-            use_keystone_auth=True,
-        )
+        client = Undersync(mock_session, "http://test.api")
 
-        # Access the client property to trigger its creation
         session = client.client
 
         assert session.headers["Content-Type"] == "application/json"
         assert session.headers["X-Auth-Token"] == "test_token"
         assert "Authorization" not in session.headers
-
-    def test_undersync_with_jwt_auth(self, mocker):
-        """Test that Undersync client uses Authorization Bearer header with JWT."""
-        from neutron_understack.undersync import Undersync
-
-        client = Undersync(
-            auth_token="test_jwt_token",
-            api_url="http://test.api",
-            use_keystone_auth=False,
-        )
-
-        # Access the client property to trigger its creation
-        session = client.client
-
-        assert session.headers["Content-Type"] == "application/json"
-        assert session.headers["Authorization"] == "Bearer test_jwt_token"
-        assert "X-Auth-Token" not in session.headers
-
-    def test_undersync_default_to_jwt_auth(self, mocker):
-        """Test that Undersync client defaults to JWT auth when not specified."""
-        from neutron_understack.undersync import Undersync
-
-        client = Undersync(
-            auth_token="test_token",
-            api_url="http://test.api",
-        )
-
-        # Access the client property to trigger its creation
-        session = client.client
-
-        assert session.headers["Content-Type"] == "application/json"
-        assert session.headers["Authorization"] == "Bearer test_token"
-        assert "X-Auth-Token" not in session.headers

--- a/python/neutron-understack/neutron_understack/undersync.py
+++ b/python/neutron-understack/neutron_understack/undersync.py
@@ -1,4 +1,3 @@
-import pathlib
 import urllib.parse
 
 import requests
@@ -15,40 +14,14 @@ class UndersyncError(Exception):
 class Undersync:
     def __init__(
         self,
-        auth_token: str | None = None,
+        session,
         api_url: str | None = None,
         timeout: int = 90,
-        use_keystone_auth: bool = False,
-        session=None,
     ) -> None:
-        """Simple client for Undersync.
-
-        Args:
-            auth_token: Authentication token. If use_keystone_auth is True,
-                       this should be a Keystone service token. Otherwise,
-                       it should be a JWT token. If not provided, it will be
-                       fetched from /etc/undersync/token.
-            api_url: Undersync API URL.
-            timeout: Request timeout in seconds.
-            use_keystone_auth: If True, use X-Auth-Token header for Keystone
-                             authentication. Otherwise, use Authorization:
-                             Bearer header for JWT authentication.
-            session: Keystone session object for automatic token refresh.
-                    If provided, takes precedence over auth_token for Keystone auth.
-        """
         self.session = session
-        self.token = auth_token or (
-            self._fetch_undersync_token() if not session else None
-        )
         self.url = "http://undersync.undersync.svc.cluster.local:8080"
         self.api_url = api_url or self.url
         self.timeout = timeout
-        self.use_keystone_auth = use_keystone_auth
-
-    def _fetch_undersync_token(self) -> str:
-        file = pathlib.Path("/etc/undersync/token")
-        with file.open() as f:
-            return f.read().strip()
 
     def _log_and_raise_for_status(self, response: requests.Response):
         try:
@@ -71,17 +44,7 @@ class Undersync:
     def client(self):
         session = requests.Session()
         session.headers = {"Content-Type": "application/json"}
-
-        if self.use_keystone_auth and self.session:
-            # Get fresh token from session for each request (enables refresh)
-            token = self.session.get_token()
-            session.headers["X-Auth-Token"] = token
-        elif self.use_keystone_auth:
-            # Fallback to stored token for backward compatibility
-            session.headers["X-Auth-Token"] = self.token
-        else:
-            session.headers["Authorization"] = f"Bearer {self.token}"
-
+        session.headers["X-Auth-Token"] = self.session.get_token()
         return session
 
     def _undersync_post(self, action: str, vlan_group: str) -> requests.Response:


### PR DESCRIPTION
Remove the JWT/static token path from the Undersync client. Keystone
authentication via the Neutron service credentials is now the only
supported method, eliminating the need to mount a token file or
configure undersync_token / undersync_use_keystone_auth.
