### PR TITLE
chore: fix sealed-secrets repo for bootstrap

### DIFF
--- a/bootstrap/kustomization.yaml
+++ b/bootstrap/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
-- sealed-secrets/
+resources: []

--- a/bootstrap/sealed-secrets/kustomization.yaml
+++ b/bootstrap/sealed-secrets/kustomization.yaml
@@ -12,4 +12,4 @@ helmCharts:
   valuesFile: values.yaml
   releaseName: sealed-secrets
   version: 2.17.9
-  repo: https://bitnami-labs.github.io/sealed-secrets
+  repo: https://bitnami.github.io/sealed-secrets


### PR DESCRIPTION
- remove sealed-secrets from default bootstrap
- fix sealed-secrets helm repo path

We need to revisit if we need the default bootstrap at all.
