### PR TITLE
feat(neutron): enforce address scope on SVI router interfaces PUC-1720

### DIFF
--- a/python/neutron-understack/neutron_understack/l3_router/svi.py
+++ b/python/neutron-understack/neutron_understack/l3_router/svi.py
@@ -2,23 +2,322 @@ import logging
 
 from neutron.services.l3_router.service_providers import base
 from neutron_lib import constants as const
+from neutron_lib import exceptions as n_exc
+from neutron_lib.callbacks import events
+from neutron_lib.callbacks import registry
+from neutron_lib.callbacks import resources
 from neutron_lib.plugins import constants as plugin_constants
 from neutron_lib.plugins import directory
 
 LOG = logging.getLogger(__name__)
 
-# Full dotted path as stored in the flavor profile's service_providers table.
-# Must match the value in understack/components/neutron/values.yaml.
-# SVI_DRIVER = "neutron_understack.l3_router.svi.Svi"
+
+def _svi_provider_driver():
+    return f"{Svi.__module__}.{Svi.__name__}"
 
 
+def _is_svi_router(context, router):
+    flavor_id = router.get("flavor_id")
+    if not flavor_id or flavor_id is const.ATTR_NOT_SPECIFIED:
+        LOG.debug("SVI check: router %s has no flavor, skipping", router.get("id"))
+        return False
+    flavor_plugin = directory.get_plugin(plugin_constants.FLAVORS)
+    flavor = flavor_plugin.get_flavor(context, flavor_id)
+    provider = flavor_plugin.get_flavor_next_provider(context, flavor["id"])[0]
+    driver = provider["driver"]
+    is_svi = str(driver) == _svi_provider_driver()
+    LOG.debug(
+        "SVI check: router %s flavor %s driver %s is_svi=%s",
+        router.get("id"),
+        flavor_id,
+        driver,
+        is_svi,
+    )
+    return is_svi
+
+
+def _get_subnet_address_scope(context, subnet_id):
+    """Return (ip_version, address_scope_id). scope is None if not set."""
+    core_plugin = directory.get_plugin()
+    subnet = core_plugin.get_subnet(context, subnet_id)
+    ip_version = subnet.get("ip_version")
+    subnetpool_id = subnet.get("subnetpool_id")
+    if not subnetpool_id:
+        LOG.debug("Subnet %s has no subnetpool, no address scope", subnet_id)
+        return ip_version, None
+    subnetpool = core_plugin.get_subnetpool(context, subnetpool_id)
+    scope_id = subnetpool.get("address_scope_id")
+    LOG.debug(
+        "Subnet %s subnetpool %s address_scope %s (IPv%s)",
+        subnet_id,
+        subnetpool_id,
+        scope_id,
+        ip_version,
+    )
+    return ip_version, scope_id
+
+
+def _get_existing_router_subnet_ids(context, router_id):
+    """Return subnet IDs of all internal interfaces already on the router."""
+    core_plugin = directory.get_plugin()
+    ports = core_plugin.get_ports(
+        context,
+        filters={
+            "device_id": [router_id],
+            "device_owner": [const.DEVICE_OWNER_ROUTER_INTF],
+        },
+    )
+    subnet_ids = [
+        ip["subnet_id"]
+        for port in ports
+        for ip in port.get("fixed_ips", [])
+        if ip.get("subnet_id")
+    ]
+    LOG.debug(
+        "Router %s already has %d subnet(s): %s",
+        router_id,
+        len(subnet_ids),
+        subnet_ids,
+    )
+    return subnet_ids
+
+
+def _router_interface_attach_mode(interface_info):
+    if "port_id" in interface_info:
+        return "port"
+    if "subnet_id" in interface_info:
+        return "subnet"
+    return "unknown"
+
+
+def _validate_address_scope_rules(context, router_id, new_subnet_ids):
+    """Validate address scope rules for subnets being attached to an SVI router.
+
+    Raises BadRequest if any subnet has no scope or conflicts with existing ones.
+    Returns {ip_version: scope_id} for the new subnets.
+    """
+    new_scopes: dict[int, str] = {}
+    LOG.debug(
+        "SVI scope check: router %s validating new subnet(s)=%s",
+        router_id,
+        new_subnet_ids,
+    )
+
+    # Rule 1: every new subnet must belong to an address scope
+    for subnet_id in new_subnet_ids:
+        ip_version, scope_id = _get_subnet_address_scope(context, subnet_id)
+        if ip_version == 6:
+            LOG.warning(
+                "SVI scope check FAILED: IPv6 subnet %s cannot attach to router %s",
+                subnet_id,
+                router_id,
+            )
+            raise n_exc.BadRequest(
+                resource="router",
+                msg=(
+                    f"IPv6 subnet {subnet_id} cannot be attached to an "
+                    "SVI router. SVI routers currently support IPv4 subnets only."
+                ),
+            )
+        if not scope_id:
+            LOG.warning(
+                "SVI scope check FAILED: subnet %s has no address scope (router %s)",
+                subnet_id,
+                router_id,
+            )
+            raise n_exc.BadRequest(
+                resource="router",
+                msg=(
+                    f"Subnet {subnet_id} must belong to an address scope "
+                    "to attach to an SVI router."
+                ),
+            )
+        if ip_version in new_scopes and new_scopes[ip_version] != scope_id:
+            LOG.warning(
+                "SVI scope check FAILED: IPv%s conflict in new attach on router %s - "
+                "subnet %s scope=%s previous_scope=%s",
+                ip_version,
+                router_id,
+                subnet_id,
+                scope_id,
+                new_scopes[ip_version],
+            )
+            raise n_exc.BadRequest(
+                resource="router",
+                msg=(
+                    f"Cannot attach subnets {new_subnet_ids!r}: IPv{ip_version} "
+                    f"address scope {scope_id!r} differs from scope "
+                    f"{new_scopes[ip_version]!r} in the same request."
+                ),
+            )
+        new_scopes[ip_version] = scope_id
+        LOG.debug(
+            "SVI scope check resolved: router %(router)s subnet %(subnet)s "
+            "IPv%(ip_version)s scope %(scope)s",
+            {
+                "router": router_id,
+                "subnet": subnet_id,
+                "ip_version": ip_version,
+                "scope": scope_id,
+            },
+        )
+
+    LOG.debug(
+        "SVI scope check requested scopes: router %(router)s scopes=%(scopes)s",
+        {"router": router_id, "scopes": new_scopes},
+    )
+
+    # Rule 2: must not conflict with existing interfaces (per IP version)
+    for existing_subnet_id in _get_existing_router_subnet_ids(context, router_id):
+        ip_version, existing_scope = _get_subnet_address_scope(
+            context, existing_subnet_id
+        )
+        if ip_version not in new_scopes:
+            LOG.debug(
+                "SVI scope check compare skipped: router %(router)s existing "
+                "subnet %(subnet)s is IPv%(ip_version)s with no new subnet in "
+                "that IP family",
+                {
+                    "router": router_id,
+                    "subnet": existing_subnet_id,
+                    "ip_version": ip_version,
+                },
+            )
+            continue
+        LOG.debug(
+            "SVI scope check compare: router %(router)s IPv%(ip_version)s "
+            "new_scope=%(new_scope)s existing_scope=%(existing_scope)s "
+            "existing_subnet=%(subnet)s",
+            {
+                "router": router_id,
+                "ip_version": ip_version,
+                "new_scope": new_scopes[ip_version],
+                "existing_scope": existing_scope,
+                "subnet": existing_subnet_id,
+            },
+        )
+        if not existing_scope:
+            LOG.warning(
+                "SVI scope check FAILED: existing IPv%s subnet %s on router %s "
+                "has no address scope",
+                ip_version,
+                existing_subnet_id,
+                router_id,
+            )
+            raise n_exc.BadRequest(
+                resource="router",
+                msg=(
+                    f"Existing subnet {existing_subnet_id} on router {router_id} "
+                    "must belong to an address scope before attaching more "
+                    "subnets to an SVI router."
+                ),
+            )
+        if existing_scope != new_scopes[ip_version]:
+            LOG.warning(
+                "SVI scope check FAILED: IPv%s conflict on router %s - "
+                "new=%s existing=%s (from subnet %s)",
+                ip_version,
+                router_id,
+                new_scopes[ip_version],
+                existing_scope,
+                existing_subnet_id,
+            )
+            raise n_exc.BadRequest(
+                resource="router",
+                msg=(
+                    f"Cannot attach subnet {new_subnet_ids!r}: its IPv{ip_version} "
+                    f"address scope {new_scopes[ip_version]!r} differs from "
+                    f"scope {existing_scope!r} already in use on router {router_id}."
+                ),
+            )
+
+    return new_scopes
+
+
+def validate_svi_router_port(plugin_context, port):
+    """Standalone SVI scope validator called from create_port_precommit.
+
+    Fires before port is committed, so invalid subnets never reach the VLAN
+    allocation / trunk / Undersync steps in create_port_postcommit.
+    Raises BadRequest if validation fails.
+    Returns True when an SVI router interface was validated, otherwise False.
+    """
+    device_owner = port.get("device_owner")
+    if device_owner != const.DEVICE_OWNER_ROUTER_INTF:
+        LOG.debug(
+            "precommit SVI scope check skipped: port %s owner %s is not an "
+            "internal router interface",
+            port.get("id"),
+            device_owner,
+        )
+        return False
+
+    router_id = port.get("device_id")
+    if not router_id:
+        LOG.debug(
+            "precommit SVI scope check skipped: port %s owner %s has no router id",
+            port.get("id"),
+            device_owner,
+        )
+        return False
+
+    try:
+        l3_plugin = directory.get_plugin(plugin_constants.L3)
+        router = l3_plugin.get_router(plugin_context, router_id)
+    except Exception:
+        LOG.exception(
+            "precommit SVI scope check failed to fetch router %s for port %s",
+            router_id,
+            port.get("id"),
+        )
+        raise
+
+    if not _is_svi_router(plugin_context, router):
+        LOG.debug(
+            "precommit SVI scope check skipped: router %(router)s is not SVI "
+            "(name=%(name)s flavor=%(flavor)s) for port %(port)s",
+            {
+                "router": router_id,
+                "name": router.get("name"),
+                "flavor": router.get("flavor_id"),
+                "port": port.get("id"),
+            },
+        )
+        return False
+
+    new_subnet_ids = [
+        ip["subnet_id"] for ip in port.get("fixed_ips", []) if ip.get("subnet_id")
+    ]
+    LOG.info(
+        "precommit SVI scope check: router %s (%s) port %s network %s subnet(s)=%s",
+        router_id,
+        router.get("name"),
+        port.get("id"),
+        port.get("network_id"),
+        new_subnet_ids,
+    )
+
+    new_scopes = _validate_address_scope_rules(
+        plugin_context, router_id, new_subnet_ids
+    )
+
+    LOG.info(
+        "precommit SVI scope check PASSED: router %s port %s subnet(s)=%s scopes=%s",
+        router_id,
+        port.get("id"),
+        new_subnet_ids,
+        new_scopes,
+    )
+    return True
+
+
+@registry.has_registry_receivers
 class Svi(base.L3ServiceProvider):
     ha_support = base.OPTIONAL
 
     def __init__(self, l3_plugin):
         super().__init__(l3_plugin)
-        # self._svi_provider = SVI_DRIVER
-        self._svi_provider = f"{self.__module__}.{self.__class__.__name__}"
+        self._svi_provider = _svi_provider_driver()
         LOG.info("SVI service provider initialized: driver=%r", self._svi_provider)
 
     @property
@@ -29,22 +328,64 @@ class Svi(base.L3ServiceProvider):
             self._flavor_plugin_ref = directory.get_plugin(plugin_constants.FLAVORS)
             return self._flavor_plugin_ref
 
-    # ATTR_NOT_SPECIFIED “the API field was not provided.”
     def _is_svi_flavor(self, context, router):
-        flavor_id = router.get("flavor_id")
-        if flavor_id is None or flavor_id is const.ATTR_NOT_SPECIFIED:
-            return False
+        # Single source of truth for SVI detection: the precommit path
+        # (validate_svi_router_port, which has no self) and this callback both
+        # go through the module-level helper instead of duplicating the
+        # flavor -> provider -> driver lookup.
+        return _is_svi_router(context, router)
 
-        flavor = self._flavor_plugin.get_flavor(context, flavor_id)
-        provider = self._flavor_plugin.get_flavor_next_provider(context, flavor["id"])[
-            0
+    @registry.receives(resources.ROUTER_INTERFACE, [events.BEFORE_CREATE])
+    def _validate_svi_router_interface(self, _resource, _event, _trigger, payload):
+        router = payload.states[0]
+        context = payload.context
+        router_id = payload.resource_id
+        metadata = payload.metadata
+        attach_mode = _router_interface_attach_mode(metadata.get("interface_info", {}))
+
+        if not self._is_svi_flavor(context, router):
+            LOG.debug(
+                "SVI callback validation skipped: router %(router)s is not SVI "
+                "(name=%(name)s flavor=%(flavor)s attach_mode=%(attach_mode)s)",
+                {
+                    "router": router_id,
+                    "name": router.get("name"),
+                    "flavor": router.get("flavor_id"),
+                    "attach_mode": attach_mode,
+                },
+            )
+            return
+
+        port = metadata["port"]
+        new_subnet_ids = [
+            ip["subnet_id"] for ip in port.get("fixed_ips", []) if ip.get("subnet_id")
         ]
-        is_svi = str(provider["driver"]) == self._svi_provider
-        LOG.debug(
-            "SVI flavor check: router %s flavor %s driver %s is_svi=%s",
-            router.get("id"),
-            flavor_id,
-            provider["driver"],
-            is_svi,
+        LOG.info(
+            "SVI callback validation: attach_mode=%(attach_mode)s "
+            "router %(router)s (%(router_name)s) port %(port)s "
+            "network %(network)s owner %(owner)s subnet(s)=%(subnets)s",
+            {
+                "attach_mode": attach_mode,
+                "router": router_id,
+                "router_name": router.get("name"),
+                "port": port.get("id"),
+                "network": port.get("network_id"),
+                "owner": port.get("device_owner"),
+                "subnets": new_subnet_ids,
+            },
         )
-        return is_svi
+
+        new_scopes = _validate_address_scope_rules(context, router_id, new_subnet_ids)
+
+        LOG.info(
+            "SVI callback validation PASSED: attach_mode=%(attach_mode)s "
+            "router %(router)s port %(port)s subnet(s)=%(subnets)s "
+            "scopes=%(scopes)s",
+            {
+                "attach_mode": attach_mode,
+                "router": router_id,
+                "port": port.get("id"),
+                "subnets": new_subnet_ids,
+                "scopes": new_scopes,
+            },
+        )

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -15,6 +15,7 @@ from neutron_understack import config
 from neutron_understack import routers
 from neutron_understack import utils
 from neutron_understack.ironic import IronicClient
+from neutron_understack.l3_router import svi as svi_router
 from neutron_understack.trunk import UnderStackTrunkDriver
 from neutron_understack.undersync import Undersync
 
@@ -25,6 +26,14 @@ LOG = logging.getLogger(__name__)
 
 
 SUPPORTED_VNIC_TYPES = [portbindings.VNIC_BAREMETAL, portbindings.VNIC_NORMAL]
+ROUTER_INTERFACE_OWNERS = (
+    p_const.DEVICE_OWNER_ROUTER_INTF,
+    p_const.DEVICE_OWNER_ROUTER_GW,
+)
+
+
+def _is_router_interface_port(port):
+    return port.get("device_owner") in ROUTER_INTERFACE_OWNERS
 
 
 class UnderstackDriver(MechanismDriver):
@@ -98,7 +107,41 @@ class UnderstackDriver(MechanismDriver):
         pass
 
     def create_port_precommit(self, context: PortContext):
-        pass
+        # Early SVI address scope check fires before port is committed and
+        # before create_port_postcommit, so invalid subnets never reach the
+        # VLAN allocation / trunk / Undersync steps.
+        # Neutron surfaces the BadRequest back through the router-interface API.
+        # update_port_precommit covers existing-port attaches.
+        if utils.is_router_interface(context):
+            LOG.info(
+                "create_port_precommit: checking SVI scope validation for "
+                "router port %s device_id=%s",
+                context.current["id"],
+                context.current.get("device_id"),
+            )
+            checked = svi_router.validate_svi_router_port(
+                context.plugin_context, context.current
+            )
+            if checked:
+                LOG.info(
+                    "create_port_precommit: SVI scope check passed for port %(port)s "
+                    "network %(network)s router %(router)s",
+                    {
+                        "port": context.current["id"],
+                        "network": context.current.get("network_id"),
+                        "router": context.current.get("device_id"),
+                    },
+                )
+            else:
+                LOG.debug(
+                    "create_port_precommit: SVI scope check not applicable for "
+                    "port %(port)s owner %(owner)s router %(router)s",
+                    {
+                        "port": context.current["id"],
+                        "owner": context.current.get("device_owner"),
+                        "router": context.current.get("device_id"),
+                    },
+                )
 
     def create_port_postcommit(self, context: PortContext) -> None:
         # Provide network node(s) with connectivity to the networks where this
@@ -111,10 +154,92 @@ class UnderstackDriver(MechanismDriver):
         )
 
         if utils.is_router_interface(context):
-            routers.create_port_postcommit(context)
+            LOG.info(
+                "Router interface port %(port)s detected on network %(net)s "
+                "device_id=%(router)s owner=%(owner)s fixed_ips=%(fixed_ips)s "
+                "- handing off to routers.create_port_postcommit",
+                {
+                    "port": port["id"],
+                    "net": port["network_id"],
+                    "router": port.get("device_id"),
+                    "owner": port.get("device_owner"),
+                    "fixed_ips": port.get("fixed_ips", []),
+                },
+            )
+            try:
+                routers.create_port_postcommit(context)
+            except Exception:
+                LOG.exception(
+                    "Router interface postcommit failed for port %(port)s "
+                    "network %(network)s router %(router)s owner %(owner)s "
+                    "fixed_ips=%(fixed_ips)s",
+                    {
+                        "port": port["id"],
+                        "network": port["network_id"],
+                        "router": port.get("device_id"),
+                        "owner": port.get("device_owner"),
+                        "fixed_ips": port.get("fixed_ips", []),
+                    },
+                )
+                raise
 
-    def update_port_precommit(self, context):
-        pass
+    def update_port_precommit(self, context: PortContext):
+        if not utils.is_router_interface(context):
+            return
+
+        original = context.original
+        current = context.current
+        became_router_interface = not _is_router_interface_port(
+            original
+        ) and _is_router_interface_port(current)
+        fixed_ips_changed = original.get("fixed_ips", []) != current.get(
+            "fixed_ips", []
+        )
+
+        if not (became_router_interface or fixed_ips_changed):
+            LOG.debug(
+                "update_port_precommit: SVI scope check not needed for port "
+                "%(port)s owner %(owner)s router %(router)s",
+                {
+                    "port": current["id"],
+                    "owner": current.get("device_owner"),
+                    "router": current.get("device_id"),
+                },
+            )
+            return
+
+        LOG.info(
+            "update_port_precommit: checking SVI scope validation for router "
+            "port %(port)s device_id=%(router)s became_router_interface=%(became)s "
+            "fixed_ips_changed=%(fixed_ips_changed)s",
+            {
+                "port": current["id"],
+                "router": current.get("device_id"),
+                "became": became_router_interface,
+                "fixed_ips_changed": fixed_ips_changed,
+            },
+        )
+        checked = svi_router.validate_svi_router_port(context.plugin_context, current)
+        if checked:
+            LOG.info(
+                "update_port_precommit: SVI scope check passed for port %(port)s "
+                "network %(network)s router %(router)s",
+                {
+                    "port": current["id"],
+                    "network": current.get("network_id"),
+                    "router": current.get("device_id"),
+                },
+            )
+        else:
+            LOG.debug(
+                "update_port_precommit: SVI scope check not applicable for "
+                "port %(port)s owner %(owner)s router %(router)s",
+                {
+                    "port": current["id"],
+                    "owner": current.get("device_owner"),
+                    "router": current.get("device_id"),
+                },
+            )
 
     def update_port_postcommit(self, context: PortContext) -> None:
         if utils.is_baremetal_port(context):

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -1,10 +1,139 @@
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
+from neutron_lib import constants as p_const
 from neutron_lib.api.definitions import portbindings
 from neutron_lib.plugins.ml2 import api
 
 from neutron_understack.neutron_understack_mech import UnderstackDriver
+
+
+def _port_update_context(original, current):
+    return SimpleNamespace(
+        original=original,
+        current=current,
+        plugin_context="plugin-context",
+    )
+
+
+class TestUpdatePortPreCommit:
+    def test_validates_when_port_becomes_router_interface(
+        self, mocker, understack_driver
+    ):
+        original = {
+            "id": "port-a",
+            "network_id": "network-a",
+            "device_owner": "",
+            "device_id": "",
+            "fixed_ips": [{"subnet_id": "subnet-a"}],
+        }
+        current = {
+            **original,
+            "device_owner": p_const.DEVICE_OWNER_ROUTER_INTF,
+            "device_id": "router-a",
+        }
+        validate = mocker.patch(
+            "neutron_understack.neutron_understack_mech."
+            "svi_router.validate_svi_router_port",
+            return_value=True,
+        )
+
+        understack_driver.update_port_precommit(_port_update_context(original, current))
+
+        validate.assert_called_once_with("plugin-context", current)
+
+    def test_validates_when_router_interface_fixed_ips_change(
+        self, mocker, understack_driver
+    ):
+        original = {
+            "id": "port-a",
+            "network_id": "network-a",
+            "device_owner": p_const.DEVICE_OWNER_ROUTER_INTF,
+            "device_id": "router-a",
+            "fixed_ips": [{"subnet_id": "subnet-a"}],
+        }
+        current = {
+            **original,
+            "fixed_ips": [
+                {"subnet_id": "subnet-a"},
+                {"subnet_id": "subnet-b"},
+            ],
+        }
+        validate = mocker.patch(
+            "neutron_understack.neutron_understack_mech."
+            "svi_router.validate_svi_router_port",
+            return_value=True,
+        )
+
+        understack_driver.update_port_precommit(_port_update_context(original, current))
+
+        validate.assert_called_once_with("plugin-context", current)
+
+    def test_validates_remaining_subnets_when_fixed_ip_removed(
+        self, mocker, understack_driver
+    ):
+        original = {
+            "id": "port-a",
+            "network_id": "network-a",
+            "device_owner": p_const.DEVICE_OWNER_ROUTER_INTF,
+            "device_id": "router-a",
+            "fixed_ips": [
+                {"subnet_id": "subnet-a"},
+                {"subnet_id": "subnet-b"},
+            ],
+        }
+        current = {
+            **original,
+            "fixed_ips": [{"subnet_id": "subnet-a"}],
+        }
+        validate = mocker.patch(
+            "neutron_understack.neutron_understack_mech."
+            "svi_router.validate_svi_router_port",
+            return_value=True,
+        )
+
+        understack_driver.update_port_precommit(_port_update_context(original, current))
+
+        validate.assert_called_once_with("plugin-context", current)
+
+    def test_skips_router_interface_without_relevant_update(
+        self, mocker, understack_driver
+    ):
+        original = {
+            "id": "port-a",
+            "network_id": "network-a",
+            "device_owner": p_const.DEVICE_OWNER_ROUTER_INTF,
+            "device_id": "router-a",
+            "fixed_ips": [{"subnet_id": "subnet-a"}],
+        }
+        current = {**original, "name": "new-name"}
+        validate = mocker.patch(
+            "neutron_understack.neutron_understack_mech."
+            "svi_router.validate_svi_router_port"
+        )
+
+        understack_driver.update_port_precommit(_port_update_context(original, current))
+
+        validate.assert_not_called()
+
+    def test_skips_non_router_interface_update(self, mocker, understack_driver):
+        original = {
+            "id": "port-a",
+            "network_id": "network-a",
+            "device_owner": "",
+            "device_id": "",
+            "fixed_ips": [{"subnet_id": "subnet-a"}],
+        }
+        current = {**original, "fixed_ips": [{"subnet_id": "subnet-b"}]}
+        validate = mocker.patch(
+            "neutron_understack.neutron_understack_mech."
+            "svi_router.validate_svi_router_port"
+        )
+
+        understack_driver.update_port_precommit(_port_update_context(original, current))
+
+        validate.assert_not_called()
 
 
 class TestUpdatePortPostCommit:

--- a/python/neutron-understack/neutron_understack/tests/test_svi.py
+++ b/python/neutron-understack/neutron_understack/tests/test_svi.py
@@ -1,0 +1,285 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+from neutron_lib import constants as const
+from neutron_lib import exceptions as n_exc
+
+from neutron_understack.l3_router import svi
+
+
+class FakeCorePlugin:
+    def __init__(self, subnets, subnetpools=None, ports=None):
+        self.subnets = subnets
+        self.subnetpools = subnetpools or {}
+        self.ports = ports or []
+
+    def get_subnet(self, _context, subnet_id):
+        return self.subnets[subnet_id]
+
+    def get_subnetpool(self, _context, subnetpool_id):
+        return self.subnetpools[subnetpool_id]
+
+    def get_ports(self, _context, filters=None):
+        return self.ports
+
+
+class FakeFlavorPlugin:
+    def __init__(self, driver):
+        self.driver = driver
+
+    def get_flavor(self, _context, flavor_id):
+        return {"id": flavor_id}
+
+    def get_flavor_next_provider(self, _context, _flavor_id):
+        return [{"driver": self.driver}]
+
+
+class FakeL3Plugin:
+    def __init__(self, router):
+        self.router = router
+
+    def get_router(self, _context, _router_id):
+        return self.router
+
+
+def _subnet(subnetpool_id, ip_version=4):
+    return {"ip_version": ip_version, "subnetpool_id": subnetpool_id}
+
+
+def _subnetpool(scope_id):
+    return {"address_scope_id": scope_id}
+
+
+def _patch_core_plugin(mocker, plugin):
+    mocker.patch.object(svi.directory, "get_plugin", return_value=plugin)
+
+
+def _patch_plugins(mocker, *, core_plugin, l3_plugin, flavor_plugin):
+    def get_plugin(plugin_type=None):
+        if plugin_type == svi.plugin_constants.L3:
+            return l3_plugin
+        if plugin_type == svi.plugin_constants.FLAVORS:
+            return flavor_plugin
+        return core_plugin
+
+    mocker.patch.object(svi.directory, "get_plugin", side_effect=get_plugin)
+
+
+def _svi_driver():
+    return f"{svi.Svi.__module__}.{svi.Svi.__name__}"
+
+
+class TestValidateAddressScopeRules:
+    def test_rejects_new_subnet_without_scope(self, mocker):
+        plugin = FakeCorePlugin({"subnet-a": _subnet(None)})
+        _patch_core_plugin(mocker, plugin)
+
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            svi._validate_address_scope_rules("context", "router-a", ["subnet-a"])
+
+        assert "must belong to an address scope" in str(exc_info.value)
+
+    def test_rejects_new_subnet_with_subnetpool_without_scope(self, mocker):
+        plugin = FakeCorePlugin(
+            {"subnet-a": _subnet("pool-a")},
+            {"pool-a": _subnetpool(None)},
+        )
+        _patch_core_plugin(mocker, plugin)
+
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            svi._validate_address_scope_rules("context", "router-a", ["subnet-a"])
+
+        assert "must belong to an address scope" in str(exc_info.value)
+
+    def test_accepts_new_subnets_with_same_scope(self, mocker):
+        plugin = FakeCorePlugin(
+            {
+                "subnet-a": _subnet("pool-a"),
+                "subnet-b": _subnet("pool-b"),
+            },
+            {
+                "pool-a": _subnetpool("scope-a"),
+                "pool-b": _subnetpool("scope-a"),
+            },
+        )
+        _patch_core_plugin(mocker, plugin)
+
+        scopes = svi._validate_address_scope_rules(
+            "context", "router-a", ["subnet-a", "subnet-b"]
+        )
+
+        assert scopes == {4: "scope-a"}
+
+    def test_rejects_new_ipv6_subnet(self, mocker):
+        plugin = FakeCorePlugin(
+            {"subnet-v6": _subnet("pool-v6", ip_version=6)},
+            {"pool-v6": _subnetpool("scope-v6")},
+        )
+        _patch_core_plugin(mocker, plugin)
+
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            svi._validate_address_scope_rules("context", "router-a", ["subnet-v6"])
+
+        assert "IPv6 subnet subnet-v6 cannot be attached" in str(exc_info.value)
+
+    def test_rejects_new_subnets_with_different_scopes(self, mocker):
+        plugin = FakeCorePlugin(
+            {
+                "subnet-a": _subnet("pool-a"),
+                "subnet-b": _subnet("pool-b"),
+            },
+            {
+                "pool-a": _subnetpool("scope-a"),
+                "pool-b": _subnetpool("scope-b"),
+            },
+        )
+        _patch_core_plugin(mocker, plugin)
+
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            svi._validate_address_scope_rules(
+                "context", "router-a", ["subnet-a", "subnet-b"]
+            )
+
+        assert "same request" in str(exc_info.value)
+
+    def test_rejects_conflict_with_existing_router_subnet(self, mocker):
+        plugin = FakeCorePlugin(
+            {
+                "new-subnet": _subnet("new-pool"),
+                "existing-subnet": _subnet("existing-pool"),
+            },
+            {
+                "new-pool": _subnetpool("new-scope"),
+                "existing-pool": _subnetpool("existing-scope"),
+            },
+            ports=[{"fixed_ips": [{"subnet_id": "existing-subnet"}]}],
+        )
+        _patch_core_plugin(mocker, plugin)
+
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            svi._validate_address_scope_rules("context", "router-a", ["new-subnet"])
+
+        assert "differs from scope" in str(exc_info.value)
+
+    def test_rejects_existing_router_subnet_without_scope(self, mocker):
+        plugin = FakeCorePlugin(
+            {
+                "new-subnet": _subnet("new-pool"),
+                "existing-subnet": _subnet(None),
+            },
+            {"new-pool": _subnetpool("scope-a")},
+            ports=[{"fixed_ips": [{"subnet_id": "existing-subnet"}]}],
+        )
+        _patch_core_plugin(mocker, plugin)
+
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            svi._validate_address_scope_rules("context", "router-a", ["new-subnet"])
+
+        assert "must belong to an address scope" in str(exc_info.value)
+
+
+class TestValidateSviRouterPort:
+    def test_skips_non_internal_router_interface(self):
+        checked = svi.validate_svi_router_port(
+            "context",
+            {
+                "id": "port-a",
+                "device_owner": const.DEVICE_OWNER_ROUTER_GW,
+                "device_id": "router-a",
+            },
+        )
+
+        assert checked is False
+
+    def test_skips_non_svi_router_interface(self, mocker):
+        core_plugin = FakeCorePlugin({"subnet-a": _subnet(None)})
+        l3_plugin = FakeL3Plugin(
+            {"id": "router-a", "name": "vrf-router", "flavor_id": "flavor-a"}
+        )
+        flavor_plugin = FakeFlavorPlugin("neutron_understack.l3_router.vrf.Vrf")
+        _patch_plugins(
+            mocker,
+            core_plugin=core_plugin,
+            l3_plugin=l3_plugin,
+            flavor_plugin=flavor_plugin,
+        )
+
+        checked = svi.validate_svi_router_port(
+            "context",
+            {
+                "id": "port-a",
+                "device_owner": const.DEVICE_OWNER_ROUTER_INTF,
+                "device_id": "router-a",
+                "fixed_ips": [{"subnet_id": "subnet-a"}],
+            },
+        )
+
+        assert checked is False
+
+    def test_rejects_svi_router_interface_without_scope(self, mocker):
+        core_plugin = FakeCorePlugin({"subnet-a": _subnet(None)})
+        l3_plugin = FakeL3Plugin(
+            {"id": "router-a", "name": "svi-router", "flavor_id": "flavor-a"}
+        )
+        flavor_plugin = FakeFlavorPlugin(_svi_driver())
+        _patch_plugins(
+            mocker,
+            core_plugin=core_plugin,
+            l3_plugin=l3_plugin,
+            flavor_plugin=flavor_plugin,
+        )
+
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            svi.validate_svi_router_port(
+                "context",
+                {
+                    "id": "port-a",
+                    "device_owner": const.DEVICE_OWNER_ROUTER_INTF,
+                    "device_id": "router-a",
+                    "fixed_ips": [{"subnet_id": "subnet-a"}],
+                },
+            )
+
+        assert "must belong to an address scope" in str(exc_info.value)
+
+
+class TestValidateSviRouterInterfaceCallback:
+    def test_rejects_svi_router_interface_without_scope(self, caplog, mocker):
+        core_plugin = FakeCorePlugin({"subnet-a": _subnet(None)})
+        flavor_plugin = FakeFlavorPlugin(_svi_driver())
+        _patch_plugins(
+            mocker,
+            core_plugin=core_plugin,
+            l3_plugin=FakeL3Plugin({}),
+            flavor_plugin=flavor_plugin,
+        )
+
+        payload = SimpleNamespace(
+            context="context",
+            resource_id="router-a",
+            states=(
+                {
+                    "id": "router-a",
+                    "name": "svi-router",
+                    "flavor_id": "flavor-a",
+                },
+            ),
+            metadata={
+                "port": {
+                    "id": "port-a",
+                    "network_id": "network-a",
+                    "device_owner": const.DEVICE_OWNER_ROUTER_INTF,
+                    "fixed_ips": [{"subnet_id": "subnet-a"}],
+                },
+                "interface_info": {"port_id": "port-a"},
+            },
+        )
+        provider = svi.Svi(None)
+
+        caplog.set_level(logging.INFO, logger=svi.LOG.name)
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            provider._validate_svi_router_interface(None, None, None, payload)
+
+        assert "must belong to an address scope" in str(exc_info.value)
+        assert "attach_mode=port" in caplog.text


### PR DESCRIPTION
## Summary

This PR enforces address-scope validation for SVI-flavored routers.

SVI router interfaces should only be attached to subnets that belong to an address scope. In addition, all attached subnets for the same IP version on a single SVI router must use the same address scope.

## What Changed

- Added SVI router detection based on the router flavor provider driver.
- Added shared SVI address-scope validation logic.
- Validates new router-interface subnets before UnderStack VLAN/trunk/OVN postcommit work.
- Validates both router interface attach paths:
  - `openstack router add subnet`
  - `openstack router add port`
- Tracks IPv4
- Rejects IPv6 scopes.
- Returns `BadRequest` / HTTP 400 for invalid SVI attachments.
- Added logs for precommit validation and callback validation, including `attach_mode=subnet` / `attach_mode=port`.
- Added unit tests for valid and invalid scope scenarios.

## Validation Rules

For SVI routers:

1. A subnet must have a subnetpool.
2. The subnetpool must have an `address_scope_id`.
3. Same-IP-version subnets attached to the same SVI router must use the same address scope.
4. IPv4
5. Rejects IPv6 scopes 
7. Non-SVI routers are not affected.

## iad-dev Smoke Testing


**Validate both attach paths:**
_openstack router add subnet
openstack router add port_

**case 1 : SVI + No Scope Fails**
`openstack router add subnet nidhi-svi-2090-svi-router  nidhi-svi-2090-noscope-subnet`
error : `BadRequestException: 400: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/routers/d2efb479-3b96-4fa2-8c45-adf1d1b71791/add_router_interface, Bad router request: Subnet 42eee879-1137-4e66-9346-a059508f5358 must belong to an address scope to attach to an SVI router..`

**case 2: SVI + First Scoped Subnet Passes**
`openstack router add subnet  nidhi-svi-2090-svi-router  nidhi-svi-2090-scope-a-subnet-1`


```shell
 openstack router show nidhi-svi-2090-svi-router -c interfaces_info
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------+
| Field           | Value                                                                                                                                  |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------+
| interfaces_info | [{"port_id": "0ea0b12a-1b28-4b05-a63f-a49104363011", "ip_address": "10.209.0.1", "subnet_id": "e2250b20-69a0-4f95-b488-05bccca33773"}] |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------+
(openstack)
``` 
**Case 3: SVI + Same Scope Passes**

❯ `openstack router add subnet   nidhi-svi-2090-svi-router   nidhi-svi-2090-scope-a-subnet-2`
```
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack router show   nidhi-svi-2090-svi-router -c interfaces_info

+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field           | Value                                                                                                                                                    |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| interfaces_info | [{"port_id": "0ea0b12a-1b28-4b05-a63f-a49104363011", "ip_address": "10.209.0.1", "subnet_id": "e2250b20-69a0-4f95-b488-05bccca33773"}, {"port_id":       |
|                 | "9093a111-b0a2-4a57-9b3b-d7dda08e7fd9", "ip_address": "10.209.1.1", "subnet_id": "d0ba5ca9-8037-4b1a-ad99-92cd8364e33c"}]                                |
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+
(openstack)```
 ```

 **case 4 : SVI + Different Scope Fails**
`openstack router add subnet nidhi-svi-2090-svi-router nidhi-svi-2090-scope-b-subnet`

```~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack router add subnet  nidhi-svi-2090-svi-router  nidhi-svi-2090-scope-b-subnet
BadRequestException: 400: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/routers/d2efb479-3b96-4fa2-8c45-adf1d1b71791/add_router_interface, Bad router request: Cannot attach subnet ['2192faae-8f14-43da-8ffe-0fe784b4b603']: its IPv4 address scope '4b628923-ad0d-4c31-ace4-b66cf05a283a' differs from scope 'ebdaf7d8-eb39-4703-803d-6f3b81c3df89' already in use on router d2efb479-3b96-4fa2-8c45-adf1d1b71791.. 
```
neutron-server pod log 
```
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers Traceback (most recent call last):
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/plugins/ml2/managers.py", line 500, in _call_on_drivers
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers     getattr(driver.obj, method_name)(context)
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_understack/neutron_understack_mech.py", line 116, in create_port_precommit
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers     checked = svi_router.validate_svi_router_port(
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_understack/l3_router/svi.py", line 290, in validate_svi_router_port
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers     new_scopes = _validate_address_scope_rules(
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers   File "/var/lib/openstack/lib/python3.12/site-packages/neutron_understack/l3_router/svi.py", line 215, in _validate_address_scope_rules
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers     raise n_exc.BadRequest(
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers neutron_lib.exceptions.BadRequest: Bad router request: Cannot attach subnet ['2192faae-8f14-43da-8ffe-0fe784b4b603']: its IPv4 address scope '4b628923-ad0d-4c31-ace4-b66cf05a283a' differs from scope 'ebdaf7d8-eb39-4703-803d-6f3b81c3df89' already in use on router d2efb479-3b96-4fa2-8c45-adf1d1b71791..
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers
2026-06-23 13:19:31.159 9 ERROR neutron.plugins.ml2.managers [None req-0f3d6414-8fa1-4a98-9eaf-4d547ba77d5c 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Mechanism driver 'understack' failed in create_port_precommit: neutron_lib.exceptions.BadRequest: Bad router request: Cannot attach subnet ['2192faae-8f14-43da-8ffe-0fe784b4b603']: its IPv4 address scope '4b628923-ad0d-4c31-ace4-b66cf05a283a' differs from scope 'ebdaf7d8-eb39-4703-803d-6f3b81c3df89' already in use on router d2efb479-3b96-4fa2-8c45-adf1d1b71791..
```
**case 5: ~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 7s
`❯ openstack port create --network nidhi-svi-2090-noscope-net nidhi-svi-2090-noscope-port`**
```~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 7s
❯ openstack router add port nidhi-svi-2090-svi-router nidhi-svi-2090-noscope-port
ConflictException: 409: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/routers/d2efb479-3b96-4fa2-8c45-adf1d1b71791/add_router_interface, Error cannot perform router interface attachment due to Callback neutron_understack.l3_router.svi.Svi._validate_svi_router_interface-186890 failed with "Bad router request: Subnet 42eee879-1137-4e66-9346-a059508f5358 must belong to an address scope to attach to an SVI router.." while attempting the operation.
(openstack)
```
**Successful Port Add test **
```(openstack)
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 7s
❯ openstack router add port nidhi-svi-2090-port-router nidhi-svi-2090-port-port-a
(openstack)
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 7s
❯ openstack router show nidhi-svi-2090-port-router -c interfaces_info
openstack port show nidhi-svi-2090-port-port-a -c id -c name -c device_owner -c device_id -c fixed_ips
+-----------------+------------------------------------------------------------------------------------------------------------------------------------------+
| Field           | Value                                                                                                                                    |
+-----------------+------------------------------------------------------------------------------------------------------------------------------------------+
| interfaces_info | [{"port_id": "73fd02df-fa0e-4e08-9601-77d208b2da1a", "ip_address": "10.209.2.223", "subnet_id": "81f093e9-209b-406f-8e56-de58ff8ef5db"}] |
+-----------------+------------------------------------------------------------------------------------------------------------------------------------------+
+--------------+-----------------------------------------------------------------------------+
| Field        | Value                                                                       |
+--------------+-----------------------------------------------------------------------------+
| device_id    | 1419eb91-5be7-4842-902d-b8ac93c7b2f7                                        |
| device_owner | network:router_interface                                                    |
| fixed_ips    | ip_address='10.209.2.223', subnet_id='81f093e9-209b-406f-8e56-de58ff8ef5db' |
| id           | 73fd02df-fa0e-4e08-9601-77d208b2da1a                                        |
| name         | nidhi-svi-2090-port-port-a                                                  |
+--------------+-----------------------------------------------------------------------------+
(openstack)
```