### PR TITLE
feat: PUC-1758: remove physical_network fallback lookup

### DIFF
--- a/changelog.d/20260817_152209_doug.goldstein_remove_physical_network_fallback.md
+++ b/changelog.d/20260817_152209_doug.goldstein_remove_physical_network_fallback.md
@@ -1,0 +1,28 @@
+### Action required
+
+Neutron no longer falls back to querying Ironic for a baremetal port's
+`physical_network` when it is absent from the port's `binding_profile`. It is
+now a hard requirement: without it, binding a baremetal port is refused and
+trunk create and delete operations are rejected with a `BadRequest`.
+
+Before upgrading, confirm no bound baremetal ports are missing
+`physical_network`, and backfill any that are:
+
+1. Take a report-only inventory of affected ports in each cloud:
+
+    ```bash
+    ./scripts/audit_ports_missing_physical_network.py --os-cloud $CLOUD
+    ```
+
+2. If the report lists any ports, backfill them from their Ironic baremetal
+   port:
+
+    ```bash
+    ./scripts/audit_ports_missing_physical_network.py --os-cloud $CLOUD --execute
+    ```
+
+3. Re-run step 1 and confirm it reports no matches.
+
+A port whose trunk parent is still bound but has no `physical_network` cannot
+have its trunk deleted until the profile is corrected. Trunks whose parent port
+is unbound are unaffected and delete as before.

--- a/python/neutron-understack/neutron_understack/ironic.py
+++ b/python/neutron-understack/neutron_understack/ironic.py
@@ -4,7 +4,6 @@ import logging
 from openstack import connection
 from openstack.baremetal.baremetal_service import BaremetalService
 from openstack.baremetal.v1.node import Node as BaremetalNode
-from openstack.baremetal.v1.port import Port as BaremetalPort
 from oslo_config import cfg
 
 from neutron_understack import config
@@ -60,18 +59,6 @@ class IronicClient:
             app_name="neutron_understack",
             app_version=version,
         ).baremetal
-
-    def baremetal_port_physical_network(self, local_link_info: dict) -> str | None:
-        port = self._port_by_local_link(local_link_info)
-        return port.physical_network if port else None
-
-    def _port_by_local_link(self, local_link_info: dict) -> BaremetalPort | None:
-        try:
-            return next(
-                self.irclient.ports(details=True, local_link_connection=local_link_info)
-            )
-        except StopIteration:
-            return None
 
     def baremetal_node_name(self, node_uuid: str) -> str | None:
         try:

--- a/python/neutron-understack/neutron_understack/neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/neutron_understack_mech.py
@@ -14,7 +14,6 @@ from oslo_config import cfg
 from neutron_understack import config
 from neutron_understack import routers
 from neutron_understack import utils
-from neutron_understack.ironic import IronicClient
 from neutron_understack.l3_router import svi as svi_router
 from neutron_understack.trunk import UnderStackTrunkDriver
 from neutron_understack.undersync import Undersync
@@ -49,7 +48,6 @@ class UnderstackDriver(MechanismDriver):
         conf = cfg.CONF.ml2_understack
 
         self.undersync = Undersync(conf.undersync_url)
-        self.ironic_client = IronicClient()
         self.trunk_driver = UnderStackTrunkDriver.create(self)
         self.subscribe()
 
@@ -266,13 +264,6 @@ class UnderstackDriver(MechanismDriver):
             port = context.current
 
         vlan_group_name = port[portbindings.PROFILE].get("physical_network")
-        if vlan_group_name is None:
-            local_link_info = utils.local_link_from_binding_profile(
-                port[portbindings.PROFILE]
-            )
-            vlan_group_name = self.ironic_client.baremetal_port_physical_network(
-                local_link_info
-            )
 
         if current_vif_unbound and original_vif_other:
             self._tenant_network_port_cleanup(context)
@@ -325,13 +316,6 @@ class UnderstackDriver(MechanismDriver):
         port = context.current
 
         vlan_group_name = port[portbindings.PROFILE].get("physical_network")
-        if vlan_group_name is None:
-            local_link_info = utils.local_link_from_binding_profile(
-                port[portbindings.PROFILE]
-            )
-            vlan_group_name = self.ironic_client.baremetal_port_physical_network(
-                local_link_info
-            )
 
         if not vlan_group_name:
             return
@@ -400,19 +384,17 @@ class UnderstackDriver(MechanismDriver):
         port = context.current
 
         vlan_group_name = port[portbindings.PROFILE].get("physical_network")
-        if vlan_group_name is None:
-            local_link_info = utils.local_link_from_binding_profile(
-                port[portbindings.PROFILE]
-            )
-            vlan_group_name = self.ironic_client.baremetal_port_physical_network(
-                local_link_info
-            )
 
         if not vlan_group_name:
             LOG.error(
-                "bind_port_segment: no physical_network found for baremetal "
-                "port with mac address: %(mac)s",
-                {"mac": mac_address},
+                "bind_port_segment: physical_network is required in the "
+                "binding_profile for baremetal port binding, but was not found. "
+                "port_id=%(port_id)s mac_address=%(mac)s network_id=%(network_id)s.",
+                {
+                    "port_id": port["id"],
+                    "mac": mac_address,
+                    "network_id": network_id,
+                },
             )
             return
 

--- a/python/neutron-understack/neutron_understack/tests/conftest.py
+++ b/python/neutron-understack/neutron_understack/tests/conftest.py
@@ -26,7 +26,6 @@ from neutron_lib.callbacks.events import DBEventPayload
 from oslo_config import fixture as config_fixture
 
 from neutron_understack import config as understack_config
-from neutron_understack.ironic import IronicClient
 from neutron_understack.neutron_understack_mech import UnderstackDriver
 from neutron_understack.tests.helpers import Ml2PluginNoInit
 from neutron_understack.tests.helpers import extend_network_dict
@@ -196,18 +195,24 @@ def subnet_context(ml2_plugin, subnet_dict) -> SubnetContext:
 
 @pytest.fixture
 def binding_profile(request, port_id) -> str:
+    """A baremetal port binding profile.
+
+    Pass ``{"physical_network": None}`` to omit that key entirely.
+    """
     req = getattr(request, "param", {})
-    return json.dumps(
-        {
-            "local_link_information": [
-                {
-                    "port_id": req.get("port_id", str(port_id)),
-                    "switch_id": "11:22:33:44:55:66",
-                    "switch_info": "a1-1-1.iad3.rackspace.net",
-                }
-            ]
-        }
-    )
+    profile = {
+        "local_link_information": [
+            {
+                "port_id": req.get("port_id", str(port_id)),
+                "switch_id": "11:22:33:44:55:66",
+                "switch_info": "a1-1-1.iad3.rackspace.net",
+            }
+        ],
+    }
+    physical_network = req.get("physical_network", "physnet")
+    if physical_network is not None:
+        profile["physical_network"] = physical_network
+    return json.dumps(profile)
 
 
 @pytest.fixture
@@ -274,30 +279,15 @@ def port_context(network_context, port_dict, port_binding, ml2_plugin) -> PortCo
 
 
 @pytest.fixture
-def ironic_client(mocker) -> IronicClient:
-    return mocker.MagicMock(spec_set=IronicClient)
-
-
-@pytest.fixture
-def understack_driver(oslo_config, ironic_client) -> UnderstackDriver:
+def understack_driver(oslo_config) -> UnderstackDriver:
     driver = UnderstackDriver()
     driver.undersync = MagicMock(spec_set=Undersync)
-    driver.ironic_client = ironic_client
     return driver
 
 
 @pytest.fixture
 def understack_trunk_driver(understack_driver) -> UnderStackTrunkDriver:
     return UnderStackTrunkDriver.create(understack_driver)
-
-
-@pytest.fixture
-def _ironic_baremetal_port_physical_network(mocker, understack_driver) -> None:
-    mocker.patch.object(
-        understack_driver.ironic_client,
-        "baremetal_port_physical_network",
-        return_value="physnet",
-    )
 
 
 @pytest.fixture

--- a/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
+++ b/python/neutron-understack/neutron_understack/tests/test_neutron_understack_mech.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -6,6 +7,7 @@ from neutron_lib import constants as p_const
 from neutron_lib.api.definitions import portbindings
 from neutron_lib.plugins.ml2 import api
 
+from neutron_understack import neutron_understack_mech
 from neutron_understack.neutron_understack_mech import UnderstackDriver
 
 
@@ -153,7 +155,6 @@ class TestUpdatePortPostCommit:
 MECH_UTILS = "neutron_understack.neutron_understack_mech.utils"
 
 
-@pytest.mark.usefixtures("_ironic_baremetal_port_physical_network")
 class TestDeletePortPostCommit:
     def test_skips_non_baremetal_port(self, understack_driver, port_context):
         port_context.current[portbindings.VNIC_TYPE] = portbindings.VNIC_NORMAL
@@ -236,7 +237,6 @@ class TestDeletePortPostCommit:
         release.assert_not_called()
 
 
-@pytest.mark.usefixtures("_ironic_baremetal_port_physical_network")
 class TestBindPort:
     def test_does_not_bind_vlan_only_segments(
         self,
@@ -327,19 +327,26 @@ class TestBindPort:
 
         port_context.continue_binding.assert_not_called()
 
-    @pytest.mark.usefixtures("_ironic_baremetal_port_physical_network")
-    def test_does_not_bind_when_physical_network_not_found(
-        self, mocker, port_context, understack_driver
+    @pytest.mark.parametrize(
+        "binding_profile", [{"physical_network": None}], indirect=True
+    )
+    def test_does_not_bind_when_physical_network_missing(
+        self, mocker, caplog, port_context, understack_driver
     ):
-        understack_driver.ironic_client.baremetal_port_physical_network.return_value = (
-            None
-        )
+        """physical_network is required: there is no fallback lookup any more.
+
+        Without it we cannot tell which VLAN group to allocate a segment in, so
+        binding is refused and the reason is logged rather than failing silently.
+        """
         mocker.patch.object(port_context, "continue_binding")
         port_context._prepare_to_bind(port_context.network.network_segments)
+        caplog.set_level(logging.ERROR, logger=neutron_understack_mech.LOG.name)
 
         understack_driver.bind_port(port_context)
 
         port_context.continue_binding.assert_not_called()
+        assert "physical_network is required" in caplog.text
+        assert port_context.current["id"] in caplog.text
 
     @pytest.mark.parametrize("port_dict", [{"trunk": True}], indirect=True)
     def test_with_trunk_details(
@@ -420,8 +427,6 @@ class TestKeystoneAuthentication:
             "neutron_understack.config.get_session",
             return_value=mock_session_instance,
         )
-        mocker.patch("neutron_understack.neutron_understack_mech.IronicClient")
-
         driver = UnderstackDriver()
         driver.initialize()
 

--- a/python/neutron-understack/neutron_understack/tests/test_trunk.py
+++ b/python/neutron-understack/neutron_understack/tests/test_trunk.py
@@ -1,6 +1,10 @@
+import logging
+
 import pytest
 from neutron.plugins.ml2.driver_context import portbindings
+from neutron_lib import exceptions as exc
 
+from neutron_understack import trunk as trunk_module
 from neutron_understack import utils
 from neutron_understack.trunk import SubportSegmentationIDError
 
@@ -51,7 +55,6 @@ class TestTrunkCreated:
         )
 
 
-@pytest.mark.usefixtures("_ironic_baremetal_port_physical_network")
 @pytest.mark.usefixtures("_utils_fetch_subport_network_id_patch")
 class Test_HandleTenantVlanIDAndSwitchportConfig:
     def test_that_check_subports_segmentation_id_is_called(
@@ -182,7 +185,6 @@ class TestTrunkDeleted:
         )
 
 
-@pytest.mark.usefixtures("_ironic_baremetal_port_physical_network")
 @pytest.mark.usefixtures("_utils_fetch_subport_network_id_patch")
 class Test_CleanParentPortSwitchportConfig:
     def test_when_parent_port_is_bound(
@@ -390,3 +392,100 @@ class TestCheckSubportsSegmentationId:
         subport.segmentation_id = 1600
         with pytest.raises(SubportSegmentationIDError):
             understack_trunk_driver._check_subports_segmentation_id([subport], trunk_id)
+
+
+@pytest.mark.parametrize("binding_profile", [{"physical_network": None}], indirect=True)
+class TestMissingPhysicalNetwork:
+    """physical_network is mandatory: there is no fallback lookup.
+
+    It is enforced on the precommit hooks, where raising aborts the
+    transaction. The postcommit hooks cannot roll anything back, so they log
+    and degrade instead of raising.
+    """
+
+    @pytest.fixture
+    def _bound_parent_port(self, mocker, port_object) -> None:
+        mocker.patch(
+            "neutron_understack.utils.fetch_port_object", return_value=port_object
+        )
+        mocker.patch("neutron_understack.utils.parent_port_is_bound", return_value=True)
+
+    def test_precommit_create_rejects_the_request(
+        self, understack_trunk_driver, port_object, subport
+    ):
+        with pytest.raises(exc.BadRequest, match="physical_network is required"):
+            understack_trunk_driver._add_subports_networks_to_parent_port_switchport(
+                port_object, [subport]
+            )
+
+    @pytest.mark.usefixtures("_bound_parent_port")
+    def test_subports_deleted_precommit_rejects_the_request(
+        self, mocker, understack_trunk_driver, trunk
+    ):
+        with pytest.raises(exc.BadRequest, match="physical_network is required"):
+            understack_trunk_driver.subports_deleted_precommit(
+                None, None, None, mocker.Mock(states=[trunk])
+            )
+
+    @pytest.mark.usefixtures("_bound_parent_port")
+    def test_trunk_deleted_precommit_rejects_the_request(
+        self, mocker, understack_trunk_driver, trunk
+    ):
+        with pytest.raises(exc.BadRequest, match="physical_network is required"):
+            understack_trunk_driver.trunk_deleted_precommit(
+                None, None, None, mocker.Mock(states=[trunk])
+            )
+
+    def test_precommit_delete_ignores_unbound_parent_port(
+        self, mocker, understack_trunk_driver, trunk, port_object
+    ):
+        """An unbound parent port has no switchport config to tear down.
+
+        There is nothing to validate, so a missing physnet must not block the
+        delete.
+        """
+        mocker.patch(
+            "neutron_understack.utils.fetch_port_object", return_value=port_object
+        )
+        mocker.patch(
+            "neutron_understack.utils.parent_port_is_bound", return_value=False
+        )
+
+        understack_trunk_driver.subports_deleted_precommit(
+            None, None, None, mocker.Mock(states=[trunk])
+        )
+
+    @pytest.mark.usefixtures("_bound_parent_port")
+    def test_subports_added_post_logs_instead_of_raising(
+        self, mocker, caplog, understack_trunk_driver, trunk
+    ):
+        caplog.set_level(logging.ERROR, logger=trunk_module.LOG.name)
+
+        understack_trunk_driver.subports_added_post(
+            None, None, None, mocker.Mock(states=[trunk])
+        )
+
+        assert "physical_network is required" in caplog.text
+        understack_trunk_driver.undersync.sync.assert_not_called()
+
+    @pytest.mark.usefixtures(
+        "_bound_parent_port", "_utils_fetch_subport_network_id_patch"
+    )
+    def test_clean_parent_port_releases_segments_without_syncing(
+        self, mocker, caplog, understack_trunk_driver, trunk, subport
+    ):
+        """Teardown still runs postcommit so the subports' VLANs do not leak.
+
+        Only the undersync call is skipped, since there is no vlan group to
+        reconcile.
+        """
+        deallocate = mocker.patch.object(
+            understack_trunk_driver, "_handle_segment_deallocation"
+        )
+        caplog.set_level(logging.ERROR, logger=trunk_module.LOG.name)
+
+        understack_trunk_driver._clean_parent_port_switchport_config(trunk, [subport])
+
+        assert "physical_network is required" in caplog.text
+        deallocate.assert_called_once()
+        understack_trunk_driver.undersync.sync.assert_not_called()

--- a/python/neutron-understack/neutron_understack/trunk.py
+++ b/python/neutron-understack/neutron_understack/trunk.py
@@ -29,6 +29,18 @@ class SubportSegmentationIDError(exc.NeutronException):
     )
 
 
+def _missing_physnet_msg(port_id: str) -> str:
+    """Explain that a parent port cannot be configured without a physnet.
+
+    physical_network names the VLAN group that undersync configures, so
+    without it there is no switch to push the trunk's subport VLANs to.
+    """
+    return (
+        "physical_network is required in the binding_profile for baremetal port "
+        f"trunk configuration, but port {port_id} does not have one."
+    )
+
+
 class UnderStackTrunkDriver(trunk_base.DriverBase):
     def __init__(
         self,
@@ -46,7 +58,6 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
             can_trunk_bound_port=can_trunk_bound_port,
         )
         self.undersync = self.plugin_driver.undersync
-        self.ironic_client = self.plugin_driver.ironic_client
 
     @property
     def is_loaded(self):
@@ -83,6 +94,12 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
             cancellable=True,
         )
         registry.subscribe(
+            self.subports_deleted_precommit,
+            resources.SUBPORTS,
+            events.PRECOMMIT_DELETE,
+            cancellable=True,
+        )
+        registry.subscribe(
             self.subports_deleted,
             resources.SUBPORTS,
             events.AFTER_DELETE,
@@ -92,6 +109,12 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
             self.trunk_created,
             resources.TRUNK,
             events.PRECOMMIT_CREATE,
+            cancellable=True,
+        )
+        registry.subscribe(
+            self.trunk_deleted_precommit,
+            resources.TRUNK,
+            events.PRECOMMIT_DELETE,
             cancellable=True,
         )
         registry.subscribe(
@@ -181,10 +204,11 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
         binding_host = parent_port.bindings[0].host
 
         vlan_group_name = binding_profile.get("physical_network")
-        if vlan_group_name is None:
-            local_link_info = utils.local_link_from_binding_profile(binding_profile)
-            vlan_group_name = self.ironic_client.baremetal_port_physical_network(
-                local_link_info
+        if not vlan_group_name:
+            # Reached from the PRECOMMIT_CREATE handlers, so raising here aborts
+            # the transaction and surfaces the error to the API caller.
+            raise exc.BadRequest(
+                resource="port", msg=_missing_physnet_msg(parent_port.id)
             )
 
         self._handle_segment_allocation(subports, vlan_group_name, binding_host)
@@ -210,11 +234,14 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
         binding_host = parent_port_obj.bindings[0].host
 
         vlan_group_name = binding_profile.get("physical_network")
-        if vlan_group_name is None:
-            local_link_info = utils.local_link_from_binding_profile(binding_profile)
-            vlan_group_name = self.ironic_client.baremetal_port_physical_network(
-                local_link_info
-            )
+        if not vlan_group_name:
+            # This runs postcommit: the subports are already gone from the DB,
+            # so raising cannot roll anything back. The PRECOMMIT_DELETE
+            # handlers reject this case while it is still abortable; getting
+            # here means the binding profile changed underneath us. Log it and
+            # still release the segments -- otherwise their VLANs leak -- but
+            # skip the undersync call, since there is no vlan group to sync.
+            LOG.error(_missing_physnet_msg(parent_port_obj.id))
         self._handle_subports_removal(
             binding_profile=binding_profile,
             binding_host=binding_host,
@@ -263,13 +290,33 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
         if utils.parent_port_is_bound(parent_port):
             binding_profile = parent_port.bindings[0].profile
             vlan_group_name = binding_profile.get("physical_network")
-            if vlan_group_name is None:
-                local_link_info = utils.local_link_from_binding_profile(binding_profile)
-                vlan_group_name = self.ironic_client.baremetal_port_physical_network(
-                    local_link_info
-                )
+            if not vlan_group_name:
+                # subports_added validates the same parent port on
+                # PRECOMMIT_CREATE, so normally we never get here. This runs
+                # postcommit, where raising cannot undo the subport creation,
+                # and there is no vlan group to sync.
+                LOG.error(_missing_physnet_msg(parent_port.id))
+                return
             LOG.debug("subports_added_post found vlan_group_name=%s", vlan_group_name)
             self.undersync.sync(vlan_group_name)
+
+    def _validate_parent_port_physnet(self, trunk: Trunk) -> None:
+        """Reject a teardown whose parent port has no physical_network.
+
+        The switchport teardown itself runs on AFTER_DELETE, where the rows are
+        already committed and an exception cannot roll them back, so the check
+        has to happen here while the transaction can still be aborted.
+        """
+        parent_port_obj = utils.fetch_port_object(trunk.port_id)
+        if not utils.parent_port_is_bound(parent_port_obj):
+            return
+        if not parent_port_obj.bindings[0].profile.get("physical_network"):
+            raise exc.BadRequest(
+                resource="port", msg=_missing_physnet_msg(parent_port_obj.id)
+            )
+
+    def subports_deleted_precommit(self, resource, event, trunk_plugin, payload):
+        self._validate_parent_port_physnet(payload.states[0])
 
     def subports_deleted(self, resource, event, trunk_plugin, payload):
         trunk = payload.states[0]
@@ -281,6 +328,11 @@ class UnderStackTrunkDriver(trunk_base.DriverBase):
         subports = trunk.sub_ports
         if subports:
             self._handle_tenant_vlan_id_and_switchport_config(subports, trunk)
+
+    def trunk_deleted_precommit(self, resource, event, trunk_plugin, payload):
+        trunk = payload.states[0]
+        if trunk.sub_ports:
+            self._validate_parent_port_physnet(trunk)
 
     def trunk_deleted(self, resource, event, trunk_plugin, payload):
         trunk = payload.states[0]

--- a/python/neutron-understack/neutron_understack/utils.py
+++ b/python/neutron-understack/neutron_understack/utils.py
@@ -472,10 +472,6 @@ def release_segment_if_unused(segment: NetworkSegment) -> None:
         release_dynamic_segment(segment.id)
 
 
-def local_link_from_binding_profile(binding_profile: dict) -> dict | None:
-    return binding_profile.get("local_link_information", [None])[0]
-
-
 def parent_port_is_bound(port: port_obj.Port) -> bool:
     port_binding = port.bindings[0]
     return bool(


### PR DESCRIPTION
## What does this change do?

Ironic requires a `physical_network` on the baremetal port to attach a vif and passes it through in the `binding_profile`, so the fallback that queried Ironic for the port matching `local_link_information` was only ever a workaround. This removes it, which also drops a synchronous Ironic API call from the port bind path.

With the fallback gone a missing `physical_network` is a hard error, enforced on the precommit hooks:

- `SUBPORTS`/`TRUNK` `PRECOMMIT_CREATE` raise `BadRequest`, aborting the transaction and surfacing the error to the API caller.
- New `SUBPORTS`/`TRUNK` `PRECOMMIT_DELETE` handlers validate the parent port before the teardown commits, since the `AFTER_DELETE` hook that does the switchport cleanup cannot roll anything back. Only a still-bound parent port blocks the delete; an unbound one tears down as before.
- The `AFTER_CREATE`/`AFTER_DELETE` hooks log instead of raising. They run after the rows are committed, where an exception cannot undo the change and — the subscriptions being `cancellable` — would surface as a 500. The delete path still releases its segments so their VLANs do not leak, and only skips the `undersync` call.
- `bind_port_segment` still refuses the bind and logs, now including the port and network ids.

Also drops the helpers the fallback was the only caller of: `IronicClient.baremetal_port_physical_network`, its `_port_by_local_link` helper, and `utils.local_link_from_binding_profile`.

## Upgrade impact

- [x] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
