### PR TITLE
fix(ansible): Updates nova-post-deploy to gracefully handle empty flavor data

### DIFF
--- a/ansible/roles/nova_flavors/tasks/main.yml
+++ b/ansible/roles/nova_flavors/tasks/main.yml
@@ -30,11 +30,12 @@
           }
         })
       }}
-  loop: "{{ device_types_data | selectattr('class', 'equalto', 'server') | selectattr('resource_class', 'defined') | subelements('resource_class') }}"
+  loop: "{{ device_types_data | d([]) | selectattr('class', 'equalto', 'server') | selectattr('resource_class', 'defined') | subelements('resource_class') }}"
+  when: device_types_data | d([]) | length > 0
 
 - name: Loop through flavors and create Nova flavors
   ansible.builtin.include_tasks: nova_flavors.yml
-  loop: "{{ flavors_data }}"
+  loop: "{{ flavors_data | d([]) }}"
   loop_control:
     loop_var: flavor_item
 


### PR DESCRIPTION
I hit an error where if the flavors configmap is empty, the ansible errors. This change will set a default and add additional logic when building the flavor data.

``` text
TASK [nova_flavors : Loop through flavors and create Nova flavors] *************
[ERROR]: Task failed: 'flavors_data' is undefined

Task failed.
Origin: /runner/project/roles/nova_flavors/tasks/main.yml:35:3

33   loop: "{{ device_types_data | selectattr('class', 'equalto', 'server') | selectattr('resource_class', 'defined')...
34
35 - name: Loop through flavors and create Nova flavors
     ^ column 3

<<< caused by >>>

'flavors_data' is undefined
Origin: /runner/project/roles/nova_flavors/tasks/main.yml:37:9

35 - name: Loop through flavors and create Nova flavors
36   ansible.builtin.include_tasks: nova_flavors.yml
37   loop: "{{ flavors_data }}"
           ^ column 9

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: 'flavors_data' is undefined"}
```