### PR TITLE
fix(docs): ensure 'uv' is available for the docs build

### DIFF
--- a/.github/workflows/properdocs.yaml
+++ b/.github/workflows/properdocs.yaml
@@ -39,6 +39,7 @@ jobs:
           python-version: 3.x
           cache: pip
           cache-dependency-path: requirements-docs.txt
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Check component docs coverage
         run: make component-docs-check
       - run: make docs


### PR DESCRIPTION
The docs now rely on 'uv' to build so ensure we have it installed.
