### PR TITLE
feat(neutron): Make SVI a standalone L3 service provider

### DIFF
--- a/python/neutron-understack/neutron_understack/l3_router/svi.py
+++ b/python/neutron-understack/neutron_understack/l3_router/svi.py
@@ -1,5 +1,50 @@
-from neutron.services.ovn_l3.service_providers.user_defined import UserDefined
+import logging
+
+from neutron.services.l3_router.service_providers import base
+from neutron_lib import constants as const
+from neutron_lib.plugins import constants as plugin_constants
+from neutron_lib.plugins import directory
+
+LOG = logging.getLogger(__name__)
+
+# Full dotted path as stored in the flavor profile's service_providers table.
+# Must match the value in understack/components/neutron/values.yaml.
+# SVI_DRIVER = "neutron_understack.l3_router.svi.Svi"
 
 
-class Svi(UserDefined):
-    pass
+class Svi(base.L3ServiceProvider):
+    ha_support = base.OPTIONAL
+
+    def __init__(self, l3_plugin):
+        super().__init__(l3_plugin)
+        # self._svi_provider = SVI_DRIVER
+        self._svi_provider = f"{self.__module__}.{self.__class__.__name__}"
+        LOG.info("SVI service provider initialized: driver=%r", self._svi_provider)
+
+    @property
+    def _flavor_plugin(self):
+        try:
+            return self._flavor_plugin_ref
+        except AttributeError:
+            self._flavor_plugin_ref = directory.get_plugin(plugin_constants.FLAVORS)
+            return self._flavor_plugin_ref
+
+    # ATTR_NOT_SPECIFIED “the API field was not provided.”
+    def _is_svi_flavor(self, context, router):
+        flavor_id = router.get("flavor_id")
+        if flavor_id is None or flavor_id is const.ATTR_NOT_SPECIFIED:
+            return False
+
+        flavor = self._flavor_plugin.get_flavor(context, flavor_id)
+        provider = self._flavor_plugin.get_flavor_next_provider(context, flavor["id"])[
+            0
+        ]
+        is_svi = str(provider["driver"]) == self._svi_provider
+        LOG.debug(
+            "SVI flavor check: router %s flavor %s driver %s is_svi=%s",
+            router.get("id"),
+            flavor_id,
+            provider["driver"],
+            is_svi,
+        )
+        return is_svi

--- a/python/neutron-understack/neutron_understack/tests/test_svi_provider.py
+++ b/python/neutron-understack/neutron_understack/tests/test_svi_provider.py
@@ -1,0 +1,71 @@
+from neutron_lib import constants as const
+
+from neutron_understack.l3_router import svi
+
+
+class FakeFlavorPlugin:
+    def __init__(self, driver):
+        self.driver = driver
+
+    def get_flavor(self, _context, flavor_id):
+        return {"id": flavor_id}
+
+    def get_flavor_next_provider(self, _context, _flavor_id):
+        return [{"driver": self.driver}]
+
+
+def _svi_driver():
+    return f"{svi.Svi.__module__}.{svi.Svi.__name__}"
+
+
+class TestSviProvider:
+    def test_flavor_plugin_is_cached(self, mocker):
+        plugin = FakeFlavorPlugin(_svi_driver())
+        get_plugin = mocker.patch.object(
+            svi.directory, "get_plugin", return_value=plugin
+        )
+        provider = svi.Svi(None)
+
+        assert provider._flavor_plugin is plugin
+        assert provider._flavor_plugin is plugin
+        get_plugin.assert_called_once_with(svi.plugin_constants.FLAVORS)
+
+    def test_is_svi_flavor_returns_false_without_flavor(self, mocker):
+        get_plugin = mocker.patch.object(svi.directory, "get_plugin")
+        provider = svi.Svi(None)
+
+        assert provider._is_svi_flavor("context", {"id": "router-a"}) is False
+        assert (
+            provider._is_svi_flavor(
+                "context",
+                {"id": "router-a", "flavor_id": const.ATTR_NOT_SPECIFIED},
+            )
+            is False
+        )
+        get_plugin.assert_not_called()
+
+    def test_is_svi_flavor_returns_true_for_svi_driver(self, mocker):
+        plugin = FakeFlavorPlugin(_svi_driver())
+        mocker.patch.object(svi.directory, "get_plugin", return_value=plugin)
+        provider = svi.Svi(None)
+
+        assert (
+            provider._is_svi_flavor(
+                "context",
+                {"id": "router-a", "flavor_id": "svi-flavor-id"},
+            )
+            is True
+        )
+
+    def test_is_svi_flavor_returns_false_for_different_driver(self, mocker):
+        plugin = FakeFlavorPlugin("neutron_understack.l3_router.vrf.Vrf")
+        mocker.patch.object(svi.directory, "get_plugin", return_value=plugin)
+        provider = svi.Svi(None)
+
+        assert (
+            provider._is_svi_flavor(
+                "context",
+                {"id": "router-a", "flavor_id": "vrf-flavor-id"},
+            )
+            is False
+        )


### PR DESCRIPTION
Foundation PR for splitting the SVI work. This changes Svi to inherit from L3ServiceProvider instead of UserDefined, preserves ha_support=OPTIONAL, and adds an _is_svi_flavor helper for matching the SVI flavor provider. Address-scope enforcement will be handled in a follow-up PR.   

- neutron-server loaded the SVI provider from neutron_understack.l3_router.svi.Svi  
`Defaulted container "neutron-server" out of: neutron-server, init (init), ovn-neutron-init (init)
2026-06-19 04:48:22.634 7 INFO neutron_understack.l3_router.svi [-] SVI service provider initialized: driver='neutron_understack.l3_router.svi.Svi'`
- openstack router create --flavor svi succeeded
- SVI router remained ha=False, matching existing SVI behavior
- attaching a no-scope subnet still succeeded
- router interfaces_info shows the attached subnet with gateway IP 192.168.252.1 

`understack on  svi-l3-provider-foundation [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack subnet create nidhi-svi-pr1-subnet-noscope \
  --network nidhi-svi-pr1-net-noscope \
  --subnet-range 192.168.252.0/24`
<img width="1290" height="466" alt="image" src="https://github.com/user-attachments/assets/6ce0b1a5-479e-41f2-a4cb-0b3a14619f69" />