### PR TITLE
feat(neutron): Prevent SVI routers from using external gateways PUC-1754

### DIFF
--- a/python/neutron-understack/neutron_understack/l3_router/svi.py
+++ b/python/neutron-understack/neutron_understack/l3_router/svi.py
@@ -335,6 +335,39 @@ class Svi(base.L3ServiceProvider):
         # flavor -> provider -> driver lookup.
         return _is_svi_router(context, router)
 
+    @registry.receives(resources.ROUTER_GATEWAY, [events.BEFORE_CREATE])
+    def _reject_svi_external_gateway(self, _resource, _event, _trigger, payload):
+        context = payload.context
+        router_id = payload.resource_id
+        router = self.l3plugin.get_router(context, router_id)
+
+        if not self._is_svi_flavor(context, router):
+            LOG.debug(
+                "SVI gateway check skipped: router %(router)s is not SVI "
+                "(name=%(name)s flavor=%(flavor)s)",
+                {
+                    "router": router_id,
+                    "name": router.get("name"),
+                    "flavor": router.get("flavor_id"),
+                },
+            )
+            return
+
+        network_id = (payload.metadata or {}).get("network_id")
+        LOG.warning(
+            "SVI gateway check FAILED: router %(router)s (%(name)s) cannot "
+            "have an external gateway network %(network)s",
+            {
+                "router": router_id,
+                "name": router.get("name"),
+                "network": network_id,
+            },
+        )
+        raise n_exc.BadRequest(
+            resource="router",
+            msg="SVI routers cannot have an external gateway.",
+        )
+
     @registry.receives(resources.ROUTER_INTERFACE, [events.BEFORE_CREATE])
     def _validate_svi_router_interface(self, _resource, _event, _trigger, payload):
         router = payload.states[0]

--- a/python/neutron-understack/neutron_understack/tests/test_svi.py
+++ b/python/neutron-understack/neutron_understack/tests/test_svi.py
@@ -283,3 +283,67 @@ class TestValidateSviRouterInterfaceCallback:
 
         assert "must belong to an address scope" in str(exc_info.value)
         assert "attach_mode=port" in caplog.text
+
+
+class TestRejectSviExternalGatewayCallback:
+    def test_rejects_svi_router_external_gateway(self, caplog, mocker):
+        router = {"id": "router-a", "name": "svi-router", "flavor_id": "flavor-a"}
+        l3_plugin = FakeL3Plugin(router)
+        flavor_plugin = FakeFlavorPlugin(_svi_driver())
+        _patch_plugins(
+            mocker,
+            core_plugin=FakeCorePlugin({}),
+            l3_plugin=l3_plugin,
+            flavor_plugin=flavor_plugin,
+        )
+        provider = svi.Svi(l3_plugin)
+        payload = SimpleNamespace(
+            context="context",
+            resource_id="router-a",
+            metadata={"network_id": "external-net"},
+        )
+
+        caplog.set_level(logging.WARNING, logger=svi.LOG.name)
+        with pytest.raises(n_exc.BadRequest) as exc_info:
+            provider._reject_svi_external_gateway(None, None, None, payload)
+
+        assert "cannot have an external gateway" in str(exc_info.value)
+        assert "SVI gateway check FAILED" in caplog.text
+        assert "external-net" in caplog.text
+
+    def test_allows_non_svi_router_external_gateway(self, mocker):
+        router = {"id": "router-a", "name": "vrf-router", "flavor_id": "flavor-a"}
+        l3_plugin = FakeL3Plugin(router)
+        flavor_plugin = FakeFlavorPlugin("neutron_understack.l3_router.vrf.Vrf")
+        _patch_plugins(
+            mocker,
+            core_plugin=FakeCorePlugin({}),
+            l3_plugin=l3_plugin,
+            flavor_plugin=flavor_plugin,
+        )
+        provider = svi.Svi(l3_plugin)
+        payload = SimpleNamespace(
+            context="context",
+            resource_id="router-a",
+            metadata={"network_id": "external-net"},
+        )
+
+        provider._reject_svi_external_gateway(None, None, None, payload)
+
+    def test_allows_router_without_flavor(self, mocker):
+        router = {"id": "router-a", "name": "plain-router", "flavor_id": None}
+        l3_plugin = FakeL3Plugin(router)
+        _patch_plugins(
+            mocker,
+            core_plugin=FakeCorePlugin({}),
+            l3_plugin=l3_plugin,
+            flavor_plugin=FakeFlavorPlugin(_svi_driver()),
+        )
+        provider = svi.Svi(l3_plugin)
+        payload = SimpleNamespace(
+            context="context",
+            resource_id="router-a",
+            metadata={"network_id": "external-net"},
+        )
+
+        provider._reject_svi_external_gateway(None, None, None, payload)


### PR DESCRIPTION
https://rackspace.atlassian.net/browse/PUC-1754

A single subscriber on the Svi class, resources.ROUTER_GATEWAY, [events.BEFORE_CREATE] , It fires before the gateway port is created, so nothing is written or rolled back. Neutron's callback-failure handler re-raises the underlying exception directly (raise e.errors[0].error), giving a Badrequest. 

iAd-dev testing :
**scenerio 1:  create SVI flavoured router add external gateway** 
```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack router create --flavor svi nidhi-svi-router
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2026-07-09T12:50:10Z                 |
| description               |                                      |
| enable_default_route_bfd  | False                                |
| enable_default_route_ecmp | False                                |
| enable_ndp_proxy          | None                                 |
| enable_snat               | True                                 |
| evpn_vni                  | 5                                    |
| external_gateway_info     | null                                 |
| external_gateways         | []                                   |
| flavor_id                 | e07c2c5f-9ac2-479a-a2ac-923872d0aff6 |
| ha                        | False                                |
| id                        | 6bedbc83-423d-45da-bbdb-9abc120e6e1d |
| name                      | nidhi-svi-router                     |
| project_id                | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number           | 1                                    |
| routes                    |                                      |
| status                    | ACTIVE                               |
| tags                      |                                      |
| updated_at                | 2026-07-09T12:50:10Z                 |
+---------------------------+--------------------------------------+
(openstack)
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack router set --external-gateway PUBLICNET nidhi-svi-router
BadRequestException: 400: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/routers/6bedbc83-423d-45da-bbdb-9abc120e6e1d/update_external_gateways, Bad router request: SVI routers cannot have an external gateway..
(openstack)
``` 

**scenerio 2 : Assign ext gateway while creating svi router** 

```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 2s
❯ openstack router create --flavor svi  --external-gateway PUBLICNET nidhi-svi-router
BadRequestException: 400: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/routers/7234dc0d-8a70-431d-ba32-54cd3539e3f0/update_external_gateways, Bad router request: SVI routers cannot have an external gateway..
(openstack)

``` 
**[Multihoming lets one router have multiple external gateway ports at the same time, instead of only one classic external_gateway_info gateway.]
Scenerio 4: Multihoming : The router ended up with multiple entries in external_gateways**

```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack router add gateway nidhi-dupe-router PUBLICNET

~ 🐍 openstack on ☁️  uc-dev-infra(baremetal)
❯ openstack router show nidhi-dupe-router
+---------------------------+----------------------------------------------------------------------------------------------------------------------+
| Field                     | Value                                                                                                                |
+---------------------------+----------------------------------------------------------------------------------------------------------------------+
| admin_state_up            | UP                                                                                                                   |
| availability_zone_hints   |                                                                                                                      |
| availability_zones        |                                                                                                                      |
| created_at                | 2026-07-06T12:53:41Z                                                                                                 |
| description               |                                                                                                                      |
| enable_default_route_bfd  | False                                                                                                                |
| enable_default_route_ecmp | False                                                                                                                |
| enable_ndp_proxy          | None                                                                                                                 |
| enable_snat               | True                                                                                                                 |
| evpn_vni                  | 1                                                                                                                    |
| external_gateway_info     | {"network_id": "356bb8c1-1470-452f-99e2-6252585c847a", "external_fixed_ips": [{"subnet_id":                          |
|                           | "36ecd265-c0cc-4079-ad73-1101164b4a5f", "ip_address": "204.232.163.34"}], "enable_snat": true}                       |
| external_gateways         | [{'network_id': '356bb8c1-1470-452f-99e2-6252585c847a', 'external_fixed_ips': [{'ip_address': '204.232.163.34',      |
|                           | 'subnet_id': '36ecd265-c0cc-4079-ad73-1101164b4a5f'}]}, {'network_id': '356bb8c1-1470-452f-99e2-6252585c847a',       |
|                           | 'external_fixed_ips': [{'ip_address': '204.232.163.31', 'subnet_id': '36ecd265-c0cc-4079-ad73-1101164b4a5f'}]}]      |
| flavor_id                 | None                                                                                                                 |
| ha                        | True                                                                                                                 |
| id                        | ed470efc-f119-4040-b0c1-123ae7784728                                                                                 |
| interfaces_info           | [{"port_id": "60080097-9727-4968-9dcd-10065871f049", "ip_address": "10.250.91.1", "subnet_id":                       |
|                           | "130d60d9-7408-42b4-a004-c82c49290e3f"}]                                                                             |
| name                      | nidhi-dupe-router                                                                                                    |
| project_id                | 32e02632f4f04415bab5895d1e7247b7                                                                                     |
| revision_number           | 4                                                                                                                    |
| routes                    |                                                                                                                      |
| status                    | ACTIVE                                                                                                               |
| tags                      |                                                                                                                      |
| updated_at                | 2026-07-09T12:57:49Z                                                                                                 |
+---------------------------+----------------------------------------------------------------------------------------------------------------------+


``` 

**scenerio 4 : non-svi router are not impacted** 


```shell
openstack router create nidhi-plain-router
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 2s
❯ openstack router set --external-gateway PUBLICNET nidhi-plain-router
(openstack)
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 8s
❯ openstack router show nidhi-plain-router -c flavor_id -c external_gateway_info -c external_gateways
+-----------------------+--------------------------------------------------------------------------------------------------------------------------+
| Field                 | Value                                                                                                                    |
+-----------------------+--------------------------------------------------------------------------------------------------------------------------+
| external_gateway_info | {"network_id": "356bb8c1-1470-452f-99e2-6252585c847a", "external_fixed_ips": [{"subnet_id":                              |
|                       | "36ecd265-c0cc-4079-ad73-1101164b4a5f", "ip_address": "204.232.163.52"}], "enable_snat": true}                           |
| external_gateways     | [{'network_id': '356bb8c1-1470-452f-99e2-6252585c847a', 'external_fixed_ips': [{'ip_address': '204.232.163.52',          |
|                       | 'subnet_id': '36ecd265-c0cc-4079-ad73-1101164b4a5f'}]}]                                                                  |
| flavor_id             | None                                                                                                                     |
+-----------------------+--------------------------------------------------------------------------------------------------------------------------+
(openstack)
``` 

Known limitation [WIP]
A legacy SVI router that already had a gateway before this change could still receive additional gateways via the multihoming extra-gateway path (which skips ROUTER_GATEWAY BEFORE_CREATE). Not reachable in normal forward operation, since new SVI routers can never acquire a first gateway.