### PR TITLE
fix(ironic): Fix anti affinity rules for default and update replica count

### DIFF
--- a/charts/argocd-understack/templates/application-dex.yaml
+++ b/charts/argocd-understack/templates/application-dex.yaml
@@ -23,7 +23,7 @@ spec:
       - $understack/components/dex/values.yaml
       - $deploy/{{ include "understack.deploy_path" $ }}/dex/values.yaml
     repoURL: https://charts.dexidp.io
-    targetRevision: 0.24.0
+    targetRevision: 0.24.1
   - path: components/dex
     ref: understack
     repoURL: {{ include "understack.understack_url" $ }}

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -265,12 +265,15 @@ pod:
             configMap:
               name: ironic-inspection-rules
               optional: true
+  replicas:
+    api: 4
+    conductor: 1
   lifecycle:
     disruption_budget:
       api:
         # this should be set to no more than (pod.replicas.api - 1)
         # usually set on per-deployment basis.
-        min_available: 0
+        min_available: 1
   resources:
     enabled: true
     api:
@@ -290,7 +293,7 @@ pod:
   affinity:
     anti:
       type:
-        default: preferredDuringSchedulingIgnoredDuringExecution
+        default: ""
         conductor: requiredDuringSchedulingIgnoredDuringExecution
       topologyKey:
         default: kubernetes.io/hostname


### PR DESCRIPTION
The ironic-api deployment included anti-affinity rules (under 'default' section), and uses 4 replicas, but we only have 3 noddes. This combination with `preferredDuringSchedulingIgnoredDuringExecution` prevents our ability to deploy the ironic-api as it’s just stuck forever scheduling due to never meeting these combined conditions.
