### PR TITLE
feat: collect Envoy Gateway metrics

### DIFF
--- a/components/envoy-gateway/kustomization.yaml
+++ b/components/envoy-gateway/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - podmonitor-envoygateway.yaml

--- a/components/envoy-gateway/podmonitor-envoygateway.yaml
+++ b/components/envoy-gateway/podmonitor-envoygateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    prometheus: kube-prometheus-stack
+  name: envoy-gateway
+  namespace: envoy-gateway
+spec:
+  namespaceSelector:
+    matchNames:
+      - envoy-gateway
+  podMetricsEndpoints:
+    - interval: 30s
+      path: /stats/prometheus
+      port: metrics
+      scrapeTimeout: 10s
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+      app.kubernetes.io/name: envoy
+      gateway.envoyproxy.io/owning-gateway-name: external-gateway


### PR DESCRIPTION
By default Envoy Gateway ships with pods that are observed through annotations. Our observability stack ignores those annotations, so the metrics from Envoy Gateway are never collected. Adding explicit `PodMonitor` enables the local kube-prometheus-stack as well as OTEL agent to scrape the EG endpoints.

The dashboards presenting those metrics are currently deployed in: [Dashboards -> Playground -> Marek](https://grafana.core.ord1.pvceng.rax.io/dashboards/f/efo05t1n85rswc/?orgId=1) folder.
Eventually, when the https://github.com/RSS-Engineering/pvc-argocd/pull/1361 lands they will be in the `Envoy Gateway` folder.

#### Envoy Proxy Global
<img width="1918" height="965" alt="image" src="https://github.com/user-attachments/assets/0f3f484e-15db-44f6-ba36-48ec0ffcf0ab" />

#### Envoy Clusters
<img width="1918" height="959" alt="image" src="https://github.com/user-attachments/assets/0c18b486-fb59-4317-ba2b-fc7f7090312f" />

