### PR TITLE
fix(nova): Updates nova deployment job sync waves based on their dependencies

### DIFF
--- a/components/nova/values.yaml
+++ b/components/nova/values.yaml
@@ -289,10 +289,12 @@ annotations:
       argocd.argoproj.io/sync-options: Force=true
       argocd.argoproj.io/sync-wave: "0"
     nova_cell_setup:
-      argocd.argoproj.io/hook: PostSync
+      argocd.argoproj.io/hook: Sync
       argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
       argocd.argoproj.io/sync-options: Force=true
+      argocd.argoproj.io/sync-wave: "1"
     nova_bootstrap:
       argocd.argoproj.io/hook: Sync
       argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
       argocd.argoproj.io/sync-options: Force=true
+      argocd.argoproj.io/sync-wave: "2"


### PR DESCRIPTION
The nova-bootstrap job init depensd on nova-cell-setup job completing first. However we had argo run nova_cell_setup as a _post_ sync job, but bootstrap as a sync job, which made argocd unhappy. This updates the jobs to run at the correct time.