### PR TITLE
chore(ironic): Set replicas and minimum available to be the same across all environments.

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -265,12 +265,15 @@ pod:
             configMap:
               name: ironic-inspection-rules
               optional: true
+  replicas:
+    api: 4
+    conductor: 1
+    novncproxy: 1
   lifecycle:
     disruption_budget:
       api:
-        # this should be set to no more than (pod.replicas.api - 1)
-        # usually set on per-deployment basis.
-        min_available: 0
+        # allow for zero downtime ironic-api deployments by keeping an api node online
+        min_available: 1
   resources:
     enabled: true
     api:


### PR DESCRIPTION
The ironic-api deployment included anti-affinity rules (under 'default' section), and uses 4 replicas, but we only have 3 noddes. This combination with preferredDuringSchedulingIgnoredDuringExecution prevents our ability to deploy the ironic-api as it’s just stuck forever scheduling due to never meeting these combined conditions.