### PR TITLE
feat: Add enroll-netdev Argo workflow to enroll network devices PUC-1761

### DIFF
--- a/python/understack-workflows/pyproject.toml
+++ b/python/understack-workflows/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.scripts]
 bmc-kube-password = "understack_workflows.main.bmc_display_password:main"
 bmc-password = "understack_workflows.main.print_bmc_password:main"
+enroll-netdev = "understack_workflows.main.enroll_netdev:main"
 enroll-server = "understack_workflows.main.enroll_server:main"
 netapp-configure-interfaces = "understack_workflows.main.netapp_configure_net:main"
 netapp-create-svm = "understack_workflows.main.netapp_create_svm:main"

--- a/python/understack-workflows/tests/test_enroll_netdev.py
+++ b/python/understack-workflows/tests/test_enroll_netdev.py
@@ -1,0 +1,165 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from unittest.mock import call
+
+from understack_workflows import ironic_node
+from understack_workflows.main import enroll_netdev
+
+
+def make_ironic_client():
+    fake_client = MagicMock()
+    node = SimpleNamespace(uuid="node-123")
+    fake_client.node.create.return_value = node
+    fake_client.port.create.side_effect = [
+        SimpleNamespace(uuid="port-1"),
+        SimpleNamespace(uuid="port-2"),
+    ]
+    return fake_client, node
+
+
+def test_enroll_creates_node_ports_logs_and_makes_available(mocker, caplog):
+    caplog.set_level(logging.INFO)
+    fake_ironic, node = make_ironic_client()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(
+        name="leaf01",
+        physical_network="f20-1-network",
+        port1_mac="00:11:22:33:44:55",
+        port1_switch="spine01.example.net",
+        port1_intf="Ethernet1/1",
+        port2_mac="00:11:22:33:44:66",
+        port2_switch="spine02.example.net",
+        port2_intf="Ethernet1/2",
+        resource_class=None,
+    )
+
+    fake_ironic.node.create.assert_called_once_with(
+        automated_clean=False,
+        driver="netdev",
+        name="leaf01",
+        resource_class="generic",
+    )
+    fake_ironic.port.create.assert_has_calls(
+        [
+            call(
+                address="00:11:22:33:44:55",
+                category="network",
+                local_link_connection={
+                    "switch_id": "00:00:00:00:00:00",
+                    "switch_info": "spine01.example.net",
+                    "port_id": "Ethernet1/1",
+                },
+                name="leaf01:port1",
+                node_uuid=node.uuid,
+                physical_network="f20-1-network",
+            ),
+            call(
+                address="00:11:22:33:44:66",
+                category="network",
+                local_link_connection={
+                    "switch_id": "00:00:00:00:00:00",
+                    "switch_info": "spine02.example.net",
+                    "port_id": "Ethernet1/2",
+                },
+                name="leaf01:port2",
+                node_uuid=node.uuid,
+                physical_network="f20-1-network",
+            ),
+        ]
+    )
+    fake_ironic.node.set_provision_state.assert_has_calls(
+        [
+            call(
+                node.uuid,
+                "manage",
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                node.uuid,
+                "provide",
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+        ]
+    )
+    fake_ironic.node.wait_for_provision_state.assert_has_calls(
+        [
+            call(
+                node.uuid,
+                "manageable",
+                timeout=ironic_node.NODE_STATE_TIMEOUT_SECS,
+            ),
+            call(
+                node.uuid,
+                "available",
+                timeout=ironic_node.NODE_STATE_TIMEOUT_SECS,
+            ),
+        ]
+    )
+    assert "Starting enroll-netdev workflow name=leaf01" in caplog.text
+    assert "Created netdev Ironic node name=leaf01 uuid=node-123" in caplog.text
+    assert "[node:node-123] Created baremetal port name=leaf01:port1" in caplog.text
+    assert "[node:node-123] Node is available" in caplog.text
+
+
+def test_enroll_records_external_cmdb_id_and_custom_resource_class(mocker):
+    fake_ironic, _ = make_ironic_client()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(
+        name="leaf01",
+        physical_network="f20-1-network",
+        port1_mac="00:11:22:33:44:55",
+        port1_switch="spine01.example.net",
+        port1_intf="Ethernet1/1",
+        port2_mac="00:11:22:33:44:66",
+        port2_switch="spine02.example.net",
+        port2_intf="Ethernet1/2",
+        external_cmdb_id="cmdb-1",
+        resource_class="switch",
+    )
+
+    fake_ironic.node.create.assert_called_once_with(
+        automated_clean=False,
+        driver="netdev",
+        name="leaf01",
+        resource_class="switch",
+        extra={"external_cmdb_id": "cmdb-1"},
+    )
+
+
+def test_argument_parser_defaults_resource_class_to_generic():
+    args = enroll_netdev.argument_parser().parse_args(
+        [
+            "--name",
+            "leaf01",
+            "--physical-network",
+            "f20-1-network",
+            "--port1-mac",
+            "00:11:22:33:44:55",
+            "--port1-switch",
+            "spine01.example.net",
+            "--port1-intf",
+            "Ethernet1/1",
+            "--port2-mac",
+            "00:11:22:33:44:66",
+            "--port2-switch",
+            "spine02.example.net",
+            "--port2-intf",
+            "Ethernet1/2",
+        ]
+    )
+
+    assert args.resource_class == "generic"
+    assert args.external_cmdb_id == ""

--- a/python/understack-workflows/understack_workflows/main/enroll_netdev.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_netdev.py
@@ -1,0 +1,227 @@
+import argparse
+import logging
+import os
+from dataclasses import dataclass
+
+from ironicclient.v1.node import Node
+
+from understack_workflows import helpers
+from understack_workflows import ironic_node
+from understack_workflows.ironic.client import IronicClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NetdevPort:
+    label: str
+    mac: str
+    switch: str
+    interface: str
+
+
+def main() -> None:
+    """Create a netdev baremetal node, its 2 ports, and make it available."""
+    helpers.setup_logger()
+    args = argument_parser().parse_args()
+
+    enroll(
+        name=args.name,
+        physical_network=args.physical_network,
+        port1_mac=args.port1_mac,
+        port1_switch=args.port1_switch,
+        port1_intf=args.port1_intf,
+        port2_mac=args.port2_mac,
+        port2_switch=args.port2_switch,
+        port2_intf=args.port2_intf,
+        external_cmdb_id=args.external_cmdb_id,
+        resource_class=args.resource_class,
+    )
+
+
+def enroll(
+    *,
+    name: str,
+    physical_network: str,
+    port1_mac: str,
+    port1_switch: str,
+    port1_intf: str,
+    port2_mac: str,
+    port2_switch: str,
+    port2_intf: str,
+    external_cmdb_id: int | str | None = None,
+    resource_class: str | None = "generic",
+) -> None:
+    effective_resource_class = resource_class or "generic"
+    logger.info(
+        "Starting enroll-netdev workflow name=%s physical_network=%s "
+        "resource_class=%s",
+        name,
+        physical_network,
+        effective_resource_class,
+    )
+
+    if external_cmdb_id:
+        logger.info(
+            "Recording external_cmdb_id=%s on the Ironic node",
+            external_cmdb_id,
+        )
+    else:
+        logger.info("No external_cmdb_id provided")
+
+    client = IronicClient()
+    node = create_netdev_node(
+        client=client,
+        name=name,
+        resource_class=effective_resource_class,
+        external_cmdb_id=external_cmdb_id,
+    )
+
+    ports = [
+        NetdevPort("port1", port1_mac, port1_switch, port1_intf),
+        NetdevPort("port2", port2_mac, port2_switch, port2_intf),
+    ]
+    for port in ports:
+        create_netdev_port(
+            client=client,
+            node=node,
+            node_name=name,
+            physical_network=physical_network,
+            port=port,
+        )
+
+    logger.info(
+        "[node:%s] Requesting manage transition, expecting manageable",
+        node.uuid,
+    )
+    ironic_node.transition(node, target_state="manage", expected_state="manageable")
+    logger.info("[node:%s] Node is manageable", node.uuid)
+
+    logger.info(
+        "[node:%s] Requesting provide transition, expecting available",
+        node.uuid,
+    )
+    ironic_node.transition(node, target_state="provide", expected_state="available")
+    logger.info("[node:%s] Node is available", node.uuid)
+    logger.info(
+        "Completed enroll-netdev workflow name=%s node_uuid=%s",
+        name,
+        node.uuid,
+    )
+
+
+def create_netdev_node(
+    *,
+    client: IronicClient,
+    name: str,
+    resource_class: str,
+    external_cmdb_id: int | str | None = None,
+) -> Node:
+    node_data = {
+        "automated_clean": False,
+        "driver": "netdev",
+        "name": name,
+        "resource_class": resource_class,
+    }
+    if external_cmdb_id:
+        node_data["extra"] = {"external_cmdb_id": external_cmdb_id}
+
+    logger.info(
+        "Creating netdev Ironic node name=%s driver=%s "
+        "resource_class=%s automated_clean=%s",
+        node_data["name"],
+        node_data["driver"],
+        node_data["resource_class"],
+        node_data["automated_clean"],
+    )
+    node = client.create_node(node_data)
+    logger.info("Created netdev Ironic node name=%s uuid=%s", name, node.uuid)
+    return node
+
+
+def create_netdev_port(
+    *,
+    client: IronicClient,
+    node: Node,
+    node_name: str,
+    physical_network: str,
+    port: NetdevPort,
+) -> None:
+    port_name = f"{node_name}:{port.label}"
+    port_data = {
+        "address": port.mac,
+        "category": "network",
+        "local_link_connection": {
+            "switch_id": "00:00:00:00:00:00",
+            "switch_info": port.switch,
+            "port_id": port.interface,
+        },
+        "name": port_name,
+        "node_uuid": node.uuid,
+        "physical_network": physical_network,
+    }
+
+    logger.info(
+        "[node:%s] Creating baremetal port name=%s mac=%s "
+        "physical_network=%s switch_id=%s switch_info=%s port_id=%s "
+        "category=network",
+        node.uuid,
+        port_name,
+        port.mac,
+        physical_network,
+        "00:00:00:00:00:00",
+        port.switch,
+        port.interface,
+    )
+    created_port = client.create_port(port_data)
+    logger.info(
+        "[node:%s] Created baremetal port name=%s uuid=%s",
+        node.uuid,
+        port_name,
+        getattr(created_port, "uuid", ""),
+    )
+
+
+def argument_parser():
+    parser = argparse.ArgumentParser(
+        prog=os.path.basename(__file__),
+        description="Run the netdev enroll workflow",
+    )
+    parser.add_argument("--name", required=True, help="Ironic node name")
+    parser.add_argument(
+        "--physical-network",
+        required=True,
+        help="Port physical_network",
+    )
+    parser.add_argument("--port1-mac", required=True, help="MAC address for port1")
+    parser.add_argument("--port1-switch", required=True, help="Switch name for port1")
+    parser.add_argument(
+        "--port1-intf",
+        required=True,
+        help="Switch interface name for port1",
+    )
+    parser.add_argument("--port2-mac", required=True, help="MAC address for port2")
+    parser.add_argument("--port2-switch", required=True, help="Switch name for port2")
+    parser.add_argument(
+        "--port2-intf",
+        required=True,
+        help="Switch interface name for port2",
+    )
+    parser.add_argument(
+        "--external-cmdb-id",
+        type=helpers.int_or_str,
+        required=False,
+        default="",
+        help="CMDB ID",
+    )
+    parser.add_argument(
+        "--resource-class",
+        required=False,
+        default="generic",
+        help="Ironic resource class",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/argo-events/kustomization.yaml
+++ b/workflows/argo-events/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - workflowtemplates/sync-provision-state-to-nautobot.yaml
   - workflowtemplates/undersync-switch.yaml
   - workflowtemplates/keystone-event-project.yaml
+  - workflowtemplates/enroll-netdev.yaml
   - workflowtemplates/enroll-server.yaml
   - workflowtemplates/reclean-server.yaml
   - workflowtemplates/openstack-oslo-event.yaml

--- a/workflows/argo-events/workflowtemplates/enroll-netdev.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-netdev.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: enroll-netdev
+  annotations:
+    workflows.argoproj.io/title: Enroll a network device in Ironic
+    workflows.argoproj.io/description: |
+      Defined in `workflows/argo-events/workflowtemplates/enroll-netdev.yaml`
+kind: WorkflowTemplate
+spec:
+  serviceAccountName: workflow
+  entrypoint: main
+  volumes:
+    - name: baremetal-manage
+      secret:
+        secretName: baremetal-manage
+        items:
+          - key: clouds.yaml
+            path: clouds.yaml
+  arguments:
+    parameters:
+      - name: name
+      - name: physical_network
+      - name: port1_mac
+      - name: port1_switch
+      - name: port1_intf
+      - name: port2_mac
+      - name: port2_switch
+      - name: port2_intf
+      - name: external_cmdb_id
+        value: ""
+      - name: resource_class
+        value: generic
+  templates:
+    - name: main
+      steps:
+        - - name: enroll-netdev
+            template: enroll-netdev
+    - name: enroll-netdev
+      container:
+        image: ghcr.io/rackerlabs/understack/ironic-nautobot-client:latest
+        command:
+          - enroll-netdev
+        args:
+          - --name
+          - "{{workflow.parameters.name}}"
+          - --physical-network
+          - "{{workflow.parameters.physical_network}}"
+          - --port1-mac
+          - "{{workflow.parameters.port1_mac}}"
+          - --port1-switch
+          - "{{workflow.parameters.port1_switch}}"
+          - --port1-intf
+          - "{{workflow.parameters.port1_intf}}"
+          - --port2-mac
+          - "{{workflow.parameters.port2_mac}}"
+          - --port2-switch
+          - "{{workflow.parameters.port2_switch}}"
+          - --port2-intf
+          - "{{workflow.parameters.port2_intf}}"
+          - --external-cmdb-id
+          - "{{workflow.parameters.external_cmdb_id}}"
+          - --resource-class
+          - "{{workflow.parameters.resource_class}}"
+        volumeMounts:
+          - mountPath: /etc/openstack
+            name: baremetal-manage
+            readOnly: true
+        envFrom:
+          - configMapRef:
+              name: cluster-metadata
+        env:
+          - name: WF_NS
+            value: "{{workflow.namespace}}"
+          - name: WF_NAME
+            value: "{{workflow.name}}"
+          - name: WF_UID
+            value: "{{workflow.uid}}"
+          - name: OS_CLOUD
+            value: understack


### PR DESCRIPTION
Implemented `enroll-netdev` WorkflowTemplate and Python entrypoint following the `enroll-server` pattern.

Validated in iad-dev by pointing rax-dev-iad3-dev-argo-events-workflows at this branch and using the pr workflow image.

```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack baremetal node show fake-netdev-test
+------------------------+--------------------------------------+
| Field                  | Value                                |
+------------------------+--------------------------------------+
| uuid                   | 17f00775-f4c1-405f-83ab-685cb0aeb354 |
| created_at             | 2026-07-16T15:07:48+00:00            |
| updated_at             | 2026-07-16T15:07:51+00:00            |
| automated_clean        | False                                |
| bios_interface         | no-bios                              |
| boot_interface         | ipxe                                 |
| boot_mode              | None                                 |
| clean_step             | {}                                   |
| conductor_group        |                                      |
| console_enabled        | False                                |
| console_interface      | no-console                           |
| disable_power_off      | False                                |
| deploy_interface       | noop                                 |
| deploy_step            | {}                                   |
| description            | None                                 |
| driver                 | netdev                               |
| driver_info            | {}                                   |
| driver_internal_info   | {}                                   |
| extra                  | {}                                   |
| fault                  | None                                 |
| firmware_interface     | no-firmware                          |
| health                 | None                                 |
| inspection_finished_at | None                                 |
| inspection_started_at  | None                                 |
| inspect_interface      | no-inspect                           |
| instance_info          | {}                                   |
| instance_name          | None                                 |
| instance_uuid          | None                                 |
| last_error             | None                                 |
| lessee                 | None                                 |
| maintenance            | False                                |
| maintenance_reason     | None                                 |
| management_interface   | fake                                 |
| name                   | fake-netdev-test                     |
| network_data           | {}                                   |
| network_interface      | neutron                              |
| owner                  | 32e02632f4f04415bab5895d1e7247b7     |
| parent_node            | None                                 |
| power_interface        | fake                                 |
| power_state            | None                                 |
| properties             | {}                                   |
| protected              | False                                |
| protected_reason       | None                                 |
| provision_state        | available                            |
| provision_updated_at   | 2026-07-16T15:07:51+00:00            |
| raid_config            | {}                                   |
| raid_interface         | no-raid                              |
| rescue_interface       | no-rescue                            |
| reservation            | None                                 |
| resource_class         | generic                              |
| retired                | False                                |
| retired_reason         | None                                 |
| secure_boot            | None                                 |
| service_step           | {}                                   |
| shard                  | None                                 |
| storage_interface      | noop                                 |
| target_power_state     | None                                 |
| target_provision_state | None                                 |
| target_raid_config     | {}                                   |
| traits                 | []                                   |
| vendor_interface       | no-vendor                            |
| conductor              | 1327175-hp3                          |
| allocation_uuid        | None                                 |
| chassis_uuid           | None                                 |
+------------------------+--------------------------------------+

~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack baremetal node show fake-netdev-test2 -c provision_state -c resource_class -c extra
+-----------------+-------------------------------------+
| Field           | Value                               |
+-----------------+-------------------------------------+
| extra           | {'external_cmdb_id': 'fake-cmdb-1'} |
| provision_state | available                           |
| resource_class  | fake-class                          |
+-----------------+-------------------------------------+ 

``` 
Happy Path Log 
```shell
~ 🐍 openstack took 17s
❯ argo -n argo-events logs @latest -f
Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:03 +0000 - understack_workflows.main.enroll_netdev - INFO - Starting enroll-netdev workflow name=fake-netdev-test2 physical_network=fake-physnet resource_class=fake-class
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:03 +0000 - understack_workflows.main.enroll_netdev - INFO - Recording external_cmdb_id=fake-cmdb-1 on the Ironic node
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:04 +0000 - understack_workflows.main.enroll_netdev - INFO - Creating netdev Ironic node name=fake-netdev-test2 driver=netdev resource_class=fake-class automated_clean=false
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:05 +0000 - understack_workflows.main.enroll_netdev - INFO - Created netdev Ironic node name=fake-netdev-test2 uuid=a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:05 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Creating baremetal port name=fake-netdev-test2:port1 mac=02:de:ad:be:ef:03 physical_network=fake-physnet switch_id=00:00:00:00:00:00 switch_info=fake-switch-1 port_id=FakeEth1/1 category=network
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:05 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Created baremetal port name=fake-netdev-test2:port1 uuid=144baaf7-cd64-4c26-829b-ef4185199f1a
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:05 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Creating baremetal port name=fake-netdev-test2:port2 mac=02:de:ad:be:ef:04 physical_network=fake-physnet switch_id=00:00:00:00:00:00 switch_info=fake-switch-2 port_id=FakeEth1/2 category=network
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:06 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Created baremetal port name=fake-netdev-test2:port2 uuid=2e719423-80c3-435a-a5db-051e35e8e12b
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:06 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Requesting manage transition, expecting manageable
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:06 +0000 - understack_workflows.ironic_node - INFO - a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e requesting provision state manage
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:07 +0000 - understack_workflows.ironic_node - INFO - Waiting for node a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e to enter provision state manageable
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:07 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Node is manageable
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:07 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Requesting provide transition, expecting available
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:08 +0000 - understack_workflows.ironic_node - INFO - a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e requesting provision state provide
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:09 +0000 - understack_workflows.ironic_node - INFO - Waiting for node a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e to enter provision state available
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:09 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e] Node is available
enroll-netdev-kh2rr-enroll-netdev-2452634961: 2026-07-16 15:19:09 +0000 - understack_workflows.main.enroll_netdev - INFO - Completed enroll-netdev workflow name=fake-netdev-test2 node_uuid=a92ce5c6-6f73-4ad8-bc87-ab50dc98d04e
enroll-netdev-kh2rr-enroll-netdev-2452634961: time="2026-07-16T15:19:10.105Z" level=info msg="sub-process exited" argo=true error="<nil>"

``` 

Test evidence:
- Submitted via `argo -n argo-events submit --from wftmpl/enroll-netdev`.
- Node was created with driver netdev.
- automated_clean is False.
- Node reached available.
- Default resource_class worked as generic.
- Custom resource_class worked.
- external_cmdb_id was recorded in node extra.
- Two baremetal ports were created with:
  - `category=network`
  - placeholder `switch_id=00:00:00:00:00:00`
  - expected `switch_info`
  - expected `port_id`
  - expected `physical_network`
  - 
```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack baremetal port list --node fake-netdev-test --long
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+--------------+
| uuid     | address  | created_at | extra | node_uuid | category | vendor | local_link_connection | portgroup_uuid | pxe_enabled | physical_network | updated_at | internal_info | is_smartnic | name         |
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+--------------+
| ed4f8928 | 02:de:ad | 2026-07-   |       | 17f00775- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None       | {}            | False       | fake-netdev- |
| -f073-   | :be:ef:0 | 16T15:07:4 |       | f4c1-     |          |        | '00:00:00:00:00:00',  |                |             |                  |            |               |             | test:port1   |
| 4a70-    | 1        | 8+00:00    |       | 405f-     |          |        | 'switch_info': 'fake- |                |             |                  |            |               |             |              |
| 920b-    |          |            |       | 83ab-     |          |        | switch-1', 'port_id': |                |             |                  |            |               |             |              |
| d30e91fc |          |            |       | 685cb0aeb |          |        | 'FakeEth1/1'}         |                |             |                  |            |               |             |              |
| ee33     |          |            |       | 354       |          |        |                       |                |             |                  |            |               |             |              |
| 529ff374 | 02:de:ad | 2026-07-   |       | 17f00775- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None       | {}            | False       | fake-netdev- |
| -25f5-   | :be:ef:0 | 16T15:07:4 |       | f4c1-     |          |        | '00:00:00:00:00:00',  |                |             |                  |            |               |             | test:port2   |
| 482f-    | 2        | 9+00:00    |       | 405f-     |          |        | 'switch_info': 'fake- |                |             |                  |            |               |             |              |
| 9eb1-    |          |            |       | 83ab-     |          |        | switch-2', 'port_id': |                |             |                  |            |               |             |              |
| 28f2b4f7 |          |            |       | 685cb0aeb |          |        | 'FakeEth1/2'}         |                |             |                  |            |               |             |              |
| 3aa2     |          |            |       | 354       |          |        |                       |                |             |                  |            |               |             |              |
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+--------------+
(openstack)
``` 

Also tested failure behavior:
- Invalid MAC fails with Ironic 400.
- Duplicate MAC fails with Ironic 409.
- These errors surface clearly in Argo logs.
```shell
enroll-netdev-ppcjx-enroll-netdev-1716104529:   File "/opt/venv/lib/python3.12/site-packages/ironicclient/common/http.py", line 472, in _http_request
enroll-netdev-ppcjx-enroll-netdev-1716104529:     raise exc.from_response(  # type: ignore[call-arg]
enroll-netdev-ppcjx-enroll-netdev-1716104529: ironicclient.common.apiclient.exceptions.Conflict: A port with MAC address 02:de:ad:be:ef:01 already exists. (HTTP 409) (Request-ID: req-18c46545-1a9b-40bd-bd9a-4804622c7857)
enroll-netdev-ppcjx-enroll-netdev-1716104529: time="2026-07-16T15:15:44.487Z" level=info msg="sub-process exited" argo=true error="<nil>"

``` 
Known limitation:
- The workflow is not idempotent today. If a run partially succeeds and then fails, retrying with the same name/MAC can fail because the node or port already exists.
- The workflow currently supports exactly two ports.

 follow-up:
Can we keep this PR scoped to the current Jira requirement of two required ports, and create a follow-up to:
1. make the workflow idempotent/find-or-create, and
2. support a variable number of ports instead of only `port1` and `port2`?