### PR TITLE
feat: adding Nautobot Admin Groups and Permission sync

### DIFF
--- a/go/nautobotop/api/v1alpha1/nautobot_types.go
+++ b/go/nautobotop/api/v1alpha1/nautobot_types.go
@@ -52,6 +52,7 @@ type NautobotSpec struct {
 	TenantGroupRef     []ConfigMapRef    `json:"tenantGroupRef,omitempty"`
 	TenantRef          []ConfigMapRef    `json:"tenantRef,omitempty"`
 	DeviceRef          []ConfigMapRef    `json:"deviceRef,omitempty"`
+	PermissionGroupRef []ConfigMapRef    `json:"permissionGroupRef,omitempty"`
 }
 
 // NautobotStatus defines the observed state of Nautobot.

--- a/go/nautobotop/internal/controller/dag_test.go
+++ b/go/nautobotop/internal/controller/dag_test.go
@@ -82,6 +82,7 @@ func TestTopologicalSort(t *testing.T) {
 				{Name: "namespace", DependsOn: []string{"location", "tenant"}},
 				{Name: "vlan", DependsOn: []string{"vlanGroup", "location", "tenant", "role"}},
 				{Name: "prefix", DependsOn: []string{"namespace", "rir", "location", "vlan", "tenant", "role"}},
+				{Name: "permissionGroup"},
 			},
 			want: []string{
 				"clusterGroup", "clusterType", "deviceType", "locationTypes",

--- a/go/nautobotop/internal/controller/nautobot_controller.go
+++ b/go/nautobotop/internal/controller/nautobot_controller.go
@@ -258,7 +258,7 @@ func (r *NautobotReconciler) syncDeviceTypes(ctx context.Context,
 	deviceTypeMap map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing device types", "count", len(deviceTypeMap))
+	log.Info("starting sync of device types", "totalEntriesDefined", len(deviceTypeMap))
 	if len(deviceTypeMap) == 0 {
 		return nil
 	}
@@ -266,6 +266,7 @@ func (r *NautobotReconciler) syncDeviceTypes(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, deviceTypeMap); err != nil {
 		return fmt.Errorf("failed to sync device types: %w", err)
 	}
+	log.Info("completed sync of device types")
 	return nil
 }
 
@@ -274,7 +275,7 @@ func (r *NautobotReconciler) syncRackGroup(ctx context.Context,
 	rackGroup map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing rack group", "count", len(rackGroup))
+	log.Info("starting sync of rack groups", "totalEntriesDefined", len(rackGroup))
 	if len(rackGroup) == 0 {
 		return nil
 	}
@@ -282,6 +283,7 @@ func (r *NautobotReconciler) syncRackGroup(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, rackGroup); err != nil {
 		return fmt.Errorf("failed to sync rack group: %w", err)
 	}
+	log.Info("completed sync of rack groups")
 	return nil
 }
 
@@ -290,7 +292,7 @@ func (r *NautobotReconciler) syncRack(ctx context.Context,
 	rackData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing racks", "count", len(rackData))
+	log.Info("starting sync of racks", "totalEntriesDefined", len(rackData))
 	if len(rackData) == 0 {
 		return nil
 	}
@@ -298,6 +300,7 @@ func (r *NautobotReconciler) syncRack(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, rackData); err != nil {
 		return fmt.Errorf("failed to sync racks: %w", err)
 	}
+	log.Info("completed sync of racks")
 	return nil
 }
 
@@ -306,7 +309,7 @@ func (r *NautobotReconciler) syncPermissionGroup(ctx context.Context,
 	permissionGroupData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing permission groups", "count", len(permissionGroupData))
+	log.Info("starting sync of permission groups", "totalEntriesDefined", len(permissionGroupData))
 	if len(permissionGroupData) == 0 {
 		return nil
 	}
@@ -314,6 +317,7 @@ func (r *NautobotReconciler) syncPermissionGroup(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, permissionGroupData); err != nil {
 		return fmt.Errorf("failed to sync permission groups: %w", err)
 	}
+	log.Info("completed sync of permission groups")
 	return nil
 }
 
@@ -322,7 +326,7 @@ func (r *NautobotReconciler) syncLocation(ctx context.Context,
 	locationType map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing location types", "count", len(locationType))
+	log.Info("starting sync of locations", "totalEntriesDefined", len(locationType))
 	if len(locationType) == 0 {
 		return nil
 	}
@@ -330,6 +334,7 @@ func (r *NautobotReconciler) syncLocation(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, locationType); err != nil {
 		return fmt.Errorf("failed to sync location types: %w", err)
 	}
+	log.Info("completed sync of locations")
 	return nil
 }
 
@@ -338,7 +343,7 @@ func (r *NautobotReconciler) syncLocationTypes(ctx context.Context,
 	locationType map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing location types", "count", len(locationType))
+	log.Info("starting sync of location types", "totalEntriesDefined", len(locationType))
 	if len(locationType) == 0 {
 		return nil
 	}
@@ -346,6 +351,7 @@ func (r *NautobotReconciler) syncLocationTypes(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, locationType); err != nil {
 		return fmt.Errorf("failed to sync location types: %w", err)
 	}
+	log.Info("completed sync of location types")
 	return nil
 }
 
@@ -354,7 +360,7 @@ func (r *NautobotReconciler) syncVlanGroup(ctx context.Context,
 	vlanGroupData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing vlan groups", "count", len(vlanGroupData))
+	log.Info("starting sync of vlan groups", "totalEntriesDefined", len(vlanGroupData))
 	if len(vlanGroupData) == 0 {
 		return nil
 	}
@@ -362,6 +368,7 @@ func (r *NautobotReconciler) syncVlanGroup(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, vlanGroupData); err != nil {
 		return fmt.Errorf("failed to sync vlan groups: %w", err)
 	}
+	log.Info("completed sync of vlan groups")
 	return nil
 }
 
@@ -370,7 +377,7 @@ func (r *NautobotReconciler) syncVlan(ctx context.Context,
 	vlanData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing vlans", "count", len(vlanData))
+	log.Info("starting sync of vlans", "totalEntriesDefined", len(vlanData))
 	if len(vlanData) == 0 {
 		return nil
 	}
@@ -378,6 +385,7 @@ func (r *NautobotReconciler) syncVlan(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, vlanData); err != nil {
 		return fmt.Errorf("failed to sync vlans: %w", err)
 	}
+	log.Info("completed sync of vlans")
 	return nil
 }
 
@@ -386,7 +394,7 @@ func (r *NautobotReconciler) syncPrefix(ctx context.Context,
 	prefixData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing prefixes", "count", len(prefixData))
+	log.Info("starting sync of prefixes", "totalEntriesDefined", len(prefixData))
 	if len(prefixData) == 0 {
 		return nil
 	}
@@ -394,6 +402,7 @@ func (r *NautobotReconciler) syncPrefix(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, prefixData); err != nil {
 		return fmt.Errorf("failed to sync prefixes: %w", err)
 	}
+	log.Info("completed sync of prefixes")
 	return nil
 }
 
@@ -402,7 +411,7 @@ func (r *NautobotReconciler) syncClusterType(ctx context.Context,
 	clusterTypeData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing cluster types", "count", len(clusterTypeData))
+	log.Info("starting sync of cluster types", "totalEntriesDefined", len(clusterTypeData))
 	if len(clusterTypeData) == 0 {
 		return nil
 	}
@@ -410,6 +419,7 @@ func (r *NautobotReconciler) syncClusterType(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, clusterTypeData); err != nil {
 		return fmt.Errorf("failed to sync cluster types: %w", err)
 	}
+	log.Info("completed sync of cluster types")
 	return nil
 }
 
@@ -418,7 +428,7 @@ func (r *NautobotReconciler) syncClusterGroup(ctx context.Context,
 	clusterGroupData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing cluster groups", "count", len(clusterGroupData))
+	log.Info("starting sync of cluster groups", "totalEntriesDefined", len(clusterGroupData))
 	if len(clusterGroupData) == 0 {
 		return nil
 	}
@@ -426,6 +436,7 @@ func (r *NautobotReconciler) syncClusterGroup(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, clusterGroupData); err != nil {
 		return fmt.Errorf("failed to sync cluster groups: %w", err)
 	}
+	log.Info("completed sync of cluster groups")
 	return nil
 }
 
@@ -434,7 +445,7 @@ func (r *NautobotReconciler) syncCluster(ctx context.Context,
 	clusterData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing clusters", "count", len(clusterData))
+	log.Info("starting sync of clusters", "totalEntriesDefined", len(clusterData))
 	if len(clusterData) == 0 {
 		return nil
 	}
@@ -442,6 +453,7 @@ func (r *NautobotReconciler) syncCluster(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, clusterData); err != nil {
 		return fmt.Errorf("failed to sync clusters: %w", err)
 	}
+	log.Info("completed sync of clusters")
 	return nil
 }
 func (r *NautobotReconciler) syncNamespace(ctx context.Context,
@@ -449,7 +461,7 @@ func (r *NautobotReconciler) syncNamespace(ctx context.Context,
 	namespaceData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing namespaces", "count", len(namespaceData))
+	log.Info("starting sync of namespaces", "totalEntriesDefined", len(namespaceData))
 	if len(namespaceData) == 0 {
 		return nil
 	}
@@ -457,6 +469,7 @@ func (r *NautobotReconciler) syncNamespace(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, namespaceData); err != nil {
 		return fmt.Errorf("failed to sync namespaces: %w", err)
 	}
+	log.Info("completed sync of namespaces")
 	return nil
 }
 
@@ -465,7 +478,7 @@ func (r *NautobotReconciler) syncRir(ctx context.Context,
 	rirData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing rirs", "count", len(rirData))
+	log.Info("starting sync of rirs", "totalEntriesDefined", len(rirData))
 	if len(rirData) == 0 {
 		return nil
 	}
@@ -473,6 +486,7 @@ func (r *NautobotReconciler) syncRir(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, rirData); err != nil {
 		return fmt.Errorf("failed to sync rirs: %w", err)
 	}
+	log.Info("completed sync of rirs")
 	return nil
 }
 
@@ -481,7 +495,7 @@ func (r *NautobotReconciler) syncRole(ctx context.Context,
 	roleData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing roles", "count", len(roleData))
+	log.Info("starting sync of roles", "totalEntriesDefined", len(roleData))
 	if len(roleData) == 0 {
 		return nil
 	}
@@ -489,6 +503,7 @@ func (r *NautobotReconciler) syncRole(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, roleData); err != nil {
 		return fmt.Errorf("failed to sync roles: %w", err)
 	}
+	log.Info("completed sync of roles")
 	return nil
 }
 
@@ -497,7 +512,7 @@ func (r *NautobotReconciler) syncTenantGroup(ctx context.Context,
 	tenantGroupData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing tenant groups", "count", len(tenantGroupData))
+	log.Info("starting sync of tenant groups", "totalEntriesDefined", len(tenantGroupData))
 	if len(tenantGroupData) == 0 {
 		return nil
 	}
@@ -505,6 +520,7 @@ func (r *NautobotReconciler) syncTenantGroup(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, tenantGroupData); err != nil {
 		return fmt.Errorf("failed to sync tenant groups: %w", err)
 	}
+	log.Info("completed sync of tenant groups")
 	return nil
 }
 
@@ -513,7 +529,7 @@ func (r *NautobotReconciler) syncTenant(ctx context.Context,
 	tenantData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing tenants", "count", len(tenantData))
+	log.Info("starting sync of tenants", "totalEntriesDefined", len(tenantData))
 	if len(tenantData) == 0 {
 		return nil
 	}
@@ -521,6 +537,7 @@ func (r *NautobotReconciler) syncTenant(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, tenantData); err != nil {
 		return fmt.Errorf("failed to sync tenants: %w", err)
 	}
+	log.Info("completed sync of tenants")
 	return nil
 }
 
@@ -529,7 +546,7 @@ func (r *NautobotReconciler) syncDevice(ctx context.Context,
 	deviceData map[string]string,
 ) error {
 	log := logf.FromContext(ctx)
-	log.Info("syncing devices", "count", len(deviceData))
+	log.Info("starting sync of devices", "totalEntriesDefined", len(deviceData))
 	if len(deviceData) == 0 {
 		return nil
 	}
@@ -537,6 +554,7 @@ func (r *NautobotReconciler) syncDevice(ctx context.Context,
 	if err := syncSvc.SyncAll(ctx, deviceData); err != nil {
 		return fmt.Errorf("failed to sync devices: %w", err)
 	}
+	log.Info("completed sync of devices")
 	return nil
 }
 

--- a/go/nautobotop/internal/controller/nautobot_controller.go
+++ b/go/nautobotop/internal/controller/nautobot_controller.go
@@ -28,6 +28,7 @@ import (
 
 	nbClient "github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/client"
 	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/sync"
+	syncadmin "github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/sync/admin"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -117,6 +118,7 @@ func (r *NautobotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		{name: "cluster", dependsOn: []string{"clusterType", "clusterGroup", "location", "device"}, configRefs: nautobotCR.Spec.ClusterRef, syncFunc: r.syncCluster},
 		// Depends on: namespace, rir, location, vlan, tenant, role
 		{name: "prefix", dependsOn: []string{"namespace", "rir", "location", "vlan", "tenant", "role"}, configRefs: nautobotCR.Spec.PrefixRef, syncFunc: r.syncPrefix},
+		{name: "permissionGroup", configRefs: nautobotCR.Spec.PermissionGroupRef, syncFunc: r.syncPermissionGroup},
 	}
 
 	// Resolve execution order using topological sort (Kahn's algorithm)
@@ -295,6 +297,22 @@ func (r *NautobotReconciler) syncRack(ctx context.Context,
 	syncSvc := sync.NewRackSync(nautobotClient)
 	if err := syncSvc.SyncAll(ctx, rackData); err != nil {
 		return fmt.Errorf("failed to sync racks: %w", err)
+	}
+	return nil
+}
+
+func (r *NautobotReconciler) syncPermissionGroup(ctx context.Context,
+	nautobotClient *nbClient.NautobotClient,
+	permissionGroupData map[string]string,
+) error {
+	log := logf.FromContext(ctx)
+	log.Info("syncing permission groups", "count", len(permissionGroupData))
+	if len(permissionGroupData) == 0 {
+		return nil
+	}
+	syncSvc := syncadmin.NewPermissionGroupSync(nautobotClient)
+	if err := syncSvc.SyncAll(ctx, permissionGroupData); err != nil {
+		return fmt.Errorf("failed to sync permission groups: %w", err)
 	}
 	return nil
 }

--- a/go/nautobotop/internal/nautobot/admin/group.go
+++ b/go/nautobotop/internal/nautobot/admin/group.go
@@ -1,0 +1,78 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/charmbracelet/log"
+	nb "github.com/nautobot/go-nautobot/v3"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/client"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/helpers"
+)
+
+type GroupService struct {
+	client *client.NautobotClient
+}
+
+func NewGroupService(nautobotClient *client.NautobotClient) *GroupService {
+	return &GroupService{
+		client: nautobotClient,
+	}
+}
+
+func (s *GroupService) Create(ctx context.Context, req nb.GroupRequest) (*nb.Group, error) {
+	group, resp, err := s.client.APIClient.UsersAPI.UsersGroupsCreate(ctx).GroupRequest(req).Execute()
+	if err != nil {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("createNewGroup", "failed to create", "model", req.Name, "error", err.Error(), "response_body", bodyString)
+		return nil, err
+	}
+	log.Info("CreateGroup", "created group", group.Name)
+	return group, nil
+}
+
+func (s *GroupService) GetByName(ctx context.Context, name string) *nb.Group {
+	list, resp, err := s.client.APIClient.UsersAPI.UsersGroupsList(ctx).Name([]string{name}).Execute()
+	if err != nil {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("GetGroupByName", "failed to get", "name", name, "error", err.Error(), "response_body", bodyString)
+		return nil
+	}
+	if list == nil || len(list.Results) == 0 {
+		return nil
+	}
+	return &list.Results[0]
+}
+
+func (s *GroupService) ListAll(ctx context.Context) []nb.Group {
+	return helpers.PaginatedList(
+		ctx,
+		func(ctx context.Context, limit, offset int32) ([]nb.Group, int32, *http.Response, error) {
+			list, resp, err := s.client.APIClient.UsersAPI.UsersGroupsList(ctx).
+				Limit(limit).
+				Offset(offset).
+				Execute()
+			if err != nil {
+				return nil, 0, resp, err
+			}
+			if list == nil {
+				return nil, 0, resp, nil
+			}
+			return list.Results, list.Count, resp, nil
+		},
+		s.client.AddReport,
+		"ListAllGroups",
+	)
+}
+
+// GetOrCreate fetches a group by name or creates it if it doesn't exist.
+func (s *GroupService) GetOrCreate(ctx context.Context, name string) (*nb.Group, error) {
+	existing := s.GetByName(ctx, name)
+	if existing != nil {
+		return existing, nil
+	}
+
+	log.Info("group not found, creating", "name", name)
+	req := nb.GroupRequest{Name: name}
+	return s.Create(ctx, req)
+}

--- a/go/nautobotop/internal/nautobot/admin/permission.go
+++ b/go/nautobotop/internal/nautobot/admin/permission.go
@@ -1,0 +1,155 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/charmbracelet/log"
+	nb "github.com/nautobot/go-nautobot/v3"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/client"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/helpers"
+)
+
+type PermissionService struct {
+	client *client.NautobotClient
+}
+
+func NewPermissionService(nautobotClient *client.NautobotClient) *PermissionService {
+	return &PermissionService{
+		client: nautobotClient,
+	}
+}
+
+func (s *PermissionService) Create(ctx context.Context, req nb.ObjectPermissionRequest) (*nb.ObjectPermission, error) {
+	perm, resp, err := s.client.APIClient.UsersAPI.UsersPermissionsCreate(ctx).ObjectPermissionRequest(req).Execute()
+	if err != nil {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("createNewPermission", "failed to create", "model", req.Name, "error", err.Error(), "response_body", bodyString)
+		return nil, err
+	}
+	log.Info("CreatePermission", "created permission", perm.Name)
+	return perm, nil
+}
+
+func (s *PermissionService) GetByName(ctx context.Context, name string) *nb.ObjectPermission {
+	list, resp, err := s.client.APIClient.UsersAPI.UsersPermissionsList(ctx).Name([]string{name}).Execute()
+	if err != nil {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("GetPermissionByName", "failed to get", "name", name, "error", err.Error(), "response_body", bodyString)
+		return nil
+	}
+	if list == nil || len(list.Results) == 0 {
+		return nil
+	}
+	return &list.Results[0]
+}
+
+func (s *PermissionService) GetByID(ctx context.Context, id string) *nb.ObjectPermission {
+	if id == "" {
+		return nil
+	}
+	list, resp, err := s.client.APIClient.UsersAPI.UsersPermissionsList(ctx).Id([]string{id}).Execute()
+	if err != nil {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("GetPermissionByID", "failed to get", "id", id, "error", err.Error(), "response_body", bodyString)
+		return nil
+	}
+	if list == nil || len(list.Results) == 0 {
+		return nil
+	}
+	return &list.Results[0]
+}
+
+func (s *PermissionService) ListAll(ctx context.Context) []nb.ObjectPermission {
+	return helpers.PaginatedList(
+		ctx,
+		func(ctx context.Context, limit, offset int32) ([]nb.ObjectPermission, int32, *http.Response, error) {
+			list, resp, err := s.client.APIClient.UsersAPI.UsersPermissionsList(ctx).
+				Limit(limit).
+				Offset(offset).
+				Execute()
+			if err != nil {
+				return nil, 0, resp, err
+			}
+			if list == nil {
+				return nil, 0, resp, nil
+			}
+			return list.Results, list.Count, resp, nil
+		},
+		s.client.AddReport,
+		"ListAllPermissions",
+	)
+}
+
+// PermissionUpdatePayload represents the desired state of a permission.
+type PermissionUpdatePayload struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Enabled     bool        `json:"enabled"`
+	Actions     interface{} `json:"actions"`
+	ObjectTypes []string    `json:"object_types"`
+	Constraints interface{} `json:"constraints"`
+	Groups      []GroupRef  `json:"groups"`
+}
+
+// GroupRef is a minimal group reference for the permission update payload.
+type GroupRef struct {
+	ID int32 `json:"id"`
+}
+
+// Update performs a full PUT via the SDK client
+func (s *PermissionService) Update(ctx context.Context, id string, payload PermissionUpdatePayload) error {
+	// Build the SDK request
+	req := *nb.NewObjectPermissionRequest(payload.ObjectTypes, payload.Name, payload.Actions)
+	req.Enabled = nb.PtrBool(payload.Enabled)
+	if payload.Description != "" {
+		req.Description = nb.PtrString(payload.Description)
+	}
+
+	// Set groups
+	groups := make([]nb.ApprovalWorkflowStageResponseApprovalWorkflowStage, 0, len(payload.Groups))
+	for _, g := range payload.Groups {
+		gid := g.ID
+		groups = append(groups, nb.ApprovalWorkflowStageResponseApprovalWorkflowStage{
+			Id: &nb.ApprovalWorkflowApprovalWorkflowDefinitionId{Int32: &gid},
+		})
+	}
+	req.Groups = groups
+
+	if payload.Constraints != nil {
+		req.Constraints = payload.Constraints
+	} else {
+		req.AdditionalProperties = map[string]interface{}{
+			"constraints": nil,
+		}
+	}
+
+	perm, resp, err := s.client.APIClient.UsersAPI.UsersPermissionsUpdate(ctx, id).ObjectPermissionRequest(req).Execute()
+	if err != nil {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("UpdatePermission", "failed to update", "id", id, "model", payload.Name, "error", err.Error(), "response_body", bodyString)
+		return err
+	}
+	log.Info("successfully updated permission", "id", id, "model", perm.GetName())
+	return nil
+}
+
+func (s *PermissionService) Destroy(ctx context.Context, id string) error {
+	owned, err := s.client.IsCreatedByUser(ctx, id)
+	if err != nil {
+		s.client.AddReport("DestroyPermission", "failed to check ownership", "id", id, "error", err.Error())
+		return err
+	}
+	if !owned {
+		log.Warn("skipping destroy, object not created by user", "id", id, "user", s.client.Username)
+		return nil
+	}
+
+	resp, err := s.client.APIClient.UsersAPI.UsersPermissionsDestroy(ctx, id).Execute()
+	if err != nil {
+		bodyString := helpers.ReadResponseBody(resp)
+		s.client.AddReport("DestroyPermission", "failed to destroy", "id", id, "error", err.Error(), "response_body", bodyString)
+		return err
+	}
+	return nil
+}

--- a/go/nautobotop/internal/nautobot/models/admin/permissionGroup.go
+++ b/go/nautobotop/internal/nautobot/models/admin/permissionGroup.go
@@ -1,0 +1,48 @@
+package admin
+
+// Permission represents a single Nautobot ObjectPermission with its group assignments.
+type Permission struct {
+	Name              string   `json:"name" yaml:"name"`
+	Description       string   `json:"description" yaml:"description"`
+	Enabled           *bool    `json:"enabled" yaml:"enabled"`
+	CanView           bool     `json:"can_view" yaml:"can_view"`
+	CanAdd            bool     `json:"can_add" yaml:"can_add"`
+	CanChange         bool     `json:"can_change" yaml:"can_change"`
+	CanDelete         bool     `json:"can_delete" yaml:"can_delete"`
+	AdditionalActions []string `json:"additional_actions" yaml:"additional_actions"`
+	ObjectTypes       []string `json:"object_types" yaml:"object_types"`
+	Groups            []string `json:"groups" yaml:"groups"`
+	Constraints       string   `json:"constraints" yaml:"constraints"`
+}
+
+// PermissionGroupConfig represents the top-level structure for the permissions configmap.
+type PermissionGroupConfig struct {
+	Permissions []Permission `json:"permissions" yaml:"permissions"`
+}
+
+// BuildActions constructs the actions list from the boolean flags and additional actions.
+func (p *Permission) BuildActions() []string {
+	var actions []string
+	if p.CanView {
+		actions = append(actions, "view")
+	}
+	if p.CanAdd {
+		actions = append(actions, "add")
+	}
+	if p.CanChange {
+		actions = append(actions, "change")
+	}
+	if p.CanDelete {
+		actions = append(actions, "delete")
+	}
+	actions = append(actions, p.AdditionalActions...)
+	return actions
+}
+
+// IsEnabled returns whether the permission is enabled (defaults to true if not set).
+func (p *Permission) IsEnabled() bool {
+	if p.Enabled == nil {
+		return true
+	}
+	return *p.Enabled
+}

--- a/go/nautobotop/internal/nautobot/sync/admin/permissionGroup.go
+++ b/go/nautobotop/internal/nautobot/sync/admin/permissionGroup.go
@@ -72,7 +72,7 @@ func (s *PermissionGroupSync) syncSinglePermission(
 		return nil
 	}
 
-	var groupIDs []int32
+	groupIDs := make([]int32, 0, len(perm.Groups))
 	for _, groupName := range perm.Groups {
 		gid, err := s.resolveGroupID(ctx, groupName, groupNameToID)
 		if err != nil {

--- a/go/nautobotop/internal/nautobot/sync/admin/permissionGroup.go
+++ b/go/nautobotop/internal/nautobot/sync/admin/permissionGroup.go
@@ -1,0 +1,161 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/log"
+	nb "github.com/nautobot/go-nautobot/v3"
+	adminsvc "github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/admin"
+	"github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/client"
+	adminmodels "github.com/rackerlabs/understack/go/nautobotop/internal/nautobot/models/admin"
+	"go.yaml.in/yaml/v3"
+)
+
+type PermissionGroupSync struct {
+	client        *client.NautobotClient
+	groupSvc      *adminsvc.GroupService
+	permissionSvc *adminsvc.PermissionService
+}
+
+func NewPermissionGroupSync(nautobotClient *client.NautobotClient) *PermissionGroupSync {
+	return &PermissionGroupSync{
+		client:        nautobotClient.GetClient(),
+		groupSvc:      adminsvc.NewGroupService(nautobotClient),
+		permissionSvc: adminsvc.NewPermissionService(nautobotClient),
+	}
+}
+
+func (s *PermissionGroupSync) SyncAll(ctx context.Context, data map[string]string) error {
+	var allPermissions []adminmodels.Permission
+
+	for key, f := range data {
+		var config adminmodels.PermissionGroupConfig
+		if err := yaml.Unmarshal([]byte(f), &config); err != nil {
+			s.client.AddReport("yamlFailed", "file: "+key+" error: "+err.Error())
+			return err
+		}
+		allPermissions = append(allPermissions, config.Permissions...)
+	}
+
+	if len(allPermissions) == 0 {
+		log.Info("no permissions to sync")
+		return nil
+	}
+
+	groupNameToID := make(map[string]int32)
+
+	for _, perm := range allPermissions {
+		if err := s.syncSinglePermission(ctx, perm, groupNameToID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *PermissionGroupSync) syncSinglePermission(
+	ctx context.Context,
+	perm adminmodels.Permission,
+	groupNameToID map[string]int32,
+) error {
+	if perm.Name == "" {
+		s.client.AddReport("permissionInvalid", "permission has no name, skipping")
+		return nil
+	}
+
+	actions := perm.BuildActions()
+	if len(actions) == 0 {
+		s.client.AddReport("permissionInvalid", "permission has no actions, skipping", "name", perm.Name)
+		log.Warn("permission has no actions, skipping", "name", perm.Name)
+		return nil
+	}
+
+	var groupIDs []int32
+	for _, groupName := range perm.Groups {
+		gid, err := s.resolveGroupID(ctx, groupName, groupNameToID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve group %q for permission %q: %w", groupName, perm.Name, err)
+		}
+		groupIDs = append(groupIDs, gid)
+	}
+
+	// Parse constraints (nil if empty)
+	var constraints interface{}
+	if perm.Constraints != "" {
+		if err := json.Unmarshal([]byte(perm.Constraints), &constraints); err != nil {
+			s.client.AddReport("constraintsInvalid", "invalid JSON constraints", "name", perm.Name, "error", err.Error())
+			log.Warn("invalid JSON constraints, skipping constraints", "name", perm.Name, "error", err)
+		}
+	}
+
+	// Check if the permission already exists
+	existing := s.permissionSvc.GetByName(ctx, perm.Name)
+	if existing != nil && existing.Id != nil {
+		payload := adminsvc.PermissionUpdatePayload{
+			Name:        perm.Name,
+			Description: perm.Description,
+			Enabled:     perm.IsEnabled(),
+			Actions:     actions,
+			ObjectTypes: perm.ObjectTypes,
+			Constraints: constraints, // nil becomes JSON null, clearing it
+		}
+		for _, gid := range groupIDs {
+			payload.Groups = append(payload.Groups, adminsvc.GroupRef{ID: gid})
+		}
+
+		if err := s.permissionSvc.Update(ctx, *existing.Id, payload); err != nil {
+			return fmt.Errorf("failed to update permission %q: %w", perm.Name, err)
+		}
+		log.Info("permission synced (updated)", "name", perm.Name, "groups", len(groupIDs))
+	} else {
+		// Create via SDK
+		groupRefs := make([]nb.ApprovalWorkflowStageResponseApprovalWorkflowStage, 0, len(groupIDs))
+		for _, gid := range groupIDs {
+			id := gid
+			groupRefs = append(groupRefs, nb.ApprovalWorkflowStageResponseApprovalWorkflowStage{
+				Id: &nb.ApprovalWorkflowApprovalWorkflowDefinitionId{Int32: &id},
+			})
+		}
+
+		req := nb.ObjectPermissionRequest{
+			Name:        perm.Name,
+			ObjectTypes: perm.ObjectTypes,
+			Actions:     actions,
+			Enabled:     nb.PtrBool(perm.IsEnabled()),
+			Groups:      groupRefs,
+		}
+		if perm.Description != "" {
+			req.Description = nb.PtrString(perm.Description)
+		}
+		if constraints != nil {
+			req.Constraints = constraints
+		}
+
+		created, err := s.permissionSvc.Create(ctx, req)
+		if err != nil {
+			return fmt.Errorf("failed to create permission %q: %w", perm.Name, err)
+		}
+		log.Info("permission synced (created)", "name", perm.Name, "id", created.GetId())
+	}
+
+	return nil
+}
+
+func (s *PermissionGroupSync) resolveGroupID(ctx context.Context, name string, cache map[string]int32) (int32, error) {
+	if id, ok := cache[name]; ok {
+		return id, nil
+	}
+
+	group, err := s.groupSvc.GetOrCreate(ctx, name)
+	if err != nil {
+		return 0, err
+	}
+	if group == nil {
+		return 0, fmt.Errorf("failed to get or create group: %s", name)
+	}
+
+	cache[name] = group.Id
+	return group.Id, nil
+}


### PR DESCRIPTION
This PR adds Nautobot Admin Groups and Permission sync.
Example of config map this will sync form.

This is only for admin that's why it's nested into admin folder to keep things cleaner

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: permission-groups
  namespace: nautobot
data:
  permission-groups.yaml: |
    permissions:
      - name: read-all
        description: Allow read access to all objects
        can_view: true
        object_types:
          - "dcim.device"
          - "dcim.location"
          - "dcim.rack"
          - "ipam.prefix"
          - "ipam.vlan"
        groups:
          - 'infra.baremetal.admin'
          - 'infra.controlplane.admin'
          - 'infra.ironops'
          - 'infra.fabricops'
          - 'infra.dctechs'
          - 'rxdb.manager'
          - 'sandbox.manager'
          - 'sddc.manager'
          - 'rxdb.member'
          - 'sandbox.member'
          - 'sddc.member'
          - 'rackspace.all'

      - name: user-api-tokens
        description: Allow users to manage their own API tokens
        can_view: true
        can_add: true
        can_change: true
        can_delete: true
        object_types:
          - "users.token"
        groups:
          - 'infra.baremetal.admin'
          - 'infra.controlplane.admin'
          - 'infra.ironops'
          - 'infra.fabricops'
          - 'infra.dctechs'
          - 'rxdb.manager'
          - 'sandbox.manager'
          - 'sddc.manager'
          - 'rxdb.member'
          - 'sandbox.member'
          - 'sddc.member'
          - 'rackspace.all'

      - name: napalm-read
        description: Allow NAPALM read operations on devices
        can_view: true
        additional_actions:
          - "napalm_read"
        object_types:
          - "dcim.device"
        groups:
          - 'infra.baremetal.admin'

      - name: job-execution
        description: Allow job execution
        can_view: true
        can_add: true
        can_change: true
        object_types:
          - "extras.job"
          - "extras.jobresult"
        groups:
          - 'infra.baremetal.admin'
          - 'infra.controlplane.admin'

      - name: sys-admin
        description: Full system administration access
        can_view: true
        can_add: true
        can_change: true
        can_delete: true
        object_types:
          - "dcim.device"
          - "dcim.location"
          - "dcim.rack"
          - "ipam.prefix"
          - "ipam.vlan"
          - "extras.job"
        groups:
          - 'infra.controlplane.admin'

      - name: storage-admin
        description: Storage administration access
        can_view: true
        can_add: true
        can_change: true
        can_delete: true
        object_types:
          - "dcim.device"
          - "dcim.rack"
        groups:
          - 'infra.baremetal.admin'
          - 'infra.controlplane.admin'

```

**Groups Screenshot**
<img width="1676" height="595" alt="image" src="https://github.com/user-attachments/assets/0da4fe90-ce06-4e63-a78b-b082cb3a3c5a" />

**Permission Screenshot**

<img width="1649" height="734" alt="image" src="https://github.com/user-attachments/assets/00b77eee-200d-4127-949f-84784eeb28fd" />

