### PR TITLE
feat(ironic): remove default deploy interface and set it in the workload and update enabled interfaces

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -48,17 +48,23 @@ conf:
     "baremetal:node:get_console": "((role:member and system_scope:all) or rule:service_role) or (role:service and system_scope:all) or (role:member and project_id:%(node.owner)s) or (role:service and project_id:%(node.owner)s) or (role:member and project_id:%(node.lessee)s)"
   ironic:
     DEFAULT:
+      # hardware types we have enabled in ironic
+      enabled_hardware_types: redfish,idrac,ilo5,ilo,netdev
+      # enabled interfaces for the above hardware types, each hardware type must
+      # have at least one enabled interface that it reports it supports
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo
-      enabled_boot_interfaces: http-ipxe,ipxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-ipxe
+      # remove fake once there is a noop that the ManualManagement uses, which netdev is derived from
+      enabled_boot_interfaces: http-ipxe,ipxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-ipxe,fake
+      enabled_console_interfaces: redfish-graphical,no-console
       enabled_deploy_interfaces: direct,ramdisk,noop
       enabled_firmware_interfaces: redfish,no-firmware
-      enabled_hardware_types: redfish,idrac,ilo5,ilo,netdev
-      enabled_inspect_interfaces: redfish,agent,idrac-redfish,ilo
-      enabled_management_interfaces: ipmitool,redfish,idrac-redfish,ilo,ilo5
+      enabled_inspect_interfaces: redfish,agent,idrac-redfish,ilo,no-inspect
+      enabled_management_interfaces: ipmitool,redfish,idrac-redfish,ilo,ilo5,noop
       enabled_network_interfaces: noop,neutron
-      enabled_power_interfaces: redfish,ipmitool,idrac-redfish,ilo
-      enabled_raid_interfaces: redfish,idrac-redfish,ilo5,agent
-      enabled_vendor_interfaces: redfish,ipmitool,idrac-redfish,ilo
+      # remove fake once there is a noop that the ManualManagement uses, which netdev is derived from
+      enabled_power_interfaces: redfish,ipmitool,idrac-redfish,ilo,fake
+      enabled_raid_interfaces: redfish,idrac-redfish,ilo5,agent,no-raid
+      enabled_vendor_interfaces: redfish,ipmitool,idrac-redfish,ilo,no-vendor
       # the service account belongs to the service project but our nodes
       # will live in the infra domain in the baremetal project so the
       # service account needs to have permissions outside of just the

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -49,7 +49,7 @@ conf:
   ironic:
     DEFAULT:
       # hardware types we have enabled in ironic
-      enabled_hardware_types: redfish,idrac,ilo5,ilo,netdev
+      enabled_hardware_types: redfish,idrac,ilo5,ilo,netdev,manual-management
       # enabled interfaces for the above hardware types, each hardware type must
       # have at least one enabled interface that it reports it supports
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -48,11 +48,6 @@ conf:
     "baremetal:node:get_console": "((role:member and system_scope:all) or rule:service_role) or (role:service and system_scope:all) or (role:member and project_id:%(node.owner)s) or (role:service and project_id:%(node.owner)s) or (role:member and project_id:%(node.lessee)s)"
   ironic:
     DEFAULT:
-      # We only want to default to direct, otherwise defaults interfere with hardware
-      # types selecting their own defaults. So we purposefully leave the defaults unset
-      # but enable everything that our Redfish focused (with iDRAC and iLO support)
-      # systems need
-      default_deploy_interface: direct
       enabled_bios_interfaces: no-bios,redfish,idrac-redfish,ilo
       enabled_boot_interfaces: http-ipxe,ipxe,redfish-virtual-media,redfish-https,idrac-redfish-virtual-media,ilo-virtual-media,ilo-uefi-https,ilo-ipxe
       enabled_deploy_interfaces: direct,ramdisk,noop

--- a/python/understack-workflows/tests/test_enroll_server.py
+++ b/python/understack-workflows/tests/test_enroll_server.py
@@ -266,6 +266,7 @@ def test_enrol_happy_path_uses_virtual_media_inspect_and_flips_back(mocker):
             "redfish_password": "calvin",
         },
         boot_interface="http-ipxe",
+        deploy_interface="direct",
         inspect_interface="idrac-redfish",
         extra={"external_cmdb_id": "cmdb-1"},
     )

--- a/python/understack-workflows/understack_workflows/ironic_node.py
+++ b/python/understack-workflows/understack_workflows/ironic_node.py
@@ -151,6 +151,7 @@ def create_ironic_node(
             "redfish_password": bmc.password,
         },
         "boot_interface": STEADY_STATE_BOOT_INTERFACE,
+        "deploy_interface": "direct",
         "inspect_interface": inspect_interface,
     }
     if external_cmdb_id:


### PR DESCRIPTION
Unfortunately due to https://bugs.launchpad.net/ironic/+bug/2158986 all hardware types must support default interfaces. This means we cannot set default deploy interface since netdev should be noop while other hardware types will use direct. So we remove that setting and pass it from the workflow. Then we set the enabled interfaces so that we have at least one for each of the used interfaces in our hardware types
