### PR TITLE
chore(ironic): bump up to latest understack/2026.1 change

### DIFF
--- a/containers/ironic/Dockerfile
+++ b/containers/ironic/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # renovate: name=openstack/ironic repo=https://github.com/rackerlabs/ironic.git branch=understack/2026.1
-ARG IRONIC_GIT_REF=e348a5f8bb2895c8304b06beef7835a85805b497
+ARG IRONIC_GIT_REF=09e61ba8010532358a5be065b6999b8aef5ea442
 ADD --keep-git-dir=true https://github.com/rackerlabs/ironic.git#${IRONIC_GIT_REF} /src/ironic
 RUN git -C /src/ironic fetch --unshallow --tags
 


### PR DESCRIPTION
This commit is a rebase of the current stable/2026.1 upstream with our
backports included.
https://github.com/openstack/ironic/compare/8b663209ff46ba2fbd05797ba7105b4f00e6dac4...e2fafdfa934817506b7fa04a40cab903af5612a4

