### PR TITLE
feat(neutron): skip OVN uplink creation for flavored routers

### DIFF
--- a/python/neutron-understack/neutron_understack/routers.py
+++ b/python/neutron-understack/neutron_understack/routers.py
@@ -9,6 +9,7 @@ from neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.ovn_client import OVNClie
 from neutron_lib import constants as p_const
 from neutron_lib import context as n_context
 from neutron_lib.api.definitions import segment as segment_def
+from neutron_lib.plugins import constants as plugin_constants
 from neutron_lib.plugins import directory
 from oslo_config import cfg
 
@@ -24,6 +25,13 @@ ROUTER_INTERFACE_AND_GW = [
     p_const.DEVICE_OWNER_ROUTER_INTF,
     p_const.DEVICE_OWNER_ROUTER_GW,
 ]
+
+
+def _router_has_flavor(ctx, router_id: str) -> bool:
+    l3_plugin = directory.get_plugin(plugin_constants.L3)
+    router = l3_plugin.get_router(ctx, router_id)
+    flavor_id = router.get("flavor_id")
+    return bool(flavor_id) and flavor_id is not p_const.ATTR_NOT_SPECIFIED
 
 
 def create_port_postcommit(context: PortContext) -> None:
@@ -52,6 +60,15 @@ def create_port_postcommit(context: PortContext) -> None:
             "Creating only a router port %(port)s for a network %(network)s "
             "as there are already other routers on the same network.",
             {"port": context.current["id"], "network": network_id},
+        )
+        return
+
+    router_id = context.current.get("device_id")
+    if router_id and _router_has_flavor(context.plugin_context, router_id):
+        LOG.debug(
+            "Skipping uplink creation for flavored router %(router)s "
+            "on network %(net)s",
+            {"router": router_id, "net": network_id},
         )
         return
 

--- a/python/neutron-understack/neutron_understack/tests/test_routers.py
+++ b/python/neutron-understack/neutron_understack/tests/test_routers.py
@@ -283,6 +283,61 @@ class TestCreatePortPostcommit:
             fake_segment, port_context.current["network_id"]
         )
 
+    def test_flavored_router_skips_uplink(self, mocker, port_context):
+        port_context.current["device_id"] = "router-uuid"
+        mocker.patch("neutron.objects.ports.Port.get_objects", return_value=[1])
+        mocker.patch("neutron_understack.routers._router_has_flavor", return_value=True)
+        create_segment = mocker.patch(
+            "neutron_understack.routers.fetch_or_create_router_segment"
+        )
+        create_neutron_port = mocker.patch(
+            "neutron_understack.utils.create_neutron_port_for_segment"
+        )
+        add_trunk = mocker.patch("neutron_understack.routers.add_subport_to_trunk")
+        create_uplink_port = mocker.patch(
+            "neutron_understack.routers.create_uplink_port"
+        )
+
+        create_port_postcommit(port_context)
+
+        create_segment.assert_not_called()
+        create_neutron_port.assert_not_called()
+        add_trunk.assert_not_called()
+        create_uplink_port.assert_not_called()
+
+    def test_unflavored_router_creates_uplink(self, mocker, port_context):
+        mocker.patch("neutron.objects.ports.Port.get_objects", return_value=[])
+        mocker.patch(
+            "neutron_understack.routers._router_has_flavor", return_value=False
+        )
+        fake_segment = {"id": "seg-123", "foo": "bar"}
+        create_segment = mocker.patch(
+            "neutron_understack.routers.fetch_or_create_router_segment",
+            return_value=fake_segment,
+        )
+        port = {"id": "port-123"}
+        create_neutron_port = mocker.patch(
+            "neutron_understack.utils.create_neutron_port_for_segment",
+            return_value=port,
+        )
+        add_trunk = mocker.patch("neutron_understack.routers.add_subport_to_trunk")
+        mocker.patch(
+            "neutron_understack.utils.network_segment_by_id",
+            return_value=fake_segment,
+        )
+        create_uplink_port = mocker.patch(
+            "neutron_understack.routers.create_uplink_port"
+        )
+
+        create_port_postcommit(port_context)
+
+        create_segment.assert_called_once_with(port_context)
+        create_neutron_port.assert_called_once_with(fake_segment, port_context)
+        add_trunk.assert_called_once_with(port, fake_segment)
+        create_uplink_port.assert_called_once_with(
+            fake_segment, port_context.current["network_id"]
+        )
+
 
 @pytest.fixture
 def ri_after_delete_payload(network_id) -> DBEventPayload:

--- a/scripts/cleanup_flavored_router_uplinks.py
+++ b/scripts/cleanup_flavored_router_uplinks.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Detect and clean up orphaned uplink ports on flavored routers.
+
+Before commit b54ef97e, a flavored router that was the first to connect to a
+network would trigger creation of:
+  - a shared Neutron port named uplink-{segment_id} (added as a trunk subport)
+  - an OVN localnet LSP also named uplink-{segment_id}
+
+These are now orphaned. This script finds and optionally removes them.
+
+Runs in dry-run mode by default. Pass --execute to apply changes.
+"""
+
+import argparse
+import logging
+import subprocess
+import sys
+
+import openstack
+import openstack.exceptions
+
+DEVICE_OWNER_ROUTER_INTF = "network:router_interface"
+OVN_POD = "ovn-ovsdb-nb-0"
+OVN_NAMESPACE = "openstack"
+
+log = logging.getLogger(__name__)
+
+
+def build_subport_trunk_map(conn) -> dict[str, str]:
+    """Return {subport_id: trunk_id} for every trunk in the cloud."""
+    mapping: dict[str, str] = {}
+    for trunk in conn.network.trunks():
+        try:
+            data = conn.network.get_trunk_subports(trunk.id)
+            for sp in data.get("sub_ports", []):
+                mapping[sp["port_id"]] = trunk.id
+        except Exception as exc:
+            log.warning("Could not fetch subports for trunk %s: %s", trunk.id, exc)
+    return mapping
+
+
+def find_orphaned_uplinks(conn, verbose: bool) -> list[dict]:
+    """Return one record per orphaned uplink Neutron port."""
+    log.info("Building subport → trunk reverse map …")
+    subport_trunk = build_subport_trunk_map(conn)
+    log.debug("Subport→trunk map: %d entries", len(subport_trunk))
+
+    log.info("Listing routers …")
+    flavored_routers = {r.id: r for r in conn.network.routers() if r.flavor_id}
+    log.info("Found %d flavored router(s)", len(flavored_routers))
+
+    if not flavored_routers:
+        return []
+
+    # network_id -> set of flavored router IDs that have an interface port there
+    network_to_flavored: dict[str, set[str]] = {}
+    for router_id in flavored_routers:
+        for port in conn.network.ports(
+            device_id=router_id,
+            device_owner=DEVICE_OWNER_ROUTER_INTF,
+        ):
+            network_to_flavored.setdefault(port.network_id, set()).add(router_id)
+
+    log.info("Flavored routers present on %d network(s)", len(network_to_flavored))
+
+    orphans: list[dict] = []
+
+    for network_id, flavored_ids_on_net in network_to_flavored.items():
+        # All router-interface ports on this network
+        all_intf_ports = list(
+            conn.network.ports(
+                network_id=network_id,
+                device_owner=DEVICE_OWNER_ROUTER_INTF,
+            )
+        )
+        all_router_ids = {p.device_id for p in all_intf_ports if p.device_id}
+
+        # Routers on this network that are NOT in our flavored set are non-flavored
+        unflavored_on_net = all_router_ids - flavored_ids_on_net
+        if unflavored_on_net:
+            log.debug(
+                "Network %s: non-flavored router(s) %s present — uplink is "
+                "legitimate, skipping",
+                network_id,
+                unflavored_on_net,
+            )
+            continue
+
+        # Look for uplink ports on this network
+        for port in conn.network.ports(network_id=network_id):
+            if not (port.name and port.name.startswith("uplink-")):
+                continue
+            segment_id = port.name.removeprefix("uplink-")
+            trunk_id = subport_trunk.get(port.id)
+            orphans.append(
+                {
+                    "router_ids": sorted(flavored_ids_on_net),
+                    "network_id": network_id,
+                    "port_id": port.id,
+                    "port_name": port.name,
+                    "segment_id": segment_id,
+                    "trunk_id": trunk_id,
+                }
+            )
+
+    return orphans
+
+
+def print_dry_run_report(orphans: list[dict]) -> None:
+    if not orphans:
+        print("[DRY-RUN] No orphaned uplink ports found.")
+        return
+
+    print(f"[DRY-RUN] Found {len(orphans)} orphaned uplink port(s):\n")
+    for o in orphans:
+        print(f"[DRY-RUN] Router(s) : {', '.join(o['router_ids'])}")
+        print(f"[DRY-RUN]   Network : {o['network_id']}")
+        print(f"[DRY-RUN]   Port    : {o['port_id']}  ({o['port_name']})")
+        if o["trunk_id"]:
+            print(
+                f"[DRY-RUN]   1. Remove subport {o['port_id']} "
+                f"from trunk {o['trunk_id']}"
+            )
+        else:
+            print(
+                f"[DRY-RUN]   1. WARN: port {o['port_id']} not found as a trunk "
+                "subport — trunk removal step will be skipped"
+            )
+        print(f"[DRY-RUN]   2. Delete Neutron port {o['port_id']}")
+        print(f"[DRY-RUN]   3. Delete OVN LSP uplink-{o['segment_id']}")
+        print()
+
+
+def execute_cleanup(conn, orphans: list[dict], kube_context: str | None) -> None:
+    if not orphans:
+        print("No orphaned uplink ports found. Nothing to do.")
+        return
+
+    kubectl_base = ["kubectl"]
+    if kube_context:
+        kubectl_base += ["--context", kube_context]
+
+    errors = 0
+    for o in orphans:
+        print(
+            f"Cleaning up {o['port_name']} (port {o['port_id']}) "
+            f"on network {o['network_id']} …"
+        )
+
+        # 1. Remove subport from trunk
+        if o["trunk_id"]:
+            print(f"  1. Removing subport from trunk {o['trunk_id']} …")
+            try:
+                conn.network.delete_trunk_subports(
+                    o["trunk_id"], [{"port_id": o["port_id"]}]
+                )
+            except Exception as exc:
+                log.error(
+                    "  Failed to remove subport %s from trunk %s: %s",
+                    o["port_id"],
+                    o["trunk_id"],
+                    exc,
+                )
+                errors += 1
+                continue
+        else:
+            log.warning(
+                "  Port %s is not a known trunk subport — skipping trunk removal",
+                o["port_id"],
+            )
+
+        # 2. Delete Neutron port
+        print(f"  2. Deleting Neutron port {o['port_id']} …")
+        try:
+            conn.network.delete_port(o["port_id"])
+        except openstack.exceptions.ConflictException as exc:
+            log.error("  Failed to delete Neutron port %s: %s", o["port_id"], exc)
+            errors += 1
+            continue
+        except Exception as exc:
+            log.error("  Unexpected error deleting port %s: %s", o["port_id"], exc)
+            errors += 1
+            continue
+
+        # 3. Delete OVN localnet LSP  (non-fatal — Neutron port is already gone)
+        lsp_name = f"uplink-{o['segment_id']}"
+        print(f"  3. Deleting OVN LSP {lsp_name} …")
+        result = subprocess.run(
+            kubectl_base
+            + [
+                "exec",
+                "-n",
+                OVN_NAMESPACE,
+                OVN_POD,
+                "--",
+                "ovn-nbctl",
+                "lsp-del",
+                lsp_name,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            log.warning(
+                "  ovn-nbctl lsp-del %s failed (rc=%d): %s",
+                lsp_name,
+                result.returncode,
+                result.stderr.strip(),
+            )
+        else:
+            print(f"  OVN LSP {lsp_name} deleted.")
+
+        print("  Done.\n")
+
+    if errors:
+        log.error("%d port(s) could not be cleaned up (see errors above).", errors)
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--os-cloud",
+        metavar="CLOUD",
+        default=None,
+        help="OpenStack cloud name from clouds.yaml (default: OS_CLOUD env var)",
+    )
+    parser.add_argument(
+        "--context",
+        metavar="KUBE_CONTEXT",
+        dest="kube_context",
+        default=None,
+        help="Kubernetes context for kubectl (default: current context)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        default=False,
+        help="Apply changes. Without this flag only a dry-run report is printed.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Enable debug logging.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    try:
+        conn = openstack.connect(cloud=args.os_cloud)
+    except Exception as exc:
+        log.error("Failed to connect to OpenStack: %s", exc)
+        sys.exit(1)
+
+    orphans = find_orphaned_uplinks(conn, verbose=args.verbose)
+
+    if not args.execute:
+        print_dry_run_report(orphans)
+        if orphans:
+            print("Run with --execute to apply the changes above.")
+    else:
+        execute_cleanup(conn, orphans, kube_context=args.kube_context)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanup_flavored_router_uplinks.py
+++ b/scripts/cleanup_flavored_router_uplinks.py
@@ -146,7 +146,16 @@ def verify_ovn_matches_openstack(network_id: str, kubectl_base: list[str]) -> No
     """
     result = subprocess.run(
         kubectl_base
-        + ["exec", "-n", OVN_NAMESPACE, OVN_POD, "--", "ovn-nbctl", "show", network_id],
+        + [
+            "exec",
+            "-n",
+            OVN_NAMESPACE,
+            OVN_POD,
+            "--",
+            "ovn-nbctl",
+            "show",
+            f"neutron-{network_id}",
+        ],
         capture_output=True,
         text=True,
     )

--- a/scripts/cleanup_flavored_router_uplinks.py
+++ b/scripts/cleanup_flavored_router_uplinks.py
@@ -131,14 +131,41 @@ def print_dry_run_report(orphans: list[dict]) -> None:
         print()
 
 
-def execute_cleanup(conn, orphans: list[dict], kube_context: str | None) -> None:
+def build_kubectl_base(kube_context: str | None) -> list[str]:
+    cmd = ["kubectl"]
+    if kube_context:
+        cmd += ["--context", kube_context]
+    return cmd
+
+
+def verify_ovn_matches_openstack(network_id: str, kubectl_base: list[str]) -> None:
+    """Confirm OVN NB knows about network_id; exit if it does not.
+
+    A missing switch most likely means --context and --os-cloud point at
+    different clusters.
+    """
+    result = subprocess.run(
+        kubectl_base
+        + ["exec", "-n", OVN_NAMESPACE, OVN_POD, "--", "ovn-nbctl", "show", network_id],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or network_id not in result.stdout:
+        context_hint = f" (context: {kubectl_base[2]})" if len(kubectl_base) > 1 else ""
+        print(
+            f"ERROR: OVN NB{context_hint} has no switch for network {network_id}.\n"
+            "This likely means --context and --os-cloud are pointing at different "
+            "clusters.\nVerify that both flags target the same environment.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    log.debug("OVN context verified: network %s is present in NB", network_id)
+
+
+def execute_cleanup(conn, orphans: list[dict], kubectl_base: list[str]) -> None:
     if not orphans:
         print("No orphaned uplink ports found. Nothing to do.")
         return
-
-    kubectl_base = ["kubectl"]
-    if kube_context:
-        kubectl_base += ["--context", kube_context]
 
     errors = 0
     for o in orphans:
@@ -263,12 +290,17 @@ def main() -> None:
 
     orphans = find_orphaned_uplinks(conn, verbose=args.verbose)
 
+    kubectl_base = build_kubectl_base(args.kube_context)
+
+    if orphans:
+        verify_ovn_matches_openstack(orphans[0]["network_id"], kubectl_base)
+
     if not args.execute:
         print_dry_run_report(orphans)
         if orphans:
             print("Run with --execute to apply the changes above.")
     else:
-        execute_cleanup(conn, orphans, kube_context=args.kube_context)
+        execute_cleanup(conn, orphans, kubectl_base)
 
 
 if __name__ == "__main__":

--- a/scripts/cleanup_orphaned_ovn_uplinks.py
+++ b/scripts/cleanup_orphaned_ovn_uplinks.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Detect and clean up orphaned OVN uplink logical switch ports.
+
+An uplink-* LSP that exists in the OVN Northbound DB but has no matching
+Neutron port with the same name is orphaned — likely left over from testing
+or an earlier bug.
+
+Runs in dry-run mode by default. Pass --execute to delete the LSPs.
+"""
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+
+import openstack
+import openstack.exceptions
+
+OVN_POD = "ovn-ovsdb-nb-0"
+OVN_NAMESPACE = "openstack"
+
+log = logging.getLogger(__name__)
+
+
+def _unwrap_ovn_value(val):
+    """Recursively unwrap an OVN JSON-encoded value."""
+    if not isinstance(val, list) or len(val) < 2:
+        return val
+    tag = val[0]
+    if tag == "uuid":
+        return val[1]
+    if tag == "set":
+        return [_unwrap_ovn_value(v) for v in val[1]]
+    if tag == "map":
+        return {_unwrap_ovn_value(k): _unwrap_ovn_value(v) for k, v in val[1]}
+    return val
+
+
+def parse_ovn_json(raw: str) -> list[dict]:
+    """Parse OVN --format=json list output into a list of row dicts."""
+    obj = json.loads(raw)
+    headings = obj["headings"]
+    return [
+        {h: _unwrap_ovn_value(v) for h, v in zip(headings, row)} for row in obj["data"]
+    ]
+
+
+def _ovn_cmd(kubectl_base: list[str], *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        kubectl_base
+        + ["exec", "-n", OVN_NAMESPACE, OVN_POD, "--", "ovn-nbctl"]
+        + list(args),
+        capture_output=True,
+        text=True,
+    )
+
+
+def list_ovn_uplink_lsps(kubectl_base: list[str]) -> list[dict]:
+    """Return [{lport_name, uuid, neutron_port_name}] for every uplink-* LSP.
+
+    Two creation paths exist:
+    - create_uplink_port() in routers.py: lport_name="uplink-{segment_id}",
+      external_ids={}.  Matched by lport_name prefix.
+    - Normal Neutron port sync: lport_name=<port-uuid>,
+      external_ids["neutron:port_name"]="uplink-{segment_id}".  Matched by
+      the external_ids field (shown as "aka" in ovn-nbctl show).
+    """
+    result = _ovn_cmd(
+        kubectl_base,
+        "--columns=name,_uuid,external_ids",
+        "--format=json",
+        "list",
+        "logical_switch_port",
+    )
+    if result.returncode != 0:
+        print(
+            f"ERROR: ovn-nbctl list logical_switch_port failed:\n{result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    rows = parse_ovn_json(result.stdout)
+    lsps = []
+    for r in rows:
+        lport_name = r.get("name", "")
+        ext_ids = r.get("external_ids") or {}
+        neutron_port_name = (
+            ext_ids.get("neutron:port_name", "") if isinstance(ext_ids, dict) else ""
+        )
+        if lport_name.startswith("uplink-") or neutron_port_name.startswith("uplink-"):
+            lsps.append(
+                {
+                    "lport_name": lport_name,
+                    "uuid": r["_uuid"],
+                    "neutron_port_name": neutron_port_name,
+                }
+            )
+    return lsps
+
+
+def build_lsp_network_map(kubectl_base: list[str]) -> dict[str, str]:
+    """Return {port_uuid: network_id} for all ports on neutron-* switches."""
+    result = _ovn_cmd(
+        kubectl_base,
+        "--columns=name,ports",
+        "--format=json",
+        "list",
+        "logical_switch",
+    )
+    if result.returncode != 0:
+        print(
+            f"ERROR: ovn-nbctl list logical_switch failed:\n{result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    rows = parse_ovn_json(result.stdout)
+    mapping: dict[str, str] = {}
+    for row in rows:
+        switch_name = row.get("name", "")
+        if not isinstance(switch_name, str) or not switch_name.startswith("neutron-"):
+            continue
+        network_id = switch_name.removeprefix("neutron-")
+        ports = row.get("ports", [])
+        if isinstance(ports, str):
+            # Single port unwrapped from ["uuid", "..."] to a bare string
+            ports = [ports]
+        for port_uuid in ports:
+            if isinstance(port_uuid, str):
+                mapping[port_uuid] = network_id
+    return mapping
+
+
+def verify_neutron_matches_ovn(conn, network_id: str, kubectl_base: list[str]) -> None:
+    """Confirm Neutron knows about a network found in OVN; exit if not.
+
+    A missing network most likely means --context and --os-cloud point at
+    different clusters.
+    """
+    try:
+        conn.network.find_network(network_id, ignore_missing=False)
+    except openstack.exceptions.ResourceNotFound:
+        context_hint = f" (context: {kubectl_base[2]})" if len(kubectl_base) > 1 else ""
+        print(
+            f"ERROR: Neutron does not know about network {network_id} that "
+            f"OVN{context_hint} reports.\n"
+            "This likely means --context and --os-cloud are pointing at different "
+            "clusters.\nVerify that both flags target the same environment.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    log.debug("Cluster sanity check passed: Neutron knows network %s", network_id)
+
+
+def find_orphaned_lsps(conn, kubectl_base: list[str], verbose: bool) -> list[dict]:
+    """Return one record per OVN uplink LSP that has no matching Neutron port."""
+    log.info("Fetching OVN uplink LSPs …")
+    lsps = list_ovn_uplink_lsps(kubectl_base)
+    log.info("Found %d uplink LSP(s) in OVN", len(lsps))
+
+    if not lsps:
+        return []
+
+    log.info("Building LSP → network map …")
+    lsp_network = build_lsp_network_map(kubectl_base)
+
+    # Sanity check: verify at least one OVN network is also visible in Neutron.
+    sample_ids = [
+        lsp_network[lsp["uuid"]] for lsp in lsps if lsp["uuid"] in lsp_network
+    ]
+    if sample_ids:
+        verify_neutron_matches_ovn(conn, sample_ids[0], kubectl_base)
+
+    log.info("Cross-checking %d LSP(s) against Neutron …", len(lsps))
+    orphans: list[dict] = []
+    for lsp in lsps:
+        if lsp["neutron_port_name"]:
+            # lport_name is the Neutron port UUID; look up directly by ID.
+            port = conn.network.find_port(lsp["lport_name"], ignore_missing=True)
+            exists = port is not None
+            display_name = lsp["neutron_port_name"]
+        else:
+            # lport_name is "uplink-{segment_id}" (create_uplink_port path); look up by name.
+            exists = bool(list(conn.network.ports(name=lsp["lport_name"])))
+            display_name = lsp["lport_name"]
+
+        if not exists:
+            network_id = lsp_network.get(lsp["uuid"], "")
+            log.debug(
+                "Orphaned: %s (network %s)", display_name, network_id or "unknown"
+            )
+            orphans.append(
+                {
+                    "display_name": display_name,
+                    "lport_name": lsp["lport_name"],
+                    "uuid": lsp["uuid"],
+                    "network_id": network_id,
+                }
+            )
+        else:
+            log.debug("OK: %s → Neutron port exists", display_name)
+
+    return orphans
+
+
+def print_dry_run_report(orphans: list[dict]) -> None:
+    if not orphans:
+        print("[DRY-RUN] No orphaned OVN uplink LSPs found.")
+        return
+
+    print(f"[DRY-RUN] Found {len(orphans)} orphaned OVN uplink LSP(s):\n")
+    for o in orphans:
+        print(f"[DRY-RUN]   Name   : {o['display_name']}")
+        print(f"[DRY-RUN]   OVN ID : {o['lport_name']}")
+        print(f"[DRY-RUN]   UUID   : {o['uuid']}")
+        if o["network_id"]:
+            print(f"[DRY-RUN]   Net    : {o['network_id']}")
+        print(f"[DRY-RUN]   Action : ovn-nbctl lsp-del {o['lport_name']}")
+        print()
+
+
+def build_kubectl_base(kube_context: str | None) -> list[str]:
+    cmd = ["kubectl"]
+    if kube_context:
+        cmd += ["--context", kube_context]
+    return cmd
+
+
+def execute_cleanup(orphans: list[dict], kubectl_base: list[str]) -> None:
+    if not orphans:
+        print("No orphaned OVN uplink LSPs found. Nothing to do.")
+        return
+
+    errors = 0
+    for o in orphans:
+        net_hint = f" (network {o['network_id']})" if o["network_id"] else ""
+        print(f"Deleting OVN LSP {o['display_name']}{net_hint} …")
+        result = _ovn_cmd(kubectl_base, "lsp-del", o["lport_name"])
+        if result.returncode != 0:
+            log.error(
+                "  lsp-del %s failed (rc=%d): %s",
+                o["lport_name"],
+                result.returncode,
+                result.stderr.strip(),
+            )
+            errors += 1
+        else:
+            print("  Deleted.")
+
+    if errors:
+        log.error("%d LSP(s) could not be deleted (see errors above).", errors)
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--os-cloud",
+        metavar="CLOUD",
+        default=None,
+        help="OpenStack cloud name from clouds.yaml (default: OS_CLOUD env var)",
+    )
+    parser.add_argument(
+        "--context",
+        metavar="KUBE_CONTEXT",
+        dest="kube_context",
+        default=None,
+        help="Kubernetes context for kubectl (default: current context)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        default=False,
+        help="Apply changes. Without this flag only a dry-run report is printed.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Enable debug logging.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    try:
+        conn = openstack.connect(cloud=args.os_cloud)
+    except Exception as exc:
+        log.error("Failed to connect to OpenStack: %s", exc)
+        sys.exit(1)
+
+    kubectl_base = build_kubectl_base(args.kube_context)
+    orphans = find_orphaned_lsps(conn, kubectl_base, verbose=args.verbose)
+
+    if not args.execute:
+        print_dry_run_report(orphans)
+        if orphans:
+            print("Run with --execute to apply the changes above.")
+    else:
+        execute_cleanup(orphans, kubectl_base)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Flavored routers (svi, vrf, etc.) implement their own routing path and do not need the physical uplink infrastructure (dynamic segment, shared port, trunk subport, OVN localnet port) that unflavored routers require.


### Testing - SVI flavor

#### Neutron router subnet attach logs

<details>

```
2026-06-29 14:20:54.333 8 INFO neutron.pecan_wsgi.hooks.translation [None req-c041aeac-714d-48dc-81b1-e74c9162c21a a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04]  GET  failed (client error): The resource could not be found.
2026-06-29 14:20:54.333 8 INFO neutron.pecan_wsgi.hooks.translation [None req-c041aeac-714d-48dc-81b1-e74c9162c21a a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04]  GET  failed (client error): The resource could not be found.
[pid: 8|app: 0|req: 56/212] 10.64.49.168 () {36 vars in 1161 bytes} [Mon Jun 29 14:20:54 2026]  GET  /v2.0/subnets/marek-test-svi-flavor-subnet => generated 128 bytes in 153 msecs (HTTP/1.1 404) 4 headers in 164 bytes (1 switches on core 0)
[pid: 9|app: 0|req: 53/213] 10.64.49.168 () {36 vars in 1183 bytes} [Mon Jun 29 14:20:54 2026]  GET  /v2.0/subnets?name=marek-test-svi-flavor-subnet => generated 717 bytes in 60 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
2026-06-29 14:20:54.728 10 INFO neutron.api.v2.resource [None req-8f919521-e613-48ec-85cc-cdbcfe76cd8a a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] show failed (client error): The resource could not be found.
2026-06-29 14:20:54.728 10 INFO neutron.api.v2.resource [None req-8f919521-e613-48ec-85cc-cdbcfe76cd8a a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] show failed (client error): The resource could not be found.
[pid: 10|app: 0|req: 61/234] 10.64.49.168 () {36 vars in 1137 bytes} [Mon Jun 29 14:20:54 2026]  GET  /v2.0/routers/marek-svi-flavor => generated 115 bytes in 79 msecs (HTTP/1.1 404) 4 headers in 164 bytes (1 switches on core 0)
[pid: 10|app: 0|req: 53/214] 10.64.49.168 () {36 vars in 1159 bytes} [Mon Jun 29 14:20:54 2026]  GET  /v2.0/routers?name=marek-svi-flavor => generated 661 bytes in 99 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
2026-06-29 14:20:55.509 9 INFO neutron_understack.neutron_understack_mech [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] create_port_precommit: checking SVI scope validation for router port f4452b9d-8ac7-4442-9b64-bb63b465b52b device_id=42918ff1-0347-4a73-9247-4d4079d14e92
2026-06-29 14:20:55.509 9 INFO neutron_understack.neutron_understack_mech [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] create_port_precommit: checking SVI scope validation for router port f4452b9d-8ac7-4442-9b64-bb63b465b52b device_id=42918ff1-0347-4a73-9247-4d4079d14e92
2026-06-29 14:20:55.560 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] precommit SVI scope check: router 42918ff1-0347-4a73-9247-4d4079d14e92 (marek-svi-flavor) port f4452b9d-8ac7-4442-9b64-bb63b465b52b network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401']
2026-06-29 14:20:55.560 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] precommit SVI scope check: router 42918ff1-0347-4a73-9247-4d4079d14e92 (marek-svi-flavor) port f4452b9d-8ac7-4442-9b64-bb63b465b52b network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401']
2026-06-29 14:20:55.651 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] precommit SVI scope check PASSED: router 42918ff1-0347-4a73-9247-4d4079d14e92 port f4452b9d-8ac7-4442-9b64-bb63b465b52b subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401'] scopes={4: '648c2fc6-e0fa-49a0-b29c-a59cce797671'}
2026-06-29 14:20:55.651 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] precommit SVI scope check PASSED: router 42918ff1-0347-4a73-9247-4d4079d14e92 port f4452b9d-8ac7-4442-9b64-bb63b465b52b subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401'] scopes={4: '648c2fc6-e0fa-49a0-b29c-a59cce797671'}
2026-06-29 14:20:55.651 9 INFO neutron_understack.neutron_understack_mech [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] create_port_precommit: SVI scope check passed for port f4452b9d-8ac7-4442-9b64-bb63b465b52b network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 router 42918ff1-0347-4a73-9247-4d4079d14e92
2026-06-29 14:20:55.651 9 INFO neutron_understack.neutron_understack_mech [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] create_port_precommit: SVI scope check passed for port f4452b9d-8ac7-4442-9b64-bb63b465b52b network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 router 42918ff1-0347-4a73-9247-4d4079d14e92
2026-06-29 14:20:55.756 9 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:20:55.756 9 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:20:55.757 9 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:20:55.757 9 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:20:55.885 9 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-f6448916-8d83-4bf2-a777-e5685c9c0d1f - - - - - -] OVN reports status down for port: f4452b9d-8ac7-4442-9b64-bb63b465b52b
2026-06-29 14:20:55.885 9 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-f6448916-8d83-4bf2-a777-e5685c9c0d1f - - - - - -] OVN reports status down for port: f4452b9d-8ac7-4442-9b64-bb63b465b52b
2026-06-29 14:20:55.961 9 INFO neutron.db.ovn_revision_numbers_db [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource f4452b9d-8ac7-4442-9b64-bb63b465b52b (type: ports) to 1
2026-06-29 14:20:55.961 9 INFO neutron.db.ovn_revision_numbers_db [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource f4452b9d-8ac7-4442-9b64-bb63b465b52b (type: ports) to 1
2026-06-29 14:20:55.985 9 INFO neutron_understack.neutron_understack_mech [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Router interface port f4452b9d-8ac7-4442-9b64-bb63b465b52b detected on network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 device_id=42918ff1-0347-4a73-9247-4d4079d14e92 owner=network:router_interface fixed_ips=[{'subnet_id': '479ca0e5-3c39-4a23-b06d-85b09532e401', 'ip_address': '192.168.77.1'}] - handing off to routers.create_port_postcommit
2026-06-29 14:20:55.985 9 INFO neutron_understack.neutron_understack_mech [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Router interface port f4452b9d-8ac7-4442-9b64-bb63b465b52b detected on network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 device_id=42918ff1-0347-4a73-9247-4d4079d14e92 owner=network:router_interface fixed_ips=[{'subnet_id': '479ca0e5-3c39-4a23-b06d-85b09532e401', 'ip_address': '192.168.77.1'}] - handing off to routers.create_port_postcommit
2026-06-29 14:20:56.102 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] SVI callback validation: attach_mode=subnet router 42918ff1-0347-4a73-9247-4d4079d14e92 (marek-svi-flavor) port f4452b9d-8ac7-4442-9b64-bb63b465b52b network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 owner network:router_interface subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401']
2026-06-29 14:20:56.102 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] SVI callback validation: attach_mode=subnet router 42918ff1-0347-4a73-9247-4d4079d14e92 (marek-svi-flavor) port f4452b9d-8ac7-4442-9b64-bb63b465b52b network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 owner network:router_interface subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401']
2026-06-29 14:20:56.180 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] SVI callback validation PASSED: attach_mode=subnet router 42918ff1-0347-4a73-9247-4d4079d14e92 port f4452b9d-8ac7-4442-9b64-bb63b465b52b subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401'] scopes={4: '648c2fc6-e0fa-49a0-b29c-a59cce797671'}
2026-06-29 14:20:56.180 9 INFO neutron_understack.l3_router.svi [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] SVI callback validation PASSED: attach_mode=subnet router 42918ff1-0347-4a73-9247-4d4079d14e92 port f4452b9d-8ac7-4442-9b64-bb63b465b52b subnet(s)=['479ca0e5-3c39-4a23-b06d-85b09532e401'] scopes={4: '648c2fc6-e0fa-49a0-b29c-a59cce797671'}
2026-06-29 14:20:56.798 9 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:20:56.798 9 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:20:56.800 9 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:20:56.800 9 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-39fff6ed-74bf-40c8-929a-a9b1d71c445e a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21: no agents available; will retry on subsequent port and subnet creation events.
[pid: 9|app: 0|req: 59/235] 10.64.49.168 () {40 vars in 1271 bytes} [Mon Jun 29 14:20:55 2026]  PUT  /v2.0/routers/42918ff1-0347-4a73-9247-4d4079d14e92/add_router_interface => generated 310 bytes in 1821 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
2026-06-29 14:21:44.230 10 INFO neutron.pecan_wsgi.hooks.translation [None req-84d98d93-0888-44f1-970e-55a6d3fd9dc1 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04]  GET  failed (client error): The resource could not be found.
2026-06-29 14:21:44.230 10 INFO neutron.pecan_wsgi.hooks.translation [None req-84d98d93-0888-44f1-970e-55a6d3fd9dc1 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04]  GET  failed (client error): The resource could not be found.
[pid: 10|app: 0|req: 54/218] 10.64.49.168 () {36 vars in 1161 bytes} [Mon Jun 29 14:21:43 2026]  GET  /v2.0/subnets/marek-test-svi-flavor-subnet => generated 128 bytes in 638 msecs (HTTP/1.1 404) 4 headers in 164 bytes (1 switches on core 0)
[pid: 7|app: 0|req: 54/219] 10.64.49.168 () {36 vars in 1183 bytes} [Mon Jun 29 14:21:44 2026]  GET  /v2.0/subnets?name=marek-test-svi-flavor-subnet => generated 717 bytes in 46 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
2026-06-29 14:21:44.690 8 INFO neutron.api.v2.resource [None req-e4b680b1-c420-4ebe-8176-a5b36685dea1 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] show failed (client error): The resource could not be found.
2026-06-29 14:21:44.690 8 INFO neutron.api.v2.resource [None req-e4b680b1-c420-4ebe-8176-a5b36685dea1 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] show failed (client error): The resource could not be found.
[pid: 8|app: 0|req: 58/220] 10.64.49.168 () {36 vars in 1137 bytes} [Mon Jun 29 14:21:44 2026]  GET  /v2.0/routers/marek-svi-flavor => generated 115 bytes in 71 msecs (HTTP/1.1 404) 4 headers in 164 bytes (1 switches on core 0)
[pid: 9|app: 0|req: 60/239] 10.64.49.168 () {36 vars in 1159 bytes} [Mon Jun 29 14:21:44 2026]  GET  /v2.0/routers?name=marek-svi-flavor => generated 661 bytes in 74 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
2026-06-29 14:21:45.165 9 INFO neutron.services.evpn.plugin [None req-db8d4951-961d-4763-943f-72c89f98a7f0 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Removed EVPN network entry for subnet 479ca0e5-3c39-4a23-b06d-85b09532e401
2026-06-29 14:21:45.165 9 INFO neutron.services.evpn.plugin [None req-db8d4951-961d-4763-943f-72c89f98a7f0 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Removed EVPN network entry for subnet 479ca0e5-3c39-4a23-b06d-85b09532e401
```
</details>



#### commands

```
❯ openstack address scope create marek-svi-flavor-scope --ip-version 4
+------------+--------------------------------------+
| Field      | Value                                |
+------------+--------------------------------------+
| id         | 648c2fc6-e0fa-49a0-b29c-a59cce797671 |
| ip_version | 4                                    |
| name       | marek-svi-flavor-scope               |
| project_id | 32e02632f4f04415bab5895d1e7247b7     |
| shared     | False                                |
+------------+--------------------------------------+


❯ openstack subnet pool create --no-default --address-scope 648c2fc6-e0fa-49a0-b29c-a59cce797671 --pool-prefix 192.168.77.0/24 marek-svi-testpool
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| address_scope_id  | 648c2fc6-e0fa-49a0-b29c-a59cce797671 |
| created_at        | 2026-06-29T14:19:53Z                 |
| default_prefixlen | 8                                    |
| default_quota     | None                                 |
| description       |                                      |
| id                | 8b3c902a-88e4-47a8-8814-e6fab1961faa |
| ip_version        | 4                                    |
| is_default        | False                                |
| max_prefixlen     | 32                                   |
| min_prefixlen     | 8                                    |
| name              | marek-svi-testpool                   |
| prefixes          | 192.168.77.0/24                      |
| project_id        | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number   | 0                                    |
| shared            | False                                |
| tags              |                                      |
| updated_at        | 2026-06-29T14:19:53Z                 |
+-------------------+--------------------------------------+


❯ openstack subnet create --network marek-test-svi-flavor-net --subnet-pool marek-svi-testpool --prefix-length 30 --no-dhcp  marek-test-svi-flavor-subnet
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| allocation_pools     | 192.168.77.2-192.168.77.2            |
| cidr                 | 192.168.77.0/30                      |
| created_at           | 2026-06-29T14:20:42Z                 |
| description          |                                      |
| dns_nameservers      |                                      |
| dns_publish_fixed_ip | None                                 |
| enable_dhcp          | False                                |
| gateway_ip           | 192.168.77.1                         |
| host_routes          |                                      |
| id                   | 479ca0e5-3c39-4a23-b06d-85b09532e401 |
| ip_version           | 4                                    |
| ipv6_address_mode    | None                                 |
| ipv6_ra_mode         | None                                 |
| name                 | marek-test-svi-flavor-subnet         |
| network_id           | 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 |
| project_id           | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number      | 0                                    |
| router:external      | False                                |
| segment_id           | None                                 |
| service_types        |                                      |
| subnetpool_id        | 8b3c902a-88e4-47a8-8814-e6fab1961faa |
| tags                 |                                      |
| updated_at           | 2026-06-29T14:20:42Z                 |
+----------------------+--------------------------------------+

❯ kubectl exec -it ovn-ovsdb-nb-0 -- ovn-nbctl show neutron-2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21
Defaulted container "ovsdb" out of: ovsdb, init (init)
switch 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 (neutron-2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21) (aka marek-test-svi-flavor-net)


~/flakez on  master [!+] ☸  uc_iad3_dev on ☁️  uc_iad_dev took 2s
❯ openstack router add subnet marek-svi-flavor marek-test-svi-flavor-subnet


# no uplink-* port created
❯ kubectl exec -it ovn-ovsdb-nb-0 -- ovn-nbctl show neutron-2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21
Defaulted container "ovsdb" out of: ovsdb, init (init)
switch 2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21 (neutron-2fe78b0b-b1d2-46ff-ab29-c42f3ec9dc21) (aka marek-test-svi-flavor-net)
    port f4452b9d-8ac7-4442-9b64-bb63b465b52b
        addresses: ["unknown"]
```

### Testing - unflavored


#### neutron logs

<details>

```
2026-06-29 14:30:43.447 10 INFO neutron.pecan_wsgi.hooks.translation [None req-cb11be38-7860-494d-ba7b-5f412bed2848 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04]  GET  failed (client error): The resource could not be found.
2026-06-29 14:30:43.447 10 INFO neutron.pecan_wsgi.hooks.translation [None req-cb11be38-7860-494d-ba7b-5f412bed2848 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04]  GET  failed (client error): The resource could not be found.
[pid: 10|app: 0|req: 80/324] 10.64.49.168 () {36 vars in 1161 bytes} [Mon Jun 29 14:30:42 2026]  GET  /v2.0/subnets/marek-test-unflavored-subnet => generated 128 bytes in 465 msecs (HTTP/1.1 404) 4 headers in 164 bytes (1 switches on core 0)
[pid: 7|app: 0|req: 78/316] 10.64.49.128 () {28 vars in 584 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/subnets => generated 12805 bytes in 201 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 8|app: 0|req: 79/317] 10.64.49.128 () {28 vars in 592 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/subnetpools => generated 2253 bytes in 21 msecs (HTTP/1.1 200) 4 headers in 158 bytes (1 switches on core 0)
[pid: 10|app: 0|req: 82/318] 10.64.49.168 () {36 vars in 1183 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/subnets?name=marek-test-unflavored-subnet => generated 685 bytes in 26 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
[pid: 9|app: 0|req: 80/319] 10.64.49.128 () {28 vars in 620 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/network-ip-availabilities => generated 15152 bytes in 34 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 7|app: 0|req: 79/320] 10.64.49.128 () {28 vars in 592 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/floatingips => generated 1050 bytes in 27 msecs (HTTP/1.1 200) 4 headers in 158 bytes (1 switches on core 0)
2026-06-29 14:30:43.696 10 INFO neutron.api.v2.resource [None req-9e54d004-ed25-4ac0-b500-ccead62805e9 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] show failed (client error): The resource could not be found.
2026-06-29 14:30:43.696 10 INFO neutron.api.v2.resource [None req-9e54d004-ed25-4ac0-b500-ccead62805e9 a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] show failed (client error): The resource could not be found.
[pid: 10|app: 0|req: 83/321] 10.64.49.168 () {36 vars in 1145 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/routers/marek-rtr-unflavored => generated 119 bytes in 17 msecs (HTTP/1.1 404) 4 headers in 164 bytes (1 switches on core 0)
[pid: 8|app: 0|req: 80/322] 10.64.49.128 () {28 vars in 586 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/networks => generated 16636 bytes in 141 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 9|app: 0|req: 81/323] 10.64.49.128 () {28 vars in 584 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/subnets => generated 12805 bytes in 87 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 9|app: 0|req: 81/325] 10.64.49.168 () {36 vars in 1167 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/routers?name=marek-rtr-unflavored => generated 630 bytes in 101 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
[pid: 7|app: 0|req: 81/326] 10.64.49.128 () {28 vars in 582 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/agents => generated 12929 bytes in 47 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 7|app: 0|req: 80/324] 10.64.49.128 () {28 vars in 584 bytes} [Mon Jun 29 14:30:43 2026]  GET  /v2.0/routers => generated 3207 bytes in 59 msecs (HTTP/1.1 200) 4 headers in 158 bytes (1 switches on core 0)
[pid: 10|app: 0|req: 84/325] 10.64.49.128 () {28 vars in 625 bytes} [Mon Jun 29 14:30:44 2026]  GET  /v2.0/agents?binary=ovn-controller => generated 815 bytes in 9 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
2026-06-29 14:30:44.308 8 INFO neutron_understack.neutron_understack_mech [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] create_port_precommit: checking SVI scope validation for router port 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 device_id=c8300398-ff39-4a64-aeef-aa9d2b0a0d3a
2026-06-29 14:30:44.308 8 INFO neutron_understack.neutron_understack_mech [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] create_port_precommit: checking SVI scope validation for router port 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 device_id=c8300398-ff39-4a64-aeef-aa9d2b0a0d3a
[pid: 10|app: 0|req: 81/327] 10.64.49.128 () {28 vars in 600 bytes} [Mon Jun 29 14:30:44 2026]  GET  /v2.0/security-groups => generated 722554 bytes in 377 msecs (HTTP/1.1 200) 4 headers in 160 bytes (3 switches on core 0)
2026-06-29 14:30:44.469 8 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:30:44.469 8 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:30:44.470 8 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 139cee36-b482-4f36-8730-21782d059e04: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:30:44.470 8 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 139cee36-b482-4f36-8730-21782d059e04: no agents available; will retry on subsequent port and subnet creation events.
[pid: 9|app: 0|req: 82/328] 10.64.49.90 () {34 vars in 1084 bytes} [Mon Jun 29 14:30:44 2026]  GET  /v2.0/ports?device_id=c9988354-1cf9-4048-8df8-79436851035a&device_id=90f71d29-7780-4397-afe2-ca5b5d05ea15 => generated 12 bytes in 25 msecs (HTTP/1.1 200) 4 headers in 156 bytes (1 switches on core 0)
2026-06-29 14:30:44.616 8 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] OVN reports status down for port: 7fd1b1b9-3f24-4411-b6bf-2f03519102d0
2026-06-29 14:30:44.616 8 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] OVN reports status down for port: 7fd1b1b9-3f24-4411-b6bf-2f03519102d0
2026-06-29 14:30:44.677 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 (type: ports) to 1
2026-06-29 14:30:44.677 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 (type: ports) to 1
2026-06-29 14:30:44.687 8 INFO neutron_understack.neutron_understack_mech [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Router interface port 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 detected on network 139cee36-b482-4f36-8730-21782d059e04 device_id=c8300398-ff39-4a64-aeef-aa9d2b0a0d3a owner=network:router_interface fixed_ips=[{'subnet_id': '74814534-6d45-4aa8-8fa5-818f33dd43a4', 'ip_address': '192.168.77.1'}] - handing off to routers.create_port_postcommit
2026-06-29 14:30:44.687 8 INFO neutron_understack.neutron_understack_mech [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Router interface port 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 detected on network 139cee36-b482-4f36-8730-21782d059e04 device_id=c8300398-ff39-4a64-aeef-aa9d2b0a0d3a owner=network:router_interface fixed_ips=[{'subnet_id': '74814534-6d45-4aa8-8fa5-818f33dd43a4', 'ip_address': '192.168.77.1'}] - handing off to routers.create_port_postcommit
2026-06-29 14:30:44.865 8 INFO neutron.db.segments_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Added segment faee4286-82a5-46cf-aa2a-2b1eb59bacd9 of type vlan for network 139cee36-b482-4f36-8730-21782d059e04
2026-06-29 14:30:44.865 8 INFO neutron.db.segments_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Added segment faee4286-82a5-46cf-aa2a-2b1eb59bacd9 of type vlan for network 139cee36-b482-4f36-8730-21782d059e04
[pid: 8|app: 0|req: 81/326] 10.64.49.128 () {28 vars in 580 bytes} [Mon Jun 29 14:30:44 2026]  GET  /v2.0/ports => generated 25616 bytes in 287 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
2026-06-29 14:30:45.059 8 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:30:45.059 8 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:30:45.060 8 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 139cee36-b482-4f36-8730-21782d059e04: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:30:45.060 8 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 139cee36-b482-4f36-8730-21782d059e04: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:30:45.097 7 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-ff5f0ba4-e6cc-449e-8c25-108ae7b97de1 - - - - - -] OVN reports status down for port: 961b8367-9183-4912-bbc2-75e5f4932e10
2026-06-29 14:30:45.097 7 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-ff5f0ba4-e6cc-449e-8c25-108ae7b97de1 - - - - - -] OVN reports status down for port: 961b8367-9183-4912-bbc2-75e5f4932e10
2026-06-29 14:30:45.119 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 961b8367-9183-4912-bbc2-75e5f4932e10 (type: ports) to 1
2026-06-29 14:30:45.119 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 961b8367-9183-4912-bbc2-75e5f4932e10 (type: ports) to 1
2026-06-29 14:30:45.135 8 WARNING openstack [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Disabling service 'compute': Encountered an exception attempting to process config for project 'nova' (service type 'compute'): no such option valid_interfaces in group [nova]: oslo_config.cfg.NoSuchOptError: no such option valid_interfaces in group [nova]
2026-06-29 14:30:45.140 8 WARNING openstack [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Disabling service 'placement': Encountered an exception attempting to process config for project 'placement' (service type 'placement'): no such option valid_interfaces in group [placement]: oslo_config.cfg.NoSuchOptError: no such option valid_interfaces in group [placement]
2026-06-29 14:30:45.951 8 INFO neutron_understack.utils [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Found network node trunk: 2e558202-0bd0-4971-a9f8-61d1adea0427 (parent_port: b20be064-000d-47c2-9d4b-f11b3efe4027, host: 1327172-hp1)
2026-06-29 14:30:45.951 8 INFO neutron_understack.utils [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Found network node trunk: 2e558202-0bd0-4971-a9f8-61d1adea0427 (parent_port: b20be064-000d-47c2-9d4b-f11b3efe4027, host: 1327172-hp1)
2026-06-29 14:30:45.952 8 INFO neutron_understack.utils [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Discovered and cached network node trunk ID: 2e558202-0bd0-4971-a9f8-61d1adea0427 (gateway_host: 1327172-hp1, gateway_uuid: 7ca98881-bca5-4c82-9369-66eb36292a95)
2026-06-29 14:30:45.952 8 INFO neutron_understack.utils [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Discovered and cached network node trunk ID: 2e558202-0bd0-4971-a9f8-61d1adea0427 (gateway_host: 1327172-hp1, gateway_uuid: 7ca98881-bca5-4c82-9369-66eb36292a95)
2026-06-29 14:30:46.653 8 INFO neutron_understack.utils [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Returning cached network node trunk ID: 2e558202-0bd0-4971-a9f8-61d1adea0427
2026-06-29 14:30:46.653 8 INFO neutron_understack.utils [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Returning cached network node trunk ID: 2e558202-0bd0-4971-a9f8-61d1adea0427
2026-06-29 14:30:47.255 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 961b8367-9183-4912-bbc2-75e5f4932e10 (type: ports) to 3
2026-06-29 14:30:47.255 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 961b8367-9183-4912-bbc2-75e5f4932e10 (type: ports) to 3
[pid: 7|app: 0|req: 81/328] 10.64.48.252 () {40 vars in 857 bytes} [Mon Jun 29 14:30:49 2026]  GET  /v2.0/networks => generated 16636 bytes in 175 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 7|app: 0|req: 82/329] 10.64.48.252 () {40 vars in 851 bytes} [Mon Jun 29 14:30:49 2026]  GET  /v2.0/ports => generated 26566 bytes in 203 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 10|app: 0|req: 85/329] 10.64.48.252 () {40 vars in 857 bytes} [Mon Jun 29 14:30:49 2026]  GET  /v2.0/segments => generated 13040 bytes in 63 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 8|app: 0|req: 82/330] 10.64.48.252 () {40 vars in 855 bytes} [Mon Jun 29 14:30:50 2026]  GET  /v2.0/subnets => generated 12805 bytes in 108 msecs (HTTP/1.1 200) 4 headers in 159 bytes (1 switches on core 0)
[pid: 9|app: 0|req: 83/331] 10.64.48.252 () {40 vars in 855 bytes} [Mon Jun 29 14:30:50 2026]  GET  /v2.0/flavors => generated 884 bytes in 24 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
[pid: 7|app: 0|req: 82/332] 10.64.48.252 () {40 vars in 855 bytes} [Mon Jun 29 14:30:50 2026]  GET  /v2.0/routers => generated 3207 bytes in 59 msecs (HTTP/1.1 200) 4 headers in 158 bytes (1 switches on core 0)
[pid: 10|app: 0|req: 82/330] 10.64.48.252 () {40 vars in 869 bytes} [Mon Jun 29 14:30:50 2026]  GET  /v2.0/address-scopes => generated 1067 bytes in 43 msecs (HTTP/1.1 200) 4 headers in 158 bytes (1 switches on core 0)
[pid: 10|app: 0|req: 86/333] 10.64.48.252 () {40 vars in 863 bytes} [Mon Jun 29 14:30:50 2026]  GET  /v2.0/subnetpools => generated 2253 bytes in 32 msecs (HTTP/1.1 200) 4 headers in 158 bytes (1 switches on core 0)
2026-06-29 14:31:00.324 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-1661dd6b-a8b5-4a19-b7a4-9f4435e8427a - - - - - -] OVN reports status down for port: uplink-faee4286-82a5-46cf-aa2a-2b1eb59bacd9
2026-06-29 14:31:00.324 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-1661dd6b-a8b5-4a19-b7a4-9f4435e8427a - - - - - -] OVN reports status down for port: uplink-faee4286-82a5-46cf-aa2a-2b1eb59bacd9
2026-06-29 14:31:00.917 8 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] OVN reports status up for port: 7fd1b1b9-3f24-4411-b6bf-2f03519102d0
2026-06-29 14:31:00.917 8 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.mech_driver [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] OVN reports status up for port: 7fd1b1b9-3f24-4411-b6bf-2f03519102d0
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event [None req-fa687f09-ff64-4a68-a85d-40d287dcdfa6 - - - - - -] Event not matched due to this exception:
: AttributeError: Row instance has no attribute 'additional_chassis'
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event Traceback (most recent call last):
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovs/db/idl.py", line 1383, in __getattr__
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event     column = self._table.columns[column_name]
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event              ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event KeyError: 'additional_chassis'
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event During handling of the above exception, another exception occurred:
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event Traceback (most recent call last):
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovsdbapp/event.py", line 147, in match
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event     return candidate.matches(event, row, updates)
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovsdbapp/backend/ovs_idl/event.py", line 53, in matches
2026-06-29 14:31:00.933 8 INFO neutron.plugins.ml2.plugin [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] Attempt 1 to provision port 7fd1b1b9-3f24-4411-b6bf-2f03519102d0
2026-06-29 14:31:00.933 8 INFO neutron.plugins.ml2.plugin [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] Attempt 1 to provision port 7fd1b1b9-3f24-4411-b6bf-2f03519102d0
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event     if not self.match_fn(event, row, old):
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovsdb_monitor.py", line 287, in match_fn
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event     no_live_migration = (not row.additional_chassis or
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event                              ^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovs/db/idl.py", line 1385, in __getattr__
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event     raise AttributeError("%s instance has no attribute '%s'" %
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event AttributeError: Row instance has no attribute 'additional_chassis'
2026-06-29 14:31:00.915 9 ERROR ovsdbapp.event
2026-06-29 14:31:00.955 8 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:31:00.955 8 WARNING neutron.scheduler.dhcp_agent_scheduler [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] No more DHCP agents
2026-06-29 14:31:00.956 8 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 139cee36-b482-4f36-8730-21782d059e04: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:31:00.956 8 WARNING neutron.api.rpc.agentnotifiers.dhcp_rpc_agent_api [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Unable to schedule network 139cee36-b482-4f36-8730-21782d059e04: no agents available; will retry on subsequent port and subnet creation events.
2026-06-29 14:31:01.117 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 (type: router_ports) to 1
2026-06-29 14:31:01.117 8 INFO neutron.db.ovn_revision_numbers_db [None req-f150a6b6-ea22-471a-8201-ee069127a15f a1be84d3bfd460e72405f86cb0c150c871483124b837d61f11a72deae66067af 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Successfully bumped revision number for resource 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 (type: router_ports) to 1
[pid: 8|app: 0|req: 85/332] 10.64.49.168 () {40 vars in 1271 bytes} [Mon Jun 29 14:30:44 2026]  PUT  /v2.0/routers/c8300398-ff39-4a64-aeef-aa9d2b0a0d3a/add_router_interface => generated 310 bytes in 17123 msecs (HTTP/1.1 200) 4 headers in 157 bytes (1 switches on core 0)
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event [None req-fa687f09-ff64-4a68-a85d-40d287dcdfa6 - - - - - -] Event not matched due to this exception:
: AttributeError: Row instance has no attribute 'additional_chassis'
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event Traceback (most recent call last):
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovs/db/idl.py", line 1383, in __getattr__
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event     column = self._table.columns[column_name]
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event              ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event KeyError: 'additional_chassis'
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event During handling of the above exception, another exception occurred:
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event Traceback (most recent call last):
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovsdbapp/event.py", line 147, in match
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event     return candidate.matches(event, row, updates)
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovsdbapp/backend/ovs_idl/event.py", line 53, in matches
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event     if not self.match_fn(event, row, old):
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovsdb_monitor.py", line 287, in match_fn
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event     no_live_migration = (not row.additional_chassis or
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event                              ^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovs/db/idl.py", line 1385, in __getattr__
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event     raise AttributeError("%s instance has no attribute '%s'" %
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event AttributeError: Row instance has no attribute 'additional_chassis'
2026-06-29 14:31:01.124 9 ERROR ovsdbapp.event
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event [None req-fa687f09-ff64-4a68-a85d-40d287dcdfa6 - - - - - -] Event not matched due to this exception:
: AttributeError: Row instance has no attribute 'additional_chassis'
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event Traceback (most recent call last):
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovs/db/idl.py", line 1383, in __getattr__
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event     column = self._table.columns[column_name]
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event              ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event KeyError: 'additional_chassis'
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event During handling of the above exception, another exception occurred:
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event Traceback (most recent call last):
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovsdbapp/event.py", line 147, in match
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event     return candidate.matches(event, row, updates)
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovsdbapp/backend/ovs_idl/event.py", line 53, in matches
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event     if not self.match_fn(event, row, old):
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovsdb_monitor.py", line 287, in match_fn
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event     no_live_migration = (not row.additional_chassis or
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event                              ^^^^^^^^^^^^^^^^^^^^^^
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event   File "/var/lib/openstack/lib/python3.12/site-packages/ovs/db/idl.py", line 1385, in __getattr__
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event     raise AttributeError("%s instance has no attribute '%s'" %
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event AttributeError: Row instance has no attribute 'additional_chassis'
2026-06-29 14:31:01.404 9 ERROR ovsdbapp.event
2026-06-29 14:31:01.497 8 INFO neutron.db.ovn_revision_numbers_db [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] Successfully bumped revision number for resource 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 (type: ports) to 2
2026-06-29 14:31:01.497 8 INFO neutron.db.ovn_revision_numbers_db [None req-1f20a768-2157-4f05-ac06-40c1141b1a9f - - - - - -] Successfully bumped revision number for resource 7fd1b1b9-3f24-4411-b6bf-2f03519102d0 (type: ports) to 2
```
</details>

#### commands

```
~/flakez on  master [!+] ☸  uc_iad3_dev on ☁️  uc_iad_dev took 2s
❯ openstack router create marek-rtr-unflavored
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2026-06-29T14:29:26Z                 |
| description               |                                      |
| enable_default_route_bfd  | False                                |
| enable_default_route_ecmp | False                                |
| enable_ndp_proxy          | None                                 |
| enable_snat               | True                                 |
| evpn_vni                  | 4                                    |
| external_gateway_info     | null                                 |
| external_gateways         | []                                   |
| flavor_id                 | None                                 |
| ha                        | True                                 |
| id                        | c8300398-ff39-4a64-aeef-aa9d2b0a0d3a |
| name                      | marek-rtr-unflavored                 |
| project_id                | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number           | 1                                    |
| routes                    |                                      |
| status                    | ACTIVE                               |
| tags                      |                                      |
| updated_at                | 2026-06-29T14:29:26Z                 |
+---------------------------+--------------------------------------+

~/flakez on  master [!+] ☸  uc_iad3_dev on ☁️  uc_iad_dev
❯ openstack network create marek-test-unflavored
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2026-06-29T14:29:40Z                 |
| description               |                                      |
| dns_domain                | None                                 |
| id                        | 139cee36-b482-4f36-8730-21782d059e04 |
| ipv4_address_scope        | None                                 |
| ipv6_address_scope        | None                                 |
| is_default                | False                                |
| is_vlan_qinq              | None                                 |
| is_vlan_transparent       | False                                |
| l2_adjacency              | True                                 |
| mtu                       | 9000                                 |
| name                      | marek-test-unflavored                |
| port_security_enabled     | True                                 |
| project_id                | 32e02632f4f04415bab5895d1e7247b7     |
| provider:network_type     | vxlan                                |
| provider:physical_network | None                                 |
| provider:segmentation_id  | 1809                                 |
| qinq                      | False                                |
| qos_policy_id             | None                                 |
| revision_number           | 1                                    |
| router:external           | Internal                             |
| segments                  | None                                 |
| shared                    | False                                |
| status                    | ACTIVE                               |
| subnets                   |                                      |
| tags                      |                                      |
| updated_at                | 2026-06-29T14:29:40Z                 |
+---------------------------+--------------------------------------+

~/flakez on  master [!+] ☸  uc_iad3_dev on ☁️  uc_iad_dev
❯ openstack subnet create --network marek-test-unflavored --subnet-range 192.168.77.0/25 --no-dhcp  marek-test-unflavored-subnet
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| allocation_pools     | 192.168.77.2-192.168.77.126          |
| cidr                 | 192.168.77.0/25                      |
| created_at           | 2026-06-29T14:30:09Z                 |
| description          |                                      |
| dns_nameservers      |                                      |
| dns_publish_fixed_ip | None                                 |
| enable_dhcp          | False                                |
| gateway_ip           | 192.168.77.1                         |
| host_routes          |                                      |
| id                   | 74814534-6d45-4aa8-8fa5-818f33dd43a4 |
| ip_version           | 4                                    |
| ipv6_address_mode    | None                                 |
| ipv6_ra_mode         | None                                 |
| name                 | marek-test-unflavored-subnet         |
| network_id           | 139cee36-b482-4f36-8730-21782d059e04 |
| project_id           | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number      | 0                                    |
| router:external      | False                                |
| segment_id           | None                                 |
| service_types        |                                      |
| subnetpool_id        | None                                 |
| tags                 |                                      |
| updated_at           | 2026-06-29T14:30:09Z                 |
+----------------------+--------------------------------------+

~/flakez on  master [!+] ☸  uc_iad3_dev on ☁️  uc_iad_dev took 2s
❯ openstack router add subnet marek-rtr-unflavored marek-test-unflavored-subnet

❯ kubectl exec -it ovn-ovsdb-nb-0 -- ovn-nbctl show neutron-139cee36-b482-4f36-8730-21782d059e04
Defaulted container "ovsdb" out of: ovsdb, init (init)
switch 139cee36-b482-4f36-8730-21782d059e04 (neutron-139cee36-b482-4f36-8730-21782d059e04) (aka marek-test-unflavored)
    port 7fd1b1b9-3f24-4411-b6bf-2f03519102d0
        addresses: ["unknown"]
    port 961b8367-9183-4912-bbc2-75e5f4932e10 (aka uplink-faee4286-82a5-46cf-aa2a-2b1eb59bacd9)
        parent: b20be064-000d-47c2-9d4b-f11b3efe4027
        tag: 1804
        addresses: ["fa:16:3e:d0:c1:81"]
    port uplink-faee4286-82a5-46cf-aa2a-2b1eb59bacd9
        type: localnet
        tag: 1804
        addresses: ["unknown"]

```
