### PR TITLE
fix(routers/ovn): leftover uplink ports

### DIFF
--- a/docs/design-guide/neutron-networking.md
+++ b/docs/design-guide/neutron-networking.md
@@ -454,9 +454,17 @@ network over the physical fabric. This is done through an **uplink port**.
 
 #### The uplink port
 
-The uplink is a Neutron port plus a matching OVN localnet Logical Switch Port
-(LSP) named `uplink-<segment_id>`. It sits on the Network Node's leaf VLAN
-segment and gives OVN a way to send and receive that network's traffic over the
+The uplink is a Neutron port named `uplink-<segment_id>`. Creating it causes
+the OVN mechanism driver to create two OVN Logical Switch Ports (LSPs) on the
+network's logical switch:
+
+- `uplink-<segment_id>` — a `localnet`-type LSP created explicitly by understack;
+  it connects the logical switch to the physical network via the Network Node's
+  trunk VLAN
+- `<port-uuid>` — a regular LSP created automatically by the OVN mechanism driver
+  when the Neutron port is created
+
+Together they give OVN a way to send and receive that network's traffic over the
 Network Node's trunk connection.
 
 The VLAN tag carried on the trunk is *local to the leaf where the Network Node
@@ -548,7 +556,8 @@ flowchart TD
     E -- no --> G["_do_uplink_cleanup()"]
     G --> H["remove trunk subport"]
     G --> I["delete uplink-SEGMENT_ID<br/>OVN localnet LSP"]
-    G --> J["delete Neutron port<br/>uplink-SEGMENT_ID"]
+    G --> I2["delete shared-port OVN LSP<br/>(port UUID)"]
+    G --> J["delete Neutron port DB row<br/>uplink-SEGMENT_ID"]
 ```
 
 <!-- markdownlint-capture -->

--- a/docs/design-guide/neutron-networking.md
+++ b/docs/design-guide/neutron-networking.md
@@ -446,6 +446,125 @@ Neutron based on certain data provided to port creation and update API calls.
 - the port has a binding host
 - the port is either unbound or has previously failed to bind
 
+### Router Interface Lifecycle
+
+When a subnet is attached to a router, the understack ML2 driver sets up a path
+so that the Network Node — the host running OVN — can forward traffic on that
+network over the physical fabric. This is done through an **uplink port**.
+
+#### The uplink port
+
+The uplink is a Neutron port plus a matching OVN localnet Logical Switch Port
+(LSP) named `uplink-<segment_id>`. It sits on the Network Node's leaf VLAN
+segment and gives OVN a way to send and receive that network's traffic over the
+Network Node's trunk connection.
+
+The VLAN tag carried on the trunk is *local to the leaf where the Network Node
+is connected*. Baremetal nodes connected to different leaves each get their own
+per-leaf VLAN segments, which will typically have different VLAN IDs. The
+`uplink-<segment_id>` name encodes the segment ID of the Network Node's leaf
+segment, making it possible to distinguish it from segments allocated for other
+leaves.
+
+```mermaid
+flowchart LR
+    BM1["Baremetal node<br/>(leaf-1, VLAN 1800)"]
+    BM2["Baremetal node<br/>(leaf-2, VLAN 1801)"]
+    NN["Network Node / OVN<br/>(leaf-1, VLAN 1802)"]
+    LS["OVN Logical Switch<br/>neutron-NETWORK_ID"]
+
+    BM1 -->|"provnet-SEG1<br/>(localnet, tag 1800)"| LS
+    BM2 -->|"provnet-SEG2<br/>(localnet, tag 1801)"| LS
+    NN -->|"uplink-SEG3<br/>(localnet, tag 1802)"| LS
+```
+
+#### Creating the uplink
+
+When `openstack router add subnet` is issued, Neutron creates a router interface
+port. The understack driver's `create_port_postcommit()` intercepts this and, if
+no other router port already exists on the network, it:
+
+1. Allocates a dynamic VLAN segment on the network-node physnet (the leaf the
+   Network Node is connected to)
+2. Creates a Neutron port named `uplink-<segment_id>` on that segment
+3. Adds that port as a tagged subport on the Network Node's trunk
+4. Creates an OVN localnet LSP `uplink-<segment_id>` on the network's logical switch
+
+For VXLAN-type networks a second step runs via the `ROUTER_INTERFACE AFTER_CREATE`
+subscription (at `PRIORITY_DEFAULT + 1000`, after OVN's own handler).
+`link_vxlan_network_ha_chassis_group()` populates the per-network
+`HA_Chassis_Group` from the router's own HCG. This is a workaround for a
+Neutron 2026.1 regression where VXLAN gateway networks leave that group empty,
+causing ARP and routing to break for baremetal ports on the network.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Neutron
+    participant Understack as UnderstackDriver
+    participant OVN
+
+    Client->>Neutron: openstack router add subnet
+    Neutron->>Understack: create_port_postcommit(router interface port)
+    Understack->>Neutron: allocate dynamic VLAN segment (network-node physnet)
+    Understack->>Neutron: create Neutron port uplink-SEGMENT_ID
+    Understack->>Neutron: add uplink port as trunk subport (tagged VLAN)
+    Understack->>OVN: create localnet LSP uplink-SEGMENT_ID
+
+    Note over Neutron,OVN: VXLAN networks only
+    Neutron-->>Understack: ROUTER_INTERFACE AFTER_CREATE (priority +1000)
+    Understack->>OVN: sync_ha_chassis_group_network_unified
+    Understack->>OVN: anchor internal LRP to network HA_Chassis_Group
+```
+
+#### Removing the uplink
+
+Cleanup must handle two different Neutron code paths depending on the operation:
+
+| Operation | Neutron internal path | Event received by understack |
+|-----------|----------------------|------------------------------|
+| `openstack router remove subnet` | `remove_router_interface()` | `ROUTER_INTERFACE AFTER_DELETE` |
+| `openstack router delete` | `delete_router()` → `delete_port()` per port | `PORT PRECOMMIT_DELETE` |
+
+`remove_router_interface()` does call `_core_plugin.delete_port()` internally
+(see [`l3_db.py#_remove_interface_by_subnet`][l3-db-remove-intf]), but the ML2
+plugin only publishes `PORT PRECOMMIT_DELETE` when the port has an ACTIVE
+binding record. Router interface ports are not guaranteed to be in that state
+at the point `delete_port` is invoked, so the event may silently not fire.
+`ROUTER_INTERFACE AFTER_DELETE` is always published by `remove_router_interface()`
+regardless of binding state, making it the reliable signal for this path. Both
+events are subscribed and both call the shared `_do_uplink_cleanup()` helper.
+
+`_do_uplink_cleanup()` is idempotent: if the shared port is already gone it
+returns immediately, so both handlers can fire without double-cleanup.
+
+```mermaid
+flowchart TD
+    A["openstack router remove subnet"] --> B["ROUTER_INTERFACE<br/>AFTER_DELETE"]
+    C["openstack router delete"] --> D["PORT<br/>PRECOMMIT_DELETE"]
+    B --> E{Any router ports<br/>still on network?}
+    D --> E
+    E -- yes --> F([skip — another<br/>router uses this network])
+    E -- no --> G["_do_uplink_cleanup()"]
+    G --> H["remove trunk subport"]
+    G --> I["delete uplink-SEGMENT_ID<br/>OVN localnet LSP"]
+    G --> J["delete Neutron port<br/>uplink-SEGMENT_ID"]
+```
+
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable MD046 -->
+!!! note "Count semantics differ between the two handlers"
+
+    Both handlers check whether any router ports remain on the network before
+    cleaning up. The threshold differs because the deleted port's DB lifetime
+    differs by code path:
+
+    - **`PORT PRECOMMIT_DELETE`**: the port is still in the DB at event time,
+      so it counts toward the total — cleanup runs when `count ≤ 1`.
+    - **`ROUTER_INTERFACE AFTER_DELETE`**: the port is already removed from the
+      DB at event time — cleanup runs when `count == 0`.
+<!-- markdownlint-restore -->
+
 [networking-baremetal]: <https://docs.openstack.org/networking-baremetal/latest/>
 [ovn]: <https://docs.ovn.org/en/latest/>
 [ovn-driver]: <https://docs.openstack.org/neutron/latest/ovn/index.html>
@@ -458,3 +577,4 @@ Neutron based on certain data provided to port creation and update API calls.
 [networking-generic-switch]: <https://docs.openstack.org/networking-generic-switch/latest/>
 [ironic-vif-attachment]: <https://docs.openstack.org/ironic/latest/admin/networking.html#vif-attachment-flow>
 [ironic-spec-dpa]: <https://review.opendev.org/c/openstack/ironic-specs/+/945642>
+[l3-db-remove-intf]: <https://github.com/openstack/neutron/blob/28.0.0/neutron/db/l3_db.py#L1175>

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -60,6 +60,16 @@ class UnderstackDriver(MechanismDriver):
             events.AFTER_CREATE,
             priority=priority_group.PRIORITY_DEFAULT + 1000,
         )
+        # Handles uplink cleanup when a subnet is explicitly detached from a
+        # router (remove_router_interface). This path does not reliably fire
+        # PORT PRECOMMIT_DELETE, so we subscribe to the ROUTER_INTERFACE event
+        # directly. The PORT PRECOMMIT_DELETE handler remains for the router-
+        # deletion path (delete_router skips ROUTER_INTERFACE events).
+        registry.subscribe(
+            routers.handle_router_interface_after_delete,
+            resources.ROUTER_INTERFACE,
+            events.AFTER_DELETE,
+        )
 
     def create_network_precommit(self, context):
         pass

--- a/python/neutron-understack/neutron_understack/routers.py
+++ b/python/neutron-understack/neutron_understack/routers.py
@@ -292,8 +292,24 @@ def delete_uplink_port(segment: NetworkSegment, network_id: str) -> None:
     ovn_client()._transaction([cmd])
 
 
+def _do_uplink_cleanup(network_id: str) -> None:
+    """Remove the trunk subport, OVN uplink LSP, and shared Neutron port."""
+    segment = fetch_router_network_segment(network_id)
+    if not segment:
+        return
+
+    shared_port = fetch_shared_router_port(segment)
+    if not shared_port:
+        # Already cleaned up (e.g. by the PORT PRECOMMIT_DELETE handler).
+        return
+
+    handle_subport_removal(shared_port)
+    delete_uplink_port(segment, network_id)
+    shared_port.delete()
+
+
 def handle_router_interface_removal(_resource, _event, trigger, payload) -> None:
-    """Handles the removal of a router interface.
+    """Handles PORT PRECOMMIT_DELETE — fires when delete_router() deletes ports directly.
 
     When router interface port is deleted, we remove the corresponding subport
     from the trunk and delete OVN localnet port.
@@ -333,17 +349,52 @@ def handle_router_interface_removal(_resource, _event, trigger, payload) -> None
         )
         return
 
-    segment = fetch_router_network_segment(network_id)
-    if not segment:
+    _do_uplink_cleanup(network_id)
+
+
+def handle_router_interface_after_delete(
+    _resource, _event, trigger, payload
+) -> None:
+    """Handles ROUTER_INTERFACE AFTER_DELETE — fires on explicit remove_router_interface().
+
+    remove_router_interface() fires ROUTER_INTERFACE AFTER_DELETE but does not
+    reliably trigger PORT PRECOMMIT_DELETE (the ML2 plugin only publishes
+    PRECOMMIT_DELETE when the port has an ACTIVE binding, which is not guaranteed
+    for router interface ports in all OVN flavours). This handler covers the
+    subnet-detachment case; the existing PORT PRECOMMIT_DELETE handler covers
+    direct port deletion during router deletion.
+
+    At AFTER_DELETE time the interface port is already removed from the DB, so
+    we check count == 0 (no remaining router ports) rather than count <= 1.
+    _do_uplink_cleanup is idempotent: if the PRECOMMIT_DELETE handler already
+    ran, fetch_shared_router_port returns None and cleanup exits silently.
+    """
+    port = payload.metadata["port"]
+    network_id = port["network_id"]
+
+    if port.get("device_owner") not in ROUTER_INTERFACE_AND_GW:
         return
 
-    shared_port = fetch_shared_router_port(segment)
-    if not shared_port:
+    # Port is already removed from DB; check whether any router ports remain.
+    remaining = Port.get_objects(
+        n_context.get_admin_context(),
+        network_id=network_id,
+        device_owner=ROUTER_INTERFACE_AND_GW,
+    )
+    if remaining:
+        LOG.debug(
+            "Router ports still present on network %(net)s, skipping uplink cleanup",
+            {"net": network_id},
+        )
         return
 
-    handle_subport_removal(shared_port)
-    delete_uplink_port(segment, network_id)
-    shared_port.delete()
+    try:
+        _do_uplink_cleanup(network_id)
+    except Exception as err:
+        LOG.error(
+            "Failed uplink cleanup for network %(net)s: %(error)s",
+            {"net": network_id, "error": err},
+        )
 
 
 def handle_subport_removal(port: Port) -> None:

--- a/python/neutron-understack/neutron_understack/routers.py
+++ b/python/neutron-understack/neutron_understack/routers.py
@@ -283,33 +283,43 @@ def link_vxlan_network_ha_chassis_group(_resource, _event, _trigger, payload) ->
         )
 
 
-def delete_uplink_port(segment: NetworkSegment, network_id: str) -> None:
+def delete_uplink_port(segment_id: str, network_id: str) -> None:
     """Remove a localnet uplink port from a network node."""
-    port_to_del = f"uplink-{segment['id']}"
     cmd = ovn_client()._nb_idl.delete_lswitch_port(
-        lport_name=port_to_del, lswitch_name=ovn_utils.ovn_name(network_id)
+        lport_name=f"uplink-{segment_id}", lswitch_name=ovn_utils.ovn_name(network_id)
+    )
+    ovn_client()._transaction([cmd])
+
+
+def delete_shared_port_lsp(port_id: str, network_id: str) -> None:
+    """Remove the OVN LSP (named by port id) for the shared uplink port.
+
+    OVO .delete() only removes the DB row; this removes the LSP explicitly.
+    """
+    cmd = ovn_client()._nb_idl.delete_lswitch_port(
+        lport_name=port_id, lswitch_name=ovn_utils.ovn_name(network_id)
     )
     ovn_client()._transaction([cmd])
 
 
 def _do_uplink_cleanup(network_id: str) -> None:
-    """Remove the trunk subport, OVN uplink LSP, and shared Neutron port."""
-    segment = fetch_router_network_segment(network_id)
-    if not segment:
-        return
-
-    shared_port = fetch_shared_router_port(segment)
+    """Remove the trunk subport, OVN uplink LSPs, and shared Neutron port."""
+    shared_port = fetch_shared_router_port(network_id)
     if not shared_port:
         # Already cleaned up (e.g. by the PORT PRECOMMIT_DELETE handler).
         return
 
+    segment_id = shared_port.name.removeprefix("uplink-")
     handle_subport_removal(shared_port)
-    delete_uplink_port(segment, network_id)
+    delete_uplink_port(segment_id, network_id)
+    delete_shared_port_lsp(shared_port.id, network_id)
     shared_port.delete()
 
 
 def handle_router_interface_removal(_resource, _event, trigger, payload) -> None:
-    """Handles PORT PRECOMMIT_DELETE — fires when delete_router() deletes ports directly.
+    """Handles PORT PRECOMMIT_DELETE — fires when delete_router() deletes ports.
+
+    Specifically fires when delete_router() deletes ports directly.
 
     When router interface port is deleted, we remove the corresponding subport
     from the trunk and delete OVN localnet port.
@@ -352,10 +362,10 @@ def handle_router_interface_removal(_resource, _event, trigger, payload) -> None
     _do_uplink_cleanup(network_id)
 
 
-def handle_router_interface_after_delete(
-    _resource, _event, trigger, payload
-) -> None:
-    """Handles ROUTER_INTERFACE AFTER_DELETE — fires on explicit remove_router_interface().
+def handle_router_interface_after_delete(_resource, _event, trigger, payload) -> None:
+    """Handles ROUTER_INTERFACE AFTER_DELETE.
+
+    Fires on explicit remove_router_interface() calls.
 
     remove_router_interface() fires ROUTER_INTERFACE AFTER_DELETE but does not
     reliably trigger PORT PRECOMMIT_DELETE (the ML2 plugin only publishes
@@ -408,29 +418,11 @@ def handle_subport_removal(port: Port) -> None:
         LOG.error("failed removing_subport: %(error)s", {"error": err})
 
 
-def fetch_router_network_segment(network_id: str) -> NetworkSegment | None:
-    segment = utils.network_segment_by_physnet(
-        network_id, cfg.CONF.ml2_understack.network_node_switchport_physnet
-    )
-    if not segment:
-        LOG.error(
-            "Router network segment not found for network %(network_id)s",
-            {"network_id": network_id},
-        )
-        return
-    LOG.debug("Router network segment found %(segment)s", {"segment": segment})
-    return segment
-
-
-def fetch_shared_router_port(segment: NetworkSegment) -> Port | None:
-    shared_ports = Port.get_objects(
-        n_context.get_admin_context(), name=f"uplink-{segment['id']}"
-    )
-
-    if not shared_ports:
-        LOG.error(
-            "No router shared ports found for segment %(segment)s", {"segment": segment}
-        )
-        return
-    LOG.debug("Router shared ports found %(ports)s", {"ports": shared_ports})
-    return shared_ports[0]
+def fetch_shared_router_port(network_id: str) -> Port | None:
+    ports = Port.get_objects(n_context.get_admin_context(), network_id=network_id)
+    for port in ports:
+        if port.name and port.name.startswith("uplink-"):
+            LOG.debug("Router shared port found %(port)s", {"port": port})
+            return port
+    LOG.debug("No router shared port on network %(net)s", {"net": network_id})
+    return None

--- a/python/neutron-understack/neutron_understack/tests/test_routers.py
+++ b/python/neutron-understack/neutron_understack/tests/test_routers.py
@@ -1,9 +1,11 @@
 import pytest
 from neutron_lib import constants as p_const
+from neutron_lib.callbacks.events import DBEventPayload
 
 from neutron_understack.routers import add_subport_to_trunk
 from neutron_understack.routers import create_port_postcommit
 from neutron_understack.routers import fetch_or_create_router_segment
+from neutron_understack.routers import handle_router_interface_after_delete
 from neutron_understack.routers import handle_router_interface_removal
 from neutron_understack.routers import handle_subport_removal
 from neutron_understack.routers import link_vxlan_network_ha_chassis_group
@@ -203,6 +205,59 @@ class TestCreatePortPostcommit:
         create_uplink_port.assert_called_once_with(
             fake_segment, port_context.current["network_id"]
         )
+
+
+@pytest.fixture
+def ri_after_delete_payload(network_id) -> DBEventPayload:
+    metadata = {
+        "port": {
+            "id": "port-uuid",
+            "device_owner": p_const.DEVICE_OWNER_ROUTER_GW,
+            "network_id": str(network_id),
+        }
+    }
+    return DBEventPayload("context", metadata=metadata)
+
+
+class TestHandleRouterInterfaceAfterDelete:
+    def test_non_router_port_skips_cleanup(self, mocker, ri_after_delete_payload):
+        mock_cleanup = mocker.patch("neutron_understack.routers._do_uplink_cleanup")
+        ri_after_delete_payload.metadata["port"]["device_owner"] = "network:dhcp"
+
+        handle_router_interface_after_delete(None, None, None, ri_after_delete_payload)
+
+        mock_cleanup.assert_not_called()
+
+    def test_remaining_router_ports_skips_cleanup(self, mocker, ri_after_delete_payload):
+        mock_cleanup = mocker.patch("neutron_understack.routers._do_uplink_cleanup")
+        mocker.patch("neutron_understack.routers.n_context.get_admin_context")
+        mocker.patch("neutron_understack.routers.Port.get_objects", return_value=["port1"])
+
+        handle_router_interface_after_delete(None, None, None, ri_after_delete_payload)
+
+        mock_cleanup.assert_not_called()
+
+    def test_last_port_removed_triggers_cleanup(
+        self, mocker, ri_after_delete_payload, network_id
+    ):
+        mock_cleanup = mocker.patch("neutron_understack.routers._do_uplink_cleanup")
+        mocker.patch("neutron_understack.routers.n_context.get_admin_context")
+        mocker.patch("neutron_understack.routers.Port.get_objects", return_value=[])
+
+        handle_router_interface_after_delete(None, None, None, ri_after_delete_payload)
+
+        mock_cleanup.assert_called_once_with(str(network_id))
+
+    def test_cleanup_error_is_logged_not_raised(self, mocker, ri_after_delete_payload):
+        mocker.patch("neutron_understack.routers.n_context.get_admin_context")
+        mocker.patch("neutron_understack.routers.Port.get_objects", return_value=[])
+        mocker.patch(
+            "neutron_understack.routers._do_uplink_cleanup",
+            side_effect=Exception("ovsdb down"),
+        )
+
+        # Must not raise
+        handle_router_interface_after_delete(None, None, None, ri_after_delete_payload)
 
 
 class TestLinkVxlanNetworkHaChassisGroup:

--- a/python/neutron-understack/neutron_understack/tests/test_routers.py
+++ b/python/neutron-understack/neutron_understack/tests/test_routers.py
@@ -2,9 +2,11 @@ import pytest
 from neutron_lib import constants as p_const
 from neutron_lib.callbacks.events import DBEventPayload
 
+from neutron_understack.routers import _do_uplink_cleanup
 from neutron_understack.routers import add_subport_to_trunk
 from neutron_understack.routers import create_port_postcommit
 from neutron_understack.routers import fetch_or_create_router_segment
+from neutron_understack.routers import fetch_shared_router_port
 from neutron_understack.routers import handle_router_interface_after_delete
 from neutron_understack.routers import handle_router_interface_removal
 from neutron_understack.routers import handle_subport_removal
@@ -115,36 +117,111 @@ class TestHandleRouterInterfaceRemoval:
         mock_sb_removal.assert_not_called()
         mock_localnet_removal.assert_not_called()
 
-    def test_last_port_on_network(
-        self, mocker, port_object, port_db_payload, network_id
-    ):
+    def test_last_port_on_network(self, mocker, port_db_payload, network_id):
         mock_sb_removal = mocker.patch(
             "neutron_understack.routers.handle_subport_removal"
         )
         mock_localnet_removal = mocker.patch(
             "neutron_understack.routers.delete_uplink_port"
         )
+        mock_lsp_removal = mocker.patch(
+            "neutron_understack.routers.delete_shared_port_lsp"
+        )
         mocker.patch(
             "neutron_understack.routers.is_only_router_port_on_network",
             return_value=True,
         )
-        fake_segment = {"id": "seg-123", "foo": "bar"}
-        mocker.patch(
-            "neutron_understack.routers.fetch_router_network_segment",
-            return_value=fake_segment,
-        )
-
+        fake_port = mocker.Mock()
+        fake_port.name = "uplink-seg-123"
+        fake_port.id = "port-uuid-abc"
         mocker.patch(
             "neutron_understack.routers.fetch_shared_router_port",
-            return_value=port_object,
+            return_value=fake_port,
         )
-        delete_shared_port = mocker.patch.object(port_object, "delete")
 
         handle_router_interface_removal(None, None, None, port_db_payload)
 
-        mock_sb_removal.assert_called_once_with(port_object)
-        mock_localnet_removal.assert_called_once_with(fake_segment, str(network_id))
-        delete_shared_port.assert_called_once()
+        mock_sb_removal.assert_called_once_with(fake_port)
+        mock_localnet_removal.assert_called_once_with("seg-123", str(network_id))
+        mock_lsp_removal.assert_called_once_with("port-uuid-abc", str(network_id))
+        fake_port.delete.assert_called_once()
+
+
+class TestFetchSharedRouterPort:
+    def test_returns_uplink_port(self, mocker, network_id):
+        uplink = mocker.Mock(name=None)
+        uplink.name = "uplink-seg-abc"
+        other = mocker.Mock(name=None)
+        other.name = "not-uplink"
+        mocker.patch("neutron_understack.routers.n_context.get_admin_context")
+        mocker.patch(
+            "neutron_understack.routers.Port.get_objects",
+            return_value=[other, uplink],
+        )
+
+        result = fetch_shared_router_port(str(network_id))
+
+        assert result is uplink
+
+    def test_returns_none_when_no_uplink_port(self, mocker, network_id):
+        other = mocker.Mock(name=None)
+        other.name = "some-port"
+        mocker.patch("neutron_understack.routers.n_context.get_admin_context")
+        mocker.patch(
+            "neutron_understack.routers.Port.get_objects",
+            return_value=[other],
+        )
+
+        result = fetch_shared_router_port(str(network_id))
+
+        assert result is None
+
+    def test_returns_none_when_empty(self, mocker, network_id):
+        mocker.patch("neutron_understack.routers.n_context.get_admin_context")
+        mocker.patch(
+            "neutron_understack.routers.Port.get_objects",
+            return_value=[],
+        )
+
+        result = fetch_shared_router_port(str(network_id))
+
+        assert result is None
+
+
+class TestDoUplinkCleanup:
+    def test_no_shared_port_skips_all(self, mocker, network_id):
+        mocker.patch(
+            "neutron_understack.routers.fetch_shared_router_port",
+            return_value=None,
+        )
+        mock_subport = mocker.patch("neutron_understack.routers.handle_subport_removal")
+        mock_uplink = mocker.patch("neutron_understack.routers.delete_uplink_port")
+        mock_lsp = mocker.patch("neutron_understack.routers.delete_shared_port_lsp")
+
+        _do_uplink_cleanup(str(network_id))
+
+        mock_subport.assert_not_called()
+        mock_uplink.assert_not_called()
+        mock_lsp.assert_not_called()
+
+    def test_shared_port_present_runs_full_cleanup(self, mocker, network_id):
+        fake_port = mocker.Mock()
+        fake_port.name = "uplink-seg-456"
+        fake_port.id = "shared-port-id"
+        mocker.patch(
+            "neutron_understack.routers.fetch_shared_router_port",
+            return_value=fake_port,
+        )
+        mock_subport = mocker.patch("neutron_understack.routers.handle_subport_removal")
+        mock_uplink = mocker.patch("neutron_understack.routers.delete_uplink_port")
+        mock_lsp = mocker.patch("neutron_understack.routers.delete_shared_port_lsp")
+
+        _do_uplink_cleanup(str(network_id))
+
+        mock_subport.assert_called_once_with(fake_port)
+        mock_uplink.assert_called_once_with("seg-456", str(network_id))
+        mock_lsp.assert_called_once_with("shared-port-id", str(network_id))
+        fake_port.delete.assert_called_once()
 
 
 @pytest.fixture
@@ -228,10 +305,14 @@ class TestHandleRouterInterfaceAfterDelete:
 
         mock_cleanup.assert_not_called()
 
-    def test_remaining_router_ports_skips_cleanup(self, mocker, ri_after_delete_payload):
+    def test_remaining_router_ports_skips_cleanup(
+        self, mocker, ri_after_delete_payload
+    ):
         mock_cleanup = mocker.patch("neutron_understack.routers._do_uplink_cleanup")
         mocker.patch("neutron_understack.routers.n_context.get_admin_context")
-        mocker.patch("neutron_understack.routers.Port.get_objects", return_value=["port1"])
+        mocker.patch(
+            "neutron_understack.routers.Port.get_objects", return_value=["port1"]
+        )
 
         handle_router_interface_after_delete(None, None, None, ri_after_delete_payload)
 


### PR DESCRIPTION
## Fix OVN uplink LSP leak on router subnet detachment

When the last subnet is detached from a router (`openstack router remove subnet`), the ML2 driver is supposed to clean up the uplink it created — remove the trunk subport, delete the OVN localnet LSP, and delete the shared Neutron port. In practice the shared Neutron port and its OVN LSP (`<port-uuid>`) were left behind.

### Root causes

Two independent bugs combined to cause the leak:

**1. Cleanup anchored to a segment that no longer exists**

`_do_uplink_cleanup` started by looking up the dynamic VLAN segment for the network. On subnet detachment, Neutron releases that segment *before* the `ROUTER_INTERFACE AFTER_DELETE` event fires. The lookup returned `None` and the entire cleanup was skipped, including the shared port deletion.

**Fix:** anchor cleanup on the shared Neutron port (`uplink-<segment_id>`) instead — it persists until we delete it. The segment ID is derived from the port's name, eliminating the dependency on a live segment.

**2. OVO `.delete()` leaves the OVN LSP behind**

`shared_port.delete()` is an OpenStack Versioned Objects call that only removes the database row. It bypasses the ML2 mechanism manager, so the OVN mechanism driver's `delete_port_postcommit` never runs and the port's LSP (named by port UUID) is never removed.

**Fix:** added `delete_shared_port_lsp()` which explicitly calls `delete_lswitch_port(port_id, ...)` on the OVN NB IDL before the OVO delete, mirroring the existing `delete_uplink_port` pattern for the localnet LSP.

Both fixes apply to both deletion paths: subnet detachment (`ROUTER_INTERFACE AFTER_DELETE`) and router deletion (`PORT PRECOMMIT_DELETE`).

### Also included

- Documentation of the router interface lifecycle in `neutron-networking.md`, covering the uplink port concept, the two OVN LSPs it produces, the creation flow, and why two event handlers are needed with different port-count thresholds.

Closes https://rackspace.atlassian.net/browse/PUC-1741