### PR TITLE
chore(neutron): bump up to latest understack/2026.1 change

### DIFF
--- a/containers/neutron/Dockerfile
+++ b/containers/neutron/Dockerfile
@@ -6,7 +6,7 @@ FROM quay.io/airshipit/neutron:${OPENSTACK_VERSION}-ubuntu_noble AS build
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # renovate: name=openstack/neutron repo=https://github.com/rackerlabs/neutron.git branch=understack/2026.1
-ARG NEUTRON_GIT_REF=f02658b3721de198f2dac04e7eb64ef9eb320732
+ARG NEUTRON_GIT_REF=51f968afde5eb80c04e0bd01391e9e3344812c9a
 ADD --keep-git-dir=true https://github.com/rackerlabs/neutron.git#${NEUTRON_GIT_REF} /src/neutron
 RUN git -C /src/neutron fetch --unshallow --tags
 


### PR DESCRIPTION
This commit is a rebase of the current stable/2026.1 upstream with our
backports included.
https://github.com/openstack/neutron/compare/1321ccbc5cd56d5502e2335c8a5a374801d88fb9...2bc474a7db20f837cabfd60de1ebd3fa0c51f736

