### PR TITLE
feat: use primary galera host for MariaDB from OpenStack services

### DIFF
--- a/components/cinder/values.yaml
+++ b/components/cinder/values.yaml
@@ -33,6 +33,9 @@ conf:
 # values, but should include all endpoints
 # required by this chart
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   oslo_messaging:
     statefulset:
       replicas: 3

--- a/components/glance/values.yaml
+++ b/components/glance/values.yaml
@@ -5,6 +5,9 @@ release_group: null
 # values, but should include all endpoints
 # required by this chart
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   oslo_messaging:
     statefulset:
       replicas: 3

--- a/components/horizon/values.yaml
+++ b/components/horizon/values.yaml
@@ -37,6 +37,9 @@ conf:
       amqp_durable_queues: true
 
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   dashboard:
     host_fqdn_override:
       public:

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -133,6 +133,9 @@ conf:
       processes: 4
 
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   oslo_messaging:
     namespace: null
     statefulset:

--- a/components/keystone/values.yaml
+++ b/components/keystone/values.yaml
@@ -295,6 +295,9 @@ conf:
 # values, but should include all endpoints
 # required by this chart
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   oslo_messaging:
     statefulset:
       replicas: 3

--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -5,6 +5,9 @@ release_group: null
 # values, but should include all endpoints
 # required by this chart
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   oslo_messaging:
     statefulset:
       replicas: 3

--- a/components/nova/values.yaml
+++ b/components/nova/values.yaml
@@ -12,6 +12,9 @@ labels:
 # values, but should include all endpoints
 # required by this chart
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   oslo_messaging:
     statefulset:
       replicas: 3

--- a/components/octavia/values.yaml
+++ b/components/octavia/values.yaml
@@ -4,6 +4,9 @@
 # values, but should include all endpoints
 # required by this chart
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   oslo_messaging:
     statefulset:
       replicas: 3

--- a/components/placement/values.yaml
+++ b/components/placement/values.yaml
@@ -46,6 +46,9 @@ pod:
     enabled: true
 
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   placement:
     scheme:
       public: 'https'

--- a/components/skyline/values.yaml
+++ b/components/skyline/values.yaml
@@ -1,5 +1,8 @@
 ---
 endpoints:
+  oslo_db:
+    hosts:
+      default: mariadb-primary
   skyline:
     host_fqdn_override:
       public:


### PR DESCRIPTION
Per the discussion on the OpenStack mailing list, multiple people have
reported that the proper behavior is to have the services connect to the
galera primary node which is what this does.

https://lists.openstack.org/archives/list/openstack-discuss@lists.openstack.org/message/7D45OTQCEOVP7DQTDYNWLGCWOTFALWIF/
