### PR TITLE
fix(nautobot-permissions): Adds nautobot jobresult permission to view job results

### DIFF
--- a/ansible/roles/nautobot_permissions/defaults/main.yml
+++ b/ansible/roles/nautobot_permissions/defaults/main.yml
@@ -108,8 +108,10 @@ nautobot_permissions_permissions:
       - change
       - view
     object_types:
+      - extras.fileproxy
       - extras.job
       - extras.jobqueue
+      - extras.jobresult
   storage-admin:
     description: System admin read/change access for storage items
     enabled: true


### PR DESCRIPTION
Nautobot changed the way the device exporting to CSV works and changed it to be a job which runs and then you download a file. The old permissions didn't work for this new flow and we're getting permissions errors. These new permissions allow admins to successfully export devices to CSV and download the CSV file now.

https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/guides/permissions/#export-job