### PR TITLE
feat: make enroll-netdev re-runnable via find-or-create PUC-1905

### DIFF
--- a/python/understack-workflows/tests/test_enroll_netdev.py
+++ b/python/understack-workflows/tests/test_enroll_netdev.py
@@ -3,19 +3,70 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 from unittest.mock import call
 
+import pytest
+from ironicclient.common.apiclient import exceptions as ironic_exceptions
+
 from understack_workflows import ironic_node
 from understack_workflows.main import enroll_netdev
+
+ENROLL_ARGS = {
+    "name": "leaf01",
+    "physical_network": "f20-1-network",
+    "ports": [
+        {
+            "label": "port1",
+            "mac": "00:11:22:33:44:55",
+            "switch": "spine01.example.net",
+            "intf": "Ethernet1/1",
+        },
+        {
+            "label": "port2",
+            "mac": "00:11:22:33:44:66",
+            "switch": "spine02.example.net",
+            "intf": "Ethernet1/2",
+        },
+    ],
+}
 
 
 def make_ironic_client():
     fake_client = MagicMock()
-    node = SimpleNamespace(uuid="node-123")
+    node = SimpleNamespace(uuid="node-123", driver="netdev", provision_state="enroll")
+    fake_client.node.get.side_effect = ironic_exceptions.NotFound()
     fake_client.node.create.return_value = node
+    fake_client.port.list.return_value = []
     fake_client.port.create.side_effect = [
         SimpleNamespace(uuid="port-1"),
         SimpleNamespace(uuid="port-2"),
     ]
     return fake_client, node
+
+
+def existing_port(label, mac, switch, interface, name=None, category="network"):
+    return SimpleNamespace(
+        uuid=f"uuid-{label}",
+        address=mac,
+        name=name or f"leaf01:{label}",
+        physical_network="f20-1-network",
+        category=category,
+        local_link_connection={
+            "switch_id": "00:00:00:00:00:00",
+            "switch_info": switch,
+            "port_id": interface,
+        },
+    )
+
+
+def matching_ports():
+    """Two existing ports that exactly match the ENROLL_ARGS request."""
+    return [
+        existing_port(
+            "port1", "00:11:22:33:44:55", "spine01.example.net", "Ethernet1/1"
+        ),
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
 
 
 def test_enroll_creates_node_ports_logs_and_makes_available(mocker, caplog):
@@ -26,17 +77,7 @@ def test_enroll_creates_node_ports_logs_and_makes_available(mocker, caplog):
         return_value=fake_ironic,
     )
 
-    enroll_netdev.enroll(
-        name="leaf01",
-        physical_network="f20-1-network",
-        port1_mac="00:11:22:33:44:55",
-        port1_switch="spine01.example.net",
-        port1_intf="Ethernet1/1",
-        port2_mac="00:11:22:33:44:66",
-        port2_switch="spine02.example.net",
-        port2_intf="Ethernet1/2",
-        resource_class=None,
-    )
+    enroll_netdev.enroll(**ENROLL_ARGS, resource_class=None)
 
     fake_ironic.node.create.assert_called_once_with(
         automated_clean=False,
@@ -118,14 +159,7 @@ def test_enroll_records_external_cmdb_id_and_custom_resource_class(mocker):
     )
 
     enroll_netdev.enroll(
-        name="leaf01",
-        physical_network="f20-1-network",
-        port1_mac="00:11:22:33:44:55",
-        port1_switch="spine01.example.net",
-        port1_intf="Ethernet1/1",
-        port2_mac="00:11:22:33:44:66",
-        port2_switch="spine02.example.net",
-        port2_intf="Ethernet1/2",
+        **ENROLL_ARGS,
         external_cmdb_id="cmdb-1",
         resource_class="switch",
     )
@@ -139,6 +173,753 @@ def test_enroll_records_external_cmdb_id_and_custom_resource_class(mocker):
     )
 
 
+def test_enroll_reuses_existing_node_and_matching_ports(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    fake_ironic.port.list.return_value = matching_ports()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    fake_ironic.node.create.assert_not_called()
+    fake_ironic.port.create.assert_not_called()
+    fake_ironic.port.update.assert_not_called()
+    fake_ironic.node.update.assert_called_once_with(
+        "node-123",
+        [{"op": "add", "path": "/resource_class", "value": "generic"}],
+    )
+    # Node was already manageable: no manage transition, only provide.
+    fake_ironic.node.set_provision_state.assert_called_once_with(
+        "node-123",
+        "provide",
+        cleansteps=None,
+        runbook=None,
+        disable_ramdisk=None,
+    )
+
+
+def test_enroll_updates_existing_port_and_creates_missing_one(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    stale_port1 = existing_port(
+        "port1", "00:11:22:33:44:55", "old-switch.example.net", "Ethernet9/9"
+    )
+    fake_ironic.port.list.return_value = [stale_port1]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    fake_ironic.port.update.assert_called_once_with(
+        "uuid-port1",
+        [
+            {
+                "op": "add",
+                "path": "/local_link_connection",
+                "value": {
+                    "switch_id": "00:00:00:00:00:00",
+                    "switch_info": "spine01.example.net",
+                    "port_id": "Ethernet1/1",
+                },
+            },
+        ],
+    )
+    fake_ironic.port.create.assert_called_once_with(
+        address="00:11:22:33:44:66",
+        category="network",
+        local_link_connection={
+            "switch_id": "00:00:00:00:00:00",
+            "switch_info": "spine02.example.net",
+            "port_id": "Ethernet1/2",
+        },
+        name="leaf01:port2",
+        node_uuid="node-123",
+        physical_network="f20-1-network",
+    )
+
+
+def test_enroll_skips_transitions_when_node_already_available(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="available"
+    )
+    fake_ironic.port.list.return_value = matching_ports()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    fake_ironic.node.set_provision_state.assert_not_called()
+    fake_ironic.node.wait_for_provision_state.assert_not_called()
+
+
+def test_enroll_steps_available_node_down_to_update_ports(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="available"
+    )
+    # port1 needs an update; port2 already matches.
+    stale_port1 = existing_port(
+        "port1", "00:11:22:33:44:55", "old-switch.example.net", "Ethernet9/9"
+    )
+    fake_ironic.port.list.return_value = [
+        stale_port1,
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    # Ironic forbids port connectivity changes while available, so the node is
+    # stepped available -> manageable, the port is updated, then provided back.
+    fake_ironic.node.set_provision_state.assert_has_calls(
+        [
+            call(
+                "node-123",
+                "manage",
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+            call(
+                "node-123",
+                "provide",
+                cleansteps=None,
+                runbook=None,
+                disable_ramdisk=None,
+            ),
+        ]
+    )
+    fake_ironic.port.update.assert_called_once()
+
+
+def test_enroll_is_true_noop_when_available_and_everything_matches(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123",
+        driver="netdev",
+        provision_state="available",
+        resource_class="generic",
+        extra={},
+    )
+    fake_ironic.port.list.return_value = matching_ports()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    # Nothing drifted: no metadata patch, no port work, no state churn.
+    fake_ironic.node.update.assert_not_called()
+    fake_ironic.port.update.assert_not_called()
+    fake_ironic.port.create.assert_not_called()
+    fake_ironic.node.set_provision_state.assert_not_called()
+
+
+def test_enroll_updates_metadata_only_on_available_node(mocker, caplog):
+    caplog.set_level(logging.INFO)
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123",
+        driver="netdev",
+        provision_state="available",
+        resource_class="old-class",
+        extra={},
+    )
+    fake_ironic.port.list.return_value = matching_ports()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS, resource_class="new-class")
+
+    # resource_class changed: node is patched, but no port work and no
+    # transition, and the log does not claim "nothing to do".
+    fake_ironic.node.update.assert_called_once_with(
+        "node-123",
+        [{"op": "add", "path": "/resource_class", "value": "new-class"}],
+    )
+    fake_ironic.node.set_provision_state.assert_not_called()
+    assert "nothing to do" not in caplog.text
+
+
+def test_enroll_fails_on_existing_node_with_other_driver(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="idrac", provision_state="active"
+    )
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    with pytest.raises(RuntimeError, match="refusing to enroll it as a netdev"):
+        enroll_netdev.enroll(**ENROLL_ARGS)
+
+    fake_ironic.node.create.assert_not_called()
+    fake_ironic.port.create.assert_not_called()
+
+
+def test_enroll_fails_on_node_in_unexpected_state(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="active"
+    )
+    fake_ironic.port.list.return_value = matching_ports()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    with pytest.raises(RuntimeError, match="Cannot enroll node in provision_state"):
+        enroll_netdev.enroll(**ENROLL_ARGS)
+
+    # State is checked before any mutation: node is not patched, no transitions.
+    fake_ironic.node.update.assert_not_called()
+    fake_ironic.node.set_provision_state.assert_not_called()
+
+
+def test_enroll_rejects_duplicate_port_macs(mocker):
+    fake_ironic, _ = make_ironic_client()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    args = {
+        **ENROLL_ARGS,
+        "ports": [
+            {
+                "label": "port1",
+                "mac": "00:11:22:33:44:55",
+                "switch": "s1",
+                "intf": "e1",
+            },
+            {
+                "label": "port2",
+                "mac": "00:11:22:33:44:55",
+                "switch": "s2",
+                "intf": "e2",
+            },
+        ],
+    }
+
+    with pytest.raises(ValueError, match="Duplicate MAC"):
+        enroll_netdev.enroll(**args)
+
+    # Fail fast, before any Ironic calls.
+    fake_ironic.node.get.assert_not_called()
+    fake_ironic.node.create.assert_not_called()
+
+
+def test_enroll_rejects_duplicate_port_labels(mocker):
+    fake_ironic, _ = make_ironic_client()
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    args = {
+        **ENROLL_ARGS,
+        "ports": [
+            {
+                "label": "port1",
+                "mac": "00:11:22:33:44:55",
+                "switch": "s1",
+                "intf": "e1",
+            },
+            {
+                "label": "port1",
+                "mac": "00:11:22:33:44:66",
+                "switch": "s2",
+                "intf": "e2",
+            },
+        ],
+    }
+
+    with pytest.raises(ValueError, match="Duplicate label"):
+        enroll_netdev.enroll(**args)
+
+    # Fail fast, before any Ironic calls.
+    fake_ironic.node.get.assert_not_called()
+    fake_ironic.node.create.assert_not_called()
+
+
+def test_enroll_creates_n_ports(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.port.create.side_effect = [
+        SimpleNamespace(uuid="port-1"),
+        SimpleNamespace(uuid="port-2"),
+        SimpleNamespace(uuid="port-3"),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(
+        name="leaf01",
+        physical_network="f20-1-network",
+        ports=[
+            {
+                "label": "port1",
+                "mac": "00:11:22:33:44:55",
+                "switch": "s1",
+                "intf": "Eth1/1",
+            },
+            {
+                "label": "port2",
+                "mac": "00:11:22:33:44:66",
+                "switch": "s2",
+                "intf": "Eth1/2",
+            },
+            {
+                "label": "port3",
+                "mac": "00:11:22:33:44:77",
+                "switch": "s3",
+                "intf": "Eth1/3",
+            },
+        ],
+    )
+
+    assert fake_ironic.port.create.call_count == 3
+    created_names = [c.kwargs["name"] for c in fake_ironic.port.create.call_args_list]
+    assert created_names == ["leaf01:port1", "leaf01:port2", "leaf01:port3"]
+
+
+def test_enroll_warns_and_keeps_orphan_ports(mocker, caplog):
+    caplog.set_level(logging.WARNING)
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    orphan = existing_port(
+        "port9", "00:99:99:99:99:99", "old.example.net", "Ethernet9/9"
+    )
+    fake_ironic.port.list.return_value = [*matching_ports(), orphan]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    fake_ironic.port.delete.assert_not_called()
+    assert "name=leaf01:port9 mac=00:99:99:99:99:99" in caplog.text
+    assert "not in the request by label" in caplog.text
+
+
+def test_enroll_shrinking_ports_leaves_extra_as_orphan(mocker, caplog):
+    caplog.set_level(logging.WARNING)
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    # Node currently has 3 ports; the request only lists the first two.
+    port3 = existing_port(
+        "port3", "00:11:22:33:44:77", "spine03.example.net", "Ethernet1/3"
+    )
+    fake_ironic.port.list.return_value = [*matching_ports(), port3]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    # port3 is not in the request: warned about, left in place, not touched.
+    fake_ironic.port.delete.assert_not_called()
+    fake_ironic.port.update.assert_not_called()
+    assert "name=leaf01:port3 mac=00:11:22:33:44:77" in caplog.text
+    assert "not in the request by label" in caplog.text
+
+
+def test_enroll_refuses_mac_move_to_existing_port(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    # Existing: port1=..:55, port2=..:66, port3=..:77 (named leaf01:port1/2/3).
+    fake_ironic.port.list.return_value = [
+        *matching_ports(),
+        existing_port(
+            "port3", "00:11:22:33:44:77", "spine03.example.net", "Ethernet1/3"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    # Operator wants port3's MAC to become port2 while port3 still exists.
+    # The workflow refuses to do an automatic label move/rename.
+    args = {
+        **ENROLL_ARGS,
+        "ports": [
+            {
+                "label": "port1",
+                "mac": "00:11:22:33:44:55",
+                "switch": "spine01.example.net",
+                "intf": "Ethernet1/1",
+            },
+            {
+                "label": "port2",
+                "mac": "00:11:22:33:44:77",
+                "switch": "spine03.example.net",
+                "intf": "Ethernet1/3",
+            },
+        ],
+    }
+
+    with pytest.raises(RuntimeError, match="already used by port uuid-port3"):
+        enroll_netdev.enroll(**args)
+
+    fake_ironic.port.update.assert_not_called()
+    fake_ironic.port.create.assert_not_called()
+
+
+def test_build_netdev_ports_rejects_unknown_fields():
+    with pytest.raises(ValueError, match="unknown field"):
+        enroll_netdev.build_netdev_ports(
+            [
+                {
+                    "label": "uplink-a",
+                    "mac": "00:11:22:33:44:55",
+                    "switch": "s1",
+                    "intf": "e1",
+                    "description": "not supported",
+                }
+            ]
+        )
+
+
+def test_build_netdev_ports_requires_fields():
+    with pytest.raises(ValueError, match="missing required field"):
+        enroll_netdev.build_netdev_ports([{"mac": "00:11:22:33:44:55"}])
+
+
+def test_build_netdev_ports_requires_non_empty():
+    with pytest.raises(ValueError, match="At least one port"):
+        enroll_netdev.build_netdev_ports([])
+
+
+def test_parse_ports_arg_rejects_non_json():
+    with pytest.raises(ValueError, match="must be valid JSON"):
+        enroll_netdev.parse_ports_arg("not-json")
+
+
+def test_parse_ports_arg_rejects_non_array():
+    with pytest.raises(ValueError, match="must be a JSON array"):
+        enroll_netdev.parse_ports_arg('{"mac": "x"}')
+
+
+def test_enroll_updates_existing_port_mac_by_label(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    fake_ironic.port.list.return_value = [
+        existing_port(
+            "port1", "00:aa:bb:cc:dd:ee", "spine01.example.net", "Ethernet1/1"
+        ),
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    fake_ironic.port.update.assert_called_once_with(
+        "uuid-port1",
+        [{"op": "add", "path": "/address", "value": "00:11:22:33:44:55"}],
+    )
+    fake_ironic.port.create.assert_not_called()
+
+
+def test_enroll_switch_id_override_on_create(mocker):
+    fake_ironic, node = make_ironic_client()
+    fake_ironic.port.create.side_effect = [SimpleNamespace(uuid="port-1")]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(
+        name="leaf01",
+        physical_network="f20-1-network",
+        ports=[
+            {
+                "label": "port1",
+                "mac": "00:11:22:33:44:55",
+                "switch": "spine01.example.net",
+                "intf": "Ethernet1/1",
+                "switch_id": "aa:bb:cc:dd:ee:ff",
+            }
+        ],
+    )
+
+    fake_ironic.port.create.assert_called_once_with(
+        address="00:11:22:33:44:55",
+        category="network",
+        local_link_connection={
+            "switch_id": "aa:bb:cc:dd:ee:ff",
+            "switch_info": "spine01.example.net",
+            "port_id": "Ethernet1/1",
+        },
+        name="leaf01:port1",
+        node_uuid=node.uuid,
+        physical_network="f20-1-network",
+    )
+
+
+def test_enroll_switch_id_override_replaces_existing_value(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    # port1 already has a real switch_id; the operator corrects it explicitly.
+    port1 = existing_port(
+        "port1", "00:11:22:33:44:55", "spine01.example.net", "Ethernet1/1"
+    )
+    port1.local_link_connection = {
+        "switch_id": "11:11:11:11:11:11",
+        "switch_info": "spine01.example.net",
+        "port_id": "Ethernet1/1",
+    }
+    fake_ironic.port.list.return_value = [
+        port1,
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(
+        name="leaf01",
+        physical_network="f20-1-network",
+        ports=[
+            {
+                "label": "port1",
+                "mac": "00:11:22:33:44:55",
+                "switch": "spine01.example.net",
+                "intf": "Ethernet1/1",
+                "switch_id": "aa:bb:cc:dd:ee:ff",
+            },
+            {
+                "label": "port2",
+                "mac": "00:11:22:33:44:66",
+                "switch": "spine02.example.net",
+                "intf": "Ethernet1/2",
+            },
+        ],
+    )
+
+    # Explicit switch_id wins over the existing real value.
+    fake_ironic.port.update.assert_called_once_with(
+        "uuid-port1",
+        [
+            {
+                "op": "add",
+                "path": "/local_link_connection",
+                "value": {
+                    "switch_id": "aa:bb:cc:dd:ee:ff",
+                    "switch_info": "spine01.example.net",
+                    "port_id": "Ethernet1/1",
+                },
+            }
+        ],
+    )
+
+
+def test_enroll_updates_port_with_null_local_link_connection(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    port1 = existing_port(
+        "port1", "00:11:22:33:44:55", "spine01.example.net", "Ethernet1/1"
+    )
+    port1.local_link_connection = None
+    fake_ironic.port.list.return_value = [
+        port1,
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    # Whole local_link_connection object is replaced, not nested keys, so the
+    # patch is valid even though the existing value was null.
+    fake_ironic.port.update.assert_called_once_with(
+        "uuid-port1",
+        [
+            {
+                "op": "add",
+                "path": "/local_link_connection",
+                "value": {
+                    "switch_id": "00:00:00:00:00:00",
+                    "switch_info": "spine01.example.net",
+                    "port_id": "Ethernet1/1",
+                },
+            },
+        ],
+    )
+
+
+def test_enroll_converges_existing_port_missing_category(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    port1 = existing_port(
+        "port1", "00:11:22:33:44:55", "spine01.example.net", "Ethernet1/1"
+    )
+    port1.category = None
+    fake_ironic.port.list.return_value = [
+        port1,
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    fake_ironic.port.update.assert_called_once_with(
+        "uuid-port1",
+        [{"op": "add", "path": "/category", "value": "network"}],
+    )
+
+
+def test_enroll_preserves_real_switch_id_when_only_metadata_changes(mocker):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="manageable"
+    )
+    # port1 already has a real switch_id and a stale switch_info/port_id.
+    port1 = existing_port(
+        "port1", "00:11:22:33:44:55", "old-switch.example.net", "Ethernet9/9"
+    )
+    port1.local_link_connection = {
+        "switch_id": "aa:bb:cc:dd:ee:ff",
+        "switch_info": "old-switch.example.net",
+        "port_id": "Ethernet9/9",
+    }
+    fake_ironic.port.list.return_value = [
+        port1,
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    # switch_info/port_id converge to the request, but the real switch_id is
+    # kept rather than being reset to the placeholder.
+    fake_ironic.port.update.assert_called_once_with(
+        "uuid-port1",
+        [
+            {
+                "op": "add",
+                "path": "/local_link_connection",
+                "value": {
+                    "switch_id": "aa:bb:cc:dd:ee:ff",
+                    "switch_info": "spine01.example.net",
+                    "port_id": "Ethernet1/1",
+                },
+            },
+        ],
+    )
+
+
+def test_enroll_does_not_touch_port_with_real_switch_id_and_matching_metadata(
+    mocker,
+):
+    fake_ironic, _ = make_ironic_client()
+    fake_ironic.node.get.side_effect = None
+    fake_ironic.node.get.return_value = SimpleNamespace(
+        uuid="node-123", driver="netdev", provision_state="available"
+    )
+    port1 = existing_port(
+        "port1", "00:11:22:33:44:55", "spine01.example.net", "Ethernet1/1"
+    )
+    port1.local_link_connection = {
+        "switch_id": "aa:bb:cc:dd:ee:ff",
+        "switch_info": "spine01.example.net",
+        "port_id": "Ethernet1/1",
+    }
+    fake_ironic.port.list.return_value = [
+        port1,
+        existing_port(
+            "port2", "00:11:22:33:44:66", "spine02.example.net", "Ethernet1/2"
+        ),
+    ]
+    mocker.patch(
+        "understack_workflows.ironic.client.get_ironic_client",
+        return_value=fake_ironic,
+    )
+
+    enroll_netdev.enroll(**ENROLL_ARGS)
+
+    # A real switch_id with otherwise-matching metadata is a no-op: no port
+    # update and no state churn on the available node.
+    fake_ironic.port.update.assert_not_called()
+    fake_ironic.node.set_provision_state.assert_not_called()
+
+
 def test_argument_parser_defaults_resource_class_to_generic():
     args = enroll_netdev.argument_parser().parse_args(
         [
@@ -146,20 +927,21 @@ def test_argument_parser_defaults_resource_class_to_generic():
             "leaf01",
             "--physical-network",
             "f20-1-network",
-            "--port1-mac",
-            "00:11:22:33:44:55",
-            "--port1-switch",
-            "spine01.example.net",
-            "--port1-intf",
-            "Ethernet1/1",
-            "--port2-mac",
-            "00:11:22:33:44:66",
-            "--port2-switch",
-            "spine02.example.net",
-            "--port2-intf",
-            "Ethernet1/2",
+            "--ports",
+            (
+                '[{"label": "port1", "mac": "00:11:22:33:44:55", '
+                '"switch": "s1", "intf": "e1"}]'
+            ),
         ]
     )
 
     assert args.resource_class == "generic"
     assert args.external_cmdb_id == ""
+    assert enroll_netdev.parse_ports_arg(args.ports) == [
+        {
+            "label": "port1",
+            "mac": "00:11:22:33:44:55",
+            "switch": "s1",
+            "intf": "e1",
+        }
+    ]

--- a/python/understack-workflows/understack_workflows/main/enroll_netdev.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_netdev.py
@@ -1,8 +1,11 @@
 import argparse
+import json
 import logging
 import os
 from dataclasses import dataclass
 
+from ironicclient.common.apiclient import exceptions as ironic_exceptions
+from ironicclient.common.utils import args_array_to_patch
 from ironicclient.v1.node import Node
 
 from understack_workflows import helpers
@@ -11,6 +14,22 @@ from understack_workflows.ironic.client import IronicClient
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_RESOURCE_CLASS = "generic"
+PLACEHOLDER_SWITCH_ID = "00:00:00:00:00:00"
+
+# Provision states from which enrollment can proceed to "available".
+# Anything else (e.g. "active", "deploying") means the node is in use
+# and we are not touching it.
+REENROLLABLE_STATES = {"enroll", "manageable", "available"}
+
+# Keys for each entry in the --ports list. The label is the stable identity
+# for a port on a node; the MAC and connection metadata are editable values
+# that converge on re-runs. switch_id is optional: when omitted the placeholder
+# is used (and an existing real value is preserved).
+REQUIRED_PORT_FIELDS = ("label", "mac", "switch", "intf")
+OPTIONAL_PORT_FIELDS = ("switch_id",)
+ALLOWED_PORT_FIELDS = frozenset(REQUIRED_PORT_FIELDS + OPTIONAL_PORT_FIELDS)
+
 
 @dataclass(frozen=True)
 class NetdevPort:
@@ -18,50 +37,118 @@ class NetdevPort:
     mac: str
     switch: str
     interface: str
+    switch_id: str | None = None
+
+
+def _has_cmdb_id(external_cmdb_id: int | str | None) -> bool:
+    """Return True unless the CMDB ID is unset (None or empty string).
+
+    A truthiness check would wrongly drop a valid CMDB ID of 0.
+    """
+    return external_cmdb_id not in (None, "")
 
 
 def main() -> None:
-    """Create a netdev baremetal node, its 2 ports, and make it available."""
+    """Create a netdev baremetal node, its ports, and make it available.
+
+    Re-running with the same parameters is safe: an existing node with the same
+    name is reused (and updated), existing ports are matched by their label
+    derived name (node_name:label) and updated in place, and provision state
+    transitions are only performed when needed.
+
+    Any number of ports may be supplied via --ports. Each port must include a
+    stable label; changing, removing, or renaming labels is a manual operation.
+    """
     helpers.setup_logger()
     args = argument_parser().parse_args()
 
     enroll(
         name=args.name,
         physical_network=args.physical_network,
-        port1_mac=args.port1_mac,
-        port1_switch=args.port1_switch,
-        port1_intf=args.port1_intf,
-        port2_mac=args.port2_mac,
-        port2_switch=args.port2_switch,
-        port2_intf=args.port2_intf,
+        ports=parse_ports_arg(args.ports),
         external_cmdb_id=args.external_cmdb_id,
         resource_class=args.resource_class,
     )
+
+
+def parse_ports_arg(raw: str) -> list[dict]:
+    """Parse the --ports argument (a JSON array) into a list of dicts."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--ports must be valid JSON: {exc}") from exc
+    if not isinstance(data, list):
+        raise ValueError("--ports must be a JSON array of port objects")
+    return data
+
+
+def build_netdev_ports(ports: list[dict]) -> list[NetdevPort]:
+    """Validate the ports list and return NetdevPort objects.
+
+    Labels are stable caller-provided identities (e.g. port1, port2, ...).
+    MAC addresses and labels must be unique within the request.
+    """
+    if not ports:
+        raise ValueError("At least one port must be provided")
+
+    result: list[NetdevPort] = []
+    seen_labels: set[str] = set()
+    seen_macs: set[str] = set()
+    for index, entry in enumerate(ports, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Port {index} must be a JSON object")
+        missing = [key for key in REQUIRED_PORT_FIELDS if not entry.get(key)]
+        if missing:
+            raise ValueError(
+                f"Port {index} is missing required field(s): {', '.join(missing)}"
+            )
+        unknown = set(entry) - ALLOWED_PORT_FIELDS
+        if unknown:
+            raise ValueError(
+                f"Port {index} has unknown field(s): {', '.join(sorted(unknown))}"
+            )
+        # Labels are case-sensitive identities: they map directly to the Ironic
+        # port name (node_name:label), and that lookup is case-sensitive, so
+        # dedup must be too.
+        if entry["label"] in seen_labels:
+            raise ValueError(f"Duplicate label {entry['label']} in ports list")
+        seen_labels.add(entry["label"])
+        mac_key = entry["mac"].lower()
+        if mac_key in seen_macs:
+            raise ValueError(f"Duplicate MAC {entry['mac']} in ports list")
+        seen_macs.add(mac_key)
+        result.append(
+            NetdevPort(
+                label=entry["label"],
+                mac=entry["mac"],
+                switch=entry["switch"],
+                interface=entry["intf"],
+                switch_id=entry.get("switch_id"),
+            )
+        )
+    return result
 
 
 def enroll(
     *,
     name: str,
     physical_network: str,
-    port1_mac: str,
-    port1_switch: str,
-    port1_intf: str,
-    port2_mac: str,
-    port2_switch: str,
-    port2_intf: str,
+    ports: list[dict],
     external_cmdb_id: int | str | None = None,
-    resource_class: str | None = "generic",
+    resource_class: str | None = DEFAULT_RESOURCE_CLASS,
 ) -> None:
-    effective_resource_class = resource_class or "generic"
+    effective_resource_class = resource_class or DEFAULT_RESOURCE_CLASS
+    netdev_ports = build_netdev_ports(ports)
     logger.info(
         "Starting enroll-netdev workflow name=%s physical_network=%s "
-        "resource_class=%s",
+        "resource_class=%s port_count=%s",
         name,
         physical_network,
         effective_resource_class,
+        len(netdev_ports),
     )
 
-    if external_cmdb_id:
+    if _has_cmdb_id(external_cmdb_id):
         logger.info(
             "Recording external_cmdb_id=%s on the Ironic node",
             external_cmdb_id,
@@ -70,44 +157,184 @@ def enroll(
         logger.info("No external_cmdb_id provided")
 
     client = IronicClient()
-    node = create_netdev_node(
+    node, created = find_or_create_netdev_node(
         client=client,
         name=name,
         resource_class=effective_resource_class,
         external_cmdb_id=external_cmdb_id,
     )
 
-    ports = [
-        NetdevPort("port1", port1_mac, port1_switch, port1_intf),
-        NetdevPort("port2", port2_mac, port2_switch, port2_intf),
-    ]
-    for port in ports:
-        create_netdev_port(
-            client=client,
+    node_ports = list(client.list_ports(node.uuid))
+    ports_by_mac = {(p.address or "").lower(): p for p in node_ports}
+    ports_by_name = {p.name: p for p in node_ports if p.name}
+
+    # Plan first (no mutations): decide which ports need create/update. This
+    # lets us skip all work when a re-run has nothing to change, only step the
+    # node's provision state when we actually have port work to do, and fail on
+    # a port conflict before mutating anything.
+    plans = [
+        plan_netdev_port(
             node=node,
             node_name=name,
             physical_network=physical_network,
             port=port,
+            existing=ports_by_name.get(f"{name}:{port.label}"),
+            ports_by_mac=ports_by_mac,
+        )
+        for port in netdev_ports
+    ]
+    pending = [plan for plan in plans if plan is not None]
+
+    warn_orphan_ports(node, name, node_ports, netdev_ports)
+
+    # Apply the reused node's metadata only after planning has validated, so a
+    # port conflict does not leave resource_class/external_cmdb_id half-updated.
+    # A freshly created node already has these set from create.
+    metadata_changed = False
+    if not created:
+        metadata_changed = update_node_metadata(
+            client=client,
+            node=node,
+            resource_class=effective_resource_class,
+            external_cmdb_id=external_cmdb_id,
         )
 
-    logger.info(
-        "[node:%s] Requesting manage transition, expecting manageable",
-        node.uuid,
-    )
-    ironic_node.transition(node, target_state="manage", expected_state="manageable")
-    logger.info("[node:%s] Node is manageable", node.uuid)
+    state = node.provision_state
 
-    logger.info(
-        "[node:%s] Requesting provide transition, expecting available",
-        node.uuid,
-    )
-    ironic_node.transition(node, target_state="provide", expected_state="available")
-    logger.info("[node:%s] Node is available", node.uuid)
+    if not pending and state == "available":
+        if metadata_changed:
+            logger.info(
+                "[node:%s] Node metadata updated; already available with no "
+                "port changes",
+                node.uuid,
+            )
+        else:
+            logger.info(
+                "[node:%s] Node already available and up to date, nothing to do",
+                node.uuid,
+            )
+        return
+
+    # Ironic refuses port connectivity changes (local_link_connection,
+    # physical_network, ...) while the node is "available", so step it back to
+    # "manageable" before applying any port work, then provide it again below.
+    if pending and state == "available":
+        logger.info(
+            "[node:%s] Stepping available, manageable to apply port changes",
+            node.uuid,
+        )
+        ironic_node.transition(node, target_state="manage", expected_state="manageable")
+        state = "manageable"
+
+    for plan in pending:
+        apply_port_plan(
+            client=client,
+            node=node,
+            node_name=name,
+            physical_network=physical_network,
+            plan=plan,
+        )
+
+    make_available(node, state)
     logger.info(
         "Completed enroll-netdev workflow name=%s node_uuid=%s",
         name,
         node.uuid,
     )
+
+
+def warn_orphan_ports(
+    node: Node, node_name: str, node_ports: list, netdev_ports: list[NetdevPort]
+) -> None:
+    """Warn about existing ports on the node that are not in the request.
+
+    These are left in place rather than deleted: removing ports on a re-run
+    would let a shortened request silently destroy data.
+    """
+    requested = {f"{node_name}:{port.label}" for port in netdev_ports}
+    for existing in node_ports:
+        if existing.name not in requested:
+            logger.warning(
+                "[node:%s] Existing port uuid=%s name=%s mac=%s is not in the "
+                "request by label; leaving it in place",
+                node.uuid,
+                existing.uuid,
+                existing.name,
+                existing.address,
+            )
+
+
+def find_or_create_netdev_node(
+    *,
+    client: IronicClient,
+    name: str,
+    resource_class: str,
+    external_cmdb_id: int | str | None = None,
+) -> tuple[Node, bool]:
+    """Find an existing netdev node by name, or create one.
+
+    Returns (node, created). A reused node is validated (driver and provision
+    state) but not mutated here; its metadata is applied later by the caller
+    once port planning has succeeded.
+    """
+    try:
+        node = client.get_node(name)
+    except ironic_exceptions.NotFound:
+        node = create_netdev_node(
+            client=client,
+            name=name,
+            resource_class=resource_class,
+            external_cmdb_id=external_cmdb_id,
+        )
+        return node, True
+
+    if node.driver != "netdev":
+        raise RuntimeError(
+            f"Node {name} ({node.uuid}) already exists with driver "
+            f"{node.driver!r}; refusing to enroll it as a netdev"
+        )
+
+    if node.provision_state not in REENROLLABLE_STATES:
+        raise RuntimeError(
+            f"[node:{node.uuid}] Cannot enroll node in provision_state "
+            f"{node.provision_state!r}; expected one of "
+            f"{sorted(REENROLLABLE_STATES)}"
+        )
+
+    logger.info(
+        "[node:%s] Reusing existing netdev node name=%s provision_state=%s",
+        node.uuid,
+        name,
+        node.provision_state,
+    )
+    return node, False
+
+
+def update_node_metadata(
+    *,
+    client: IronicClient,
+    node: Node,
+    resource_class: str,
+    external_cmdb_id: int | str | None = None,
+) -> bool:
+    """Patch resource_class/external_cmdb_id only if they differ from the node.
+
+    Returns True if a patch was sent, so the caller can report accurately.
+    """
+    updates = []
+    if getattr(node, "resource_class", None) != resource_class:
+        updates.append(f"resource_class={resource_class}")
+    if _has_cmdb_id(external_cmdb_id):
+        current = (getattr(node, "extra", None) or {}).get("external_cmdb_id")
+        if current != external_cmdb_id:
+            updates.append(f"extra/external_cmdb_id={external_cmdb_id}")
+
+    if not updates:
+        return False
+
+    logger.info("[node:%s] Updating node metadata %s", node.uuid, updates)
+    client.update_node(node.uuid, args_array_to_patch("add", updates))
+    return True
 
 
 def create_netdev_node(
@@ -123,7 +350,7 @@ def create_netdev_node(
         "name": name,
         "resource_class": resource_class,
     }
-    if external_cmdb_id:
+    if _has_cmdb_id(external_cmdb_id):
         node_data["extra"] = {"external_cmdb_id": external_cmdb_id}
 
     logger.info(
@@ -139,6 +366,130 @@ def create_netdev_node(
     return node
 
 
+def plan_netdev_port(
+    *,
+    node: Node,
+    node_name: str,
+    physical_network: str,
+    port: NetdevPort,
+    existing=None,
+    ports_by_mac: dict | None = None,
+) -> dict | None:
+    """Decide what a single port needs, without mutating anything.
+
+    Returns a plan dict describing the action, or None if the port already
+    matches the request. Raises on a MAC conflict that would imply an
+    automatic label move/rename.
+
+    Plan shapes:
+      {"kind": "create", "port": NetdevPort}
+      {"kind": "update", "existing": Port, "patch": [json-patch ops]}
+    """
+    port_name = f"{node_name}:{port.label}"
+    ports_by_mac = ports_by_mac or {}
+    mac_owner = ports_by_mac.get(port.mac.lower())
+
+    if existing is None:
+        if mac_owner is not None:
+            raise RuntimeError(
+                f"[node:{node.uuid}] Cannot create port {port_name} with MAC "
+                f"{port.mac}: that MAC is already used by port {mac_owner.uuid} "
+                f"name={mac_owner.name}. Delete or rename that existing port "
+                "manually if this is an intentional label change."
+            )
+        return {"kind": "create", "port": port}
+
+    current_llc = existing.local_link_connection or {}
+
+    # switch_id rule: an explicit value in the request wins (lets operators set
+    # or correct it). Otherwise preserve a real value already recorded, and only
+    # (re)write the placeholder while the stored value is still placeholder/unset.
+    # switch_info and port_id always converge to the request.
+    current_switch_id = current_llc.get("switch_id")
+    if port.switch_id not in (None, ""):
+        switch_id = port.switch_id
+    elif current_switch_id in (None, "", PLACEHOLDER_SWITCH_ID):
+        switch_id = PLACEHOLDER_SWITCH_ID
+    else:
+        switch_id = current_switch_id
+
+    desired_llc = {
+        "switch_id": switch_id,
+        "switch_info": port.switch,
+        "port_id": port.interface,
+    }
+
+    patch = []
+    if (existing.address or "").lower() != port.mac.lower():
+        if mac_owner is not None and mac_owner.uuid != existing.uuid:
+            raise RuntimeError(
+                f"[node:{node.uuid}] Cannot update port {port_name} to MAC "
+                f"{port.mac}: that MAC is already used by port {mac_owner.uuid} "
+                f"name={mac_owner.name}. Delete or rename that existing port "
+                "manually if this is an intentional label change."
+            )
+        patch.append({"op": "add", "path": "/address", "value": port.mac})
+    if existing.physical_network != physical_network:
+        patch.append(
+            {"op": "add", "path": "/physical_network", "value": physical_network}
+        )
+    if getattr(existing, "category", None) != "network":
+        patch.append({"op": "add", "path": "/category", "value": "network"})
+    if any(current_llc.get(key) != value for key, value in desired_llc.items()):
+        # Replace the whole object rather than nested keys: Ironic allows
+        # local_link_connection to be null, and a nested JSON patch would fail
+        # when the parent object is absent.
+        patch.append(
+            {"op": "add", "path": "/local_link_connection", "value": desired_llc}
+        )
+
+    if not patch:
+        logger.info(
+            "[node:%s] Port name=%s mac=%s already up to date, skipping",
+            node.uuid,
+            port_name,
+            port.mac,
+        )
+        return None
+
+    return {"kind": "update", "existing": existing, "patch": patch}
+
+
+def apply_port_plan(
+    *,
+    client: IronicClient,
+    node: Node,
+    node_name: str,
+    physical_network: str,
+    plan: dict,
+) -> None:
+    """Apply one plan produced by plan_netdev_port.
+
+    The node must already be in a state that permits port connectivity changes
+    (enroll or manageable); the caller is responsible for that.
+    """
+    if plan["kind"] == "create":
+        create_netdev_port(
+            client=client,
+            node=node,
+            node_name=node_name,
+            physical_network=physical_network,
+            port=plan["port"],
+        )
+        return
+
+    existing = plan["existing"]
+    patch = plan["patch"]
+    logger.info(
+        "[node:%s] Updating existing port uuid=%s mac=%s patch=%s",
+        node.uuid,
+        existing.uuid,
+        existing.address,
+        patch,
+    )
+    client.update_port(existing.uuid, patch)
+
+
 def create_netdev_port(
     *,
     client: IronicClient,
@@ -148,11 +499,12 @@ def create_netdev_port(
     port: NetdevPort,
 ) -> None:
     port_name = f"{node_name}:{port.label}"
+    switch_id = port.switch_id or PLACEHOLDER_SWITCH_ID
     port_data = {
         "address": port.mac,
         "category": "network",
         "local_link_connection": {
-            "switch_id": "00:00:00:00:00:00",
+            "switch_id": switch_id,
             "switch_info": port.switch,
             "port_id": port.interface,
         },
@@ -169,7 +521,7 @@ def create_netdev_port(
         port_name,
         port.mac,
         physical_network,
-        "00:00:00:00:00:00",
+        switch_id,
         port.switch,
         port.interface,
     )
@@ -180,6 +532,39 @@ def create_netdev_port(
         port_name,
         getattr(created_port, "uuid", ""),
     )
+
+
+def make_available(node: Node, state: str) -> None:
+    """Drive the node to "available" given its current provision state.
+
+    ``state`` is passed in rather than read from the node because earlier steps
+    may have already transitioned it (e.g. available to manageable) without
+    refreshing the local node object.
+    """
+    if state == "available":
+        logger.info("[node:%s] Node is already available", node.uuid)
+        return
+
+    if state not in REENROLLABLE_STATES:
+        raise RuntimeError(
+            f"[node:{node.uuid}] Cannot make node available from "
+            f"provision_state {state!r}"
+        )
+
+    if state == "enroll":
+        logger.info(
+            "[node:%s] Requesting manage transition, expecting manageable",
+            node.uuid,
+        )
+        ironic_node.transition(node, target_state="manage", expected_state="manageable")
+        logger.info("[node:%s] Node is manageable", node.uuid)
+
+    logger.info(
+        "[node:%s] Requesting provide transition, expecting available",
+        node.uuid,
+    )
+    ironic_node.transition(node, target_state="provide", expected_state="available")
+    logger.info("[node:%s] Node is available", node.uuid)
 
 
 def argument_parser():
@@ -193,19 +578,15 @@ def argument_parser():
         required=True,
         help="Port physical_network",
     )
-    parser.add_argument("--port1-mac", required=True, help="MAC address for port1")
-    parser.add_argument("--port1-switch", required=True, help="Switch name for port1")
     parser.add_argument(
-        "--port1-intf",
+        "--ports",
         required=True,
-        help="Switch interface name for port1",
-    )
-    parser.add_argument("--port2-mac", required=True, help="MAC address for port2")
-    parser.add_argument("--port2-switch", required=True, help="Switch name for port2")
-    parser.add_argument(
-        "--port2-intf",
-        required=True,
-        help="Switch interface name for port2",
+        help=(
+            "JSON array of ports with stable labels, e.g. "
+            '[{"label": "port1", "mac": "..", "switch": "..", "intf": ".."}]. '
+            'Optional per-port "switch_id" (real switch MAC) overrides the '
+            "00:00:00:00:00:00 placeholder. Change/remove/rename labels manually."
+        ),
     )
     parser.add_argument(
         "--external-cmdb-id",
@@ -217,7 +598,7 @@ def argument_parser():
     parser.add_argument(
         "--resource-class",
         required=False,
-        default="generic",
+        default=DEFAULT_RESOURCE_CLASS,
         help="Ironic resource class",
     )
     return parser

--- a/workflows/argo-events/workflowtemplates/enroll-netdev.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-netdev.yaml
@@ -21,12 +21,11 @@ spec:
     parameters:
       - name: name
       - name: physical_network
-      - name: port1_mac
-      - name: port1_switch
-      - name: port1_intf
-      - name: port2_mac
-      - name: port2_switch
-      - name: port2_intf
+      # JSON array of ports with stable labels. Change/delete/rename labels
+      # manually. Optional per-port "switch_id" (real switch MAC) overrides the
+      # 00:00:00:00:00:00 placeholder, e.g.
+      # [{"label":"port1","mac":"..","switch":"..","intf":"..","switch_id":".."}]
+      - name: ports
       - name: external_cmdb_id
         value: ""
       - name: resource_class
@@ -46,18 +45,8 @@ spec:
           - "{{workflow.parameters.name}}"
           - --physical-network
           - "{{workflow.parameters.physical_network}}"
-          - --port1-mac
-          - "{{workflow.parameters.port1_mac}}"
-          - --port1-switch
-          - "{{workflow.parameters.port1_switch}}"
-          - --port1-intf
-          - "{{workflow.parameters.port1_intf}}"
-          - --port2-mac
-          - "{{workflow.parameters.port2_mac}}"
-          - --port2-switch
-          - "{{workflow.parameters.port2_switch}}"
-          - --port2-intf
-          - "{{workflow.parameters.port2_intf}}"
+          - --ports
+          - "{{workflow.parameters.ports}}"
           - --external-cmdb-id
           - "{{workflow.parameters.external_cmdb_id}}"
           - --resource-class


### PR DESCRIPTION
Parent PR : https://github.com/rackerlabs/understack/pull/2144

**Possible through enroll-netdev** 

   Operation Notes
- Create a netdev node  fresh enroll
- Create N ports  any number, labeled
- Add a port  new label in the list 
- Update switch_info / port_id , local_link_connection converges
- Update physical_network per port
- Set or correct category  (like I it  forced to network ) 
- Set / updatee switch_id optional per-port override; explicit wins, else preserve
- Edit a port's MAC in place  same label + new unique MAC (NIC replacement)
- Update resource_class node-level
- Set/update external_cmdb_id including 0
- Re-run safely no-op when nothing changed
- Recover a partial failure resubmit same name, no cleanup needed
- Drive node to available state-aware manage/provide, auto steps available , manageable for edits [No manual step-down required ] 

**Manual Operation** 

- Delete a port (shrink)  workflow warns + keeps the orphan; openstack baremetal port delete (node must be manageable)
- Rename a port label fails safely with a clear error; rename via openstack, or delete + re-add
- Move/swap a MAC between existing ports on the same node fails safely; do it by hand
- Reuse a MAC that's on another port  fails; delete/rename that port first
- Name collides with a non-netdev (server) node refused; pick a different name
- Node in an in-use state (active, deploying) refused; handle that node separately
- Remove/unset external_cmdb_id workflow only sets, never clears; unset via openstack
- Delete the node always manual

**Detailed Testing logs :** 

Fresh enroll (2 labeled ports)
```shell

~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:01","switch":"sw-1","intf":"Eth1/1"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'


~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ openstack baremetal port list --node bf257688-2716-4527-b101-20d742e90d47  --long
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+----------------+
| uuid     | address  | created_at | extra | node_uuid | category | vendor | local_link_connection | portgroup_uuid | pxe_enabled | physical_network | updated_at | internal_info | is_smartnic | name           |
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+----------------+
| 63df04bc | 02:de:ad | 2026-07-   |       | bf257688- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None       | {}            | False       | nidhi-nd:port1 |
| -14e7-   | :be:ef:0 | 27T13:58:5 |       | 2716-     |          |        | '00:00:00:00:00:00',  |                |             |                  |            |               |             |                |
| 4dff-    | 1        | 4+00:00    |       | 4527-     |          |        | 'switch_info':        |                |             |                  |            |               |             |                |
| b278-    |          |            |       | b101-     |          |        | 'sw-1', 'port_id':    |                |             |                  |            |               |             |                |
| 32b53434 |          |            |       | 20d742e90 |          |        | 'Eth1/1'}             |                |             |                  |            |               |             |                |
| ed4c     |          |            |       | d47       |          |        |                       |                |             |                  |            |               |             |                |
| 3724dc18 | 02:de:ad | 2026-07-   |       | bf257688- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None       | {}            | False       | nidhi-nd:port2 |
| -bcbb-   | :be:ef:0 | 27T13:58:5 |       | 2716-     |          |        | '00:00:00:00:00:00',  |                |             |                  |            |               |             |                |
| 4533-    | 2        | 5+00:00    |       | 4527-     |          |        | 'switch_info':        |                |             |                  |            |               |             |                |
| 9942-    |          |            |       | b101-     |          |        | 'sw-2', 'port_id':    |                |             |                  |            |               |             |                |
| e9d2e2af |          |            |       | 20d742e90 |          |        | 'Eth1/2'}             |                |             |                  |            |               |             |                |
| 2af7     |          |            |       | d47       |          |        |                       |                |             |                  |            |               |             |                |
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+----------------+

~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack --os-cloud uc-dev-infra baremetal node show nidhi-nd -c provision_state -c driver -c resource_class -c extra
+-----------------+-----------+
| Field           | Value     |
+-----------------+-----------+
| driver          | netdev    |
| extra           | {}        |
| provision_state | available |
| resource_class  | generic   |
+-----------------+-----------+
(openstack)  

``` 

Rerunning the same command is no-op

update CMDB id 
```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 9s
❯ openstack --os-cloud uc-dev-infra baremetal node show nidhi-nd-cmdb -c extra
+-------+----------------------------------+
| Field | Value                            |
+-------+----------------------------------+
| extra | {'external_cmdb_id': 'CMDB-123'} |
+-------+----------------------------------+
``` 

update Metadata-only (resource_class) on available
```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:01","switch":"sw-1","intf":"Eth1/1"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'


~ 🐍 openstack on ☁️  uc-dev-infra(baremetal)
❯ openstack --os-cloud uc-dev-infra baremetal node show nidhi-nd -c provision_state -c driver -c resource_class -c extra
+-----------------+-----------+
| Field           | Value     |
+-----------------+-----------+
| driver          | netdev    |
| extra           | {}        |
| provision_state | available |
| resource_class  | switch    |
+-----------------+-----------+


``` 

Update ports metadata , steping dowm to manageable (argo log )

```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:01","switch":"NEW-sw-1","intf":"Eth9/9"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'

~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ argo -n argo-events logs enroll-netdev-5qhdm -f
Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:17 +0000 - understack_workflows.main.enroll_netdev - INFO - Starting enroll-netdev workflow name=nidhi-nd physical_network=fake-physnet resource_class=switch port_count=2
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:17 +0000 - understack_workflows.main.enroll_netdev - INFO - No external_cmdb_id provided
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:18 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Reusing existing netdev node name=nidhi-nd provision_state=available
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:18 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Port name=nidhi-nd:port2 mac=02:de:ad:be:ef:02 already up to date, skipping
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:18 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Stepping available  manageable to apply port changes
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:19 +0000 - understack_workflows.ironic_node - INFO - bf257688-2716-4527-b101-20d742e90d47 requesting provision state manage
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:19 +0000 - understack_workflows.ironic_node - INFO - Waiting for node bf257688-2716-4527-b101-20d742e90d47 to enter provision state manageable
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:20 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Updating existing port uuid=63df04bc-14e7-4dff-b278-32b53434ed4c mac=02:de:ad:be:ef:01 patch=[{'op': 'add', 'path': '/local_link_connection', 'value': {'switch_id': '00:00:00:00:00:00', 'switch_info': 'NEW-sw-1', 'port_id': 'Eth9/9'}}]
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:22 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Requesting provide transition, expecting available
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:22 +0000 - understack_workflows.ironic_node - INFO - bf257688-2716-4527-b101-20d742e90d47 requesting provision state provide
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:23 +0000 - understack_workflows.ironic_node - INFO - Waiting for node bf257688-2716-4527-b101-20d742e90d47 to enter provision state available
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:23 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Node is available
enroll-netdev-5qhdm-enroll-netdev-930250783: 2026-07-27 14:07:23 +0000 - understack_workflows.main.enroll_netdev - INFO - Completed enroll-netdev workflow name=nidhi-nd node_uuid=bf257688-2716-4527-b101-20d742e90d47
enroll-netdev-5qhdm-enroll-netdev-930250783: time="2026-07-27T14:07:24.629Z" level=info msg="sub-process exited" argo=true error="<nil>"



+----------------+----------------+----------------+-------+----------------+----------+--------+-----------------------+----------------+-------------+------------------+----------------+---------------+-------------+----------------+
| uuid           | address        | created_at     | extra | node_uuid      | category | vendor | local_link_connection | portgroup_uuid | pxe_enabled | physical_network | updated_at     | internal_info | is_smartnic | name           |
+----------------+----------------+----------------+-------+----------------+----------+--------+-----------------------+----------------+-------------+------------------+----------------+---------------+-------------+----------------+
| 63df04bc-14e7- | 02:de:ad:be:ef | 2026-07-       |       | bf257688-2716- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | 2026-07-       | {}            | False       | nidhi-nd:port1 |
| 4dff-b278-     | :01            | 27T13:58:54+00 |       | 4527-b101-     |          |        | '00:00:00:00:00:00',  |                |             |                  | 27T14:07:21+00 |               |             |                |
| 32b53434ed4c   |                | :00            |       | 20d742e90d47   |          |        | 'switch_info': 'NEW-  |                |             |                  | :00            |               |             |                |
|                |                |                |       |                |          |        | sw-1', 'port_id':     |                |             |                  |                |               |             |                |
|                |                |                |       |                |          |        | 'Eth9/9'}             |                |             |                  |                |               |             |                |
| 3724dc18-bcbb- | 02:de:ad:be:ef | 2026-07-       |       | bf257688-2716- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None           | {}            | False       | nidhi-nd:port2 |
| 4533-9942-     | :02            | 27T13:58:55+00 |       | 4527-b101-     |          |        | '00:00:00:00:00:00',  |                |             |                  |                |               |             |                |
| e9d2e2af2af7   |                | :00            |       | 20d742e90d47   |          |        | 'switch_info':        |                |             |                  |                |               |             |                |
|                |                |                |       |                |          |        | 'sw-2', 'port_id':    |                |             |                  |                |               |             |                |
|                |                |                |       |                |          |        | 'Eth1/2'}             |                |             |                  |                |               |             |                |
+----------------+----------------+----------------+-------+----------------+----------+--------+-----------------------+----------------+-------------+------------------+----------------+---------------+-------------+----------------+




``` 


Updating switch Id on port 1:

```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:01","switch":"NEW-sw-1","intf":"Eth9/9","switch_id":"aa:bb:cc:dd:ee:ff"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'

Argo log : 
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:01 +0000 - understack_workflows.main.enroll_netdev - INFO - Starting enroll-netdev workflow name=nidhi-nd physical_network=fake-physnet resource_class=switch port_count=2
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:01 +0000 - understack_workflows.main.enroll_netdev - INFO - No external_cmdb_id provided
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:02 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Reusing existing netdev node name=nidhi-nd provision_state=available
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:02 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Port name=nidhi-nd:port2 mac=02:de:ad:be:ef:02 already up to date, skipping
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:02 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Stepping available  manageable to apply port changes
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:03 +0000 - understack_workflows.ironic_node - INFO - bf257688-2716-4527-b101-20d742e90d47 requesting provision state manage
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:04 +0000 - understack_workflows.ironic_node - INFO - Waiting for node bf257688-2716-4527-b101-20d742e90d47 to enter provision state manageable
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:04 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Updating existing port uuid=63df04bc-14e7-4dff-b278-32b53434ed4c mac=02:de:ad:be:ef:01 patch=[{'op': 'add', 'path': '/local_link_connection', 'value': {'switch_id': 'aa:bb:cc:dd:ee:ff', 'switch_info': 'NEW-sw-1', 'port_id': 'Eth9/9'}}]
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:06 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Requesting provide transition, expecting available
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:06 +0000 - understack_workflows.ironic_node - INFO - bf257688-2716-4527-b101-20d742e90d47 requesting provision state provide
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:07 +0000 - understack_workflows.ironic_node - INFO - Waiting for node bf257688-2716-4527-b101-20d742e90d47 to enter provision state available
enroll-netdev-l84rc-enroll-netdev-3502888293: 2026-07-27 14:10:07 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Node is available


``` 

  if we omit , anything from ports while upadting the metadata is still preserved :
  Omit switch_id on re-run, preserved (change switch_info only)


```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:01","switch":"NEW-sw-1","intf":"Eth9/9","switch_id":"aa:bb:cc:dd:ee:ff"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'


  argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:01","switch":"NEWER-sw-1","intf":"Eth9/9"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'


~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 29s
❯ openstack baremetal port list --node bf257688-2716-4527-b101-20d742e90d47  --long
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+--------------+
| uuid     | address  | created_at | extra | node_uuid | category | vendor | local_link_connection | portgroup_uuid | pxe_enabled | physical_network | updated_at | internal_info | is_smartnic | name         |
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+--------------+
| 63df04bc | 02:de:ad | 2026-07-   |       | bf257688- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | 2026-07-   | {}            | False       | nidhi-       |
| -14e7-   | :be:ef:0 | 27T13:58:5 |       | 2716-     |          |        | 'aa:bb:cc:dd:ee:ff',  |                |             |                  | 27T14:10:0 |               |             | nd:port1     |
| 4dff-    | 1        | 4+00:00    |       | 4527-     |          |        | 'switch_info': 'NEW-  |                |             |                  | 6+00:00    |               |             |              |
| b278-    |          |            |       | b101-     |          |        | sw-1', 'port_id':     |                |             |                  |            |               |             |              |
| 32b53434 |          |            |       | 20d742e90 |          |        | 'Eth9/9'}             |                |             |                  |            |               |             |              |
| ed4c     |          |            |       | d47       |          |        |                       |                |             |                  |            |               |             |              |
| 3724dc18 | 02:de:ad | 2026-07-   |       | bf257688- | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None       | {}            | False       | nidhi-       |
| -bcbb-   | :be:ef:0 | 27T13:58:5 |       | 2716-     |          |        | '00:00:00:00:00:00',  |                |             |                  |            |               |             | nd:port2     |
| 4533-    | 2        | 5+00:00    |       | 4527-     |          |        | 'switch_info':        |                |             |                  |            |               |             |              |
| 9942-    |          |            |       | b101-     |          |        | 'sw-2', 'port_id':    |                |             |                  |            |               |             |              |
| e9d2e2af |          |            |       | 20d742e90 |          |        | 'Eth1/2'}             |                |             |                  |            |               |             |              |
| 2af7     |          |            |       | d47       |          |        |                       |                |             |                  |            |               |             |              |
+----------+----------+------------+-------+-----------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+--------------+



``` 

MAC Edit: 

```shell
argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:09","switch":"NEWER-sw-1","intf":"Eth9/9"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'

  tack on ☁️  uc-dev-infra(baremetal) took 6s
❯ argo -n argo-events logs enroll-netdev-xc9l4 -f
Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:52 +0000 - understack_workflows.main.enroll_netdev - INFO - Starting enroll-netdev workflow name=nidhi-nd physical_network=fake-physnet resource_class=switch port_count=2
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:52 +0000 - understack_workflows.main.enroll_netdev - INFO - No external_cmdb_id provided
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:53 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Reusing existing netdev node name=nidhi-nd provision_state=available
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:53 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Port name=nidhi-nd:port2 mac=02:de:ad:be:ef:02 already up to date, skipping
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:53 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Stepping available  manageable to apply port changes
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:54 +0000 - understack_workflows.ironic_node - INFO - bf257688-2716-4527-b101-20d742e90d47 requesting provision state manage
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:55 +0000 - understack_workflows.ironic_node - INFO - Waiting for node bf257688-2716-4527-b101-20d742e90d47 to enter provision state manageable
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:55 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Updating existing port uuid=63df04bc-14e7-4dff-b278-32b53434ed4c mac=02:de:ad:be:ef:01 patch=[{'op': 'add', 'path': '/address', 'value': '02:de:ad:be:ef:09'}]
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:57 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Requesting provide transition, expecting available
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:57 +0000 - understack_workflows.ironic_node - INFO - bf257688-2716-4527-b101-20d742e90d47 requesting provision state provide
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:58 +0000 - understack_workflows.ironic_node - INFO - Waiting for node bf257688-2716-4527-b101-20d742e90d47 to enter provision state available
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:58 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Node is available
enroll-netdev-xc9l4-enroll-netdev-242961740: 2026-07-27 14:16:58 +0000 - understack_workflows.main.enroll_netdev - INFO - Completed enroll-netdev workflow name=nidhi-nd node_uuid=bf257688-2716-4527-b101-20d742e90d47
enroll-netdev-xc9l4-enroll-netdev-242961740: time="2026-07-27T14:16:59.369Z" level=info msg="sub-process exited" argo=true error="<nil>"

~ 🐍 openstack on ☁️  uc-dev-infra(baremetal)
❯ openstack baremetal port list --node bf257688-2716-4527-b101-20d742e90d47  --long
+-----------------------+-------------------+-----------------------+-------+-----------------------+----------+--------+-----------------------+----------------+-------------+------------------+---------------------------+---------------+-------------+----------------+
| uuid                  | address           | created_at            | extra | node_uuid             | category | vendor | local_link_connection | portgroup_uuid | pxe_enabled | physical_network | updated_at                | internal_info | is_smartnic | name           |
+-----------------------+-------------------+-----------------------+-------+-----------------------+----------+--------+-----------------------+----------------+-------------+------------------+---------------------------+---------------+-------------+----------------+
| 63df04bc-14e7-4dff-   | 02:de:ad:be:ef:09 | 2026-07-              |       | bf257688-2716-4527-   | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | 2026-07-27T14:16:56+00:00 | {}            | False       | nidhi-nd:port1 |
| b278-32b53434ed4c     |                   | 27T13:58:54+00:00     |       | b101-20d742e90d47     |          |        | 'aa:bb:cc:dd:ee:ff',  |                |             |                  |                           |               |             |                |
|                       |                   |                       |       |                       |          |        | 'switch_info':        |                |             |                  |                           |               |             |                |
|                       |                   |                       |       |                       |          |        | 'NEWER-sw-1',         |                |             |                  |                           |               |             |                |
|                       |




``` 

Mac collission (port3 wants port1's MAC) ,  fails safely

```shell
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:09","switch":"NEWER-sw-1","intf":"Eth9/9"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"},{"label":"port3","mac":"02:de:ad:be:ef:09","switch":"sw-3","intf":"Eth1/3"}]'

Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
Name:                enroll-netdev-v4s8m
Namespace:           argo-events
ServiceAccount:      unset
Status:              Pending
Created:             Mon Jul 27 19:49:50 +0530 (now)
Progress:
Parameters:
  name:              nidhi-nd
  physical_network:  fake-physnet
  resource_class:    switch
  ports:             [{"label":"port1","mac":"02:de:ad:be:ef:09","switch":"NEWER-sw-1","intf":"Eth9/9"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"},{"label":"port3","mac":"02:de:ad:be:ef:09","switch":"sw-3","intf":"Eth1/3"}]
(openstack)
~ 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ argo -n argo-events logs enroll-netdev-v4s8m -f
Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
enroll-netdev-v4s8m-enroll-netdev-479259856: Traceback (most recent call last):
enroll-netdev-v4s8m-enroll-netdev-479259856:   File "/opt/venv/bin/enroll-netdev", line 10, in <module>
enroll-netdev-v4s8m-enroll-netdev-479259856:     sys.exit(main())
enroll-netdev-v4s8m-enroll-netdev-479259856:              ^^^^^^
enroll-netdev-v4s8m-enroll-netdev-479259856:   File "/opt/venv/lib/python3.12/site-packages/understack_workflows/main/enroll_netdev.py", line 65, in main
enroll-netdev-v4s8m-enroll-netdev-479259856:     enroll(
enroll-netdev-v4s8m-enroll-netdev-479259856:   File "/opt/venv/lib/python3.12/site-packages/understack_workflows/main/enroll_netdev.py", line 141, in enroll
enroll-netdev-v4s8m-enroll-netdev-479259856:     netdev_ports = build_netdev_ports(ports)
enroll-netdev-v4s8m-enroll-netdev-479259856:                    ^^^^^^^^^^^^^^^^^^^^^^^^^
enroll-netdev-v4s8m-enroll-netdev-479259856:   File "/opt/venv/lib/python3.12/site-packages/understack_workflows/main/enroll_netdev.py", line 118, in build_netdev_ports
enroll-netdev-v4s8m-enroll-netdev-479259856:     raise ValueError(f"Duplicate MAC {entry['mac']} in ports list")
enroll-netdev-v4s8m-enroll-netdev-479259856: ValueError: Duplicate MAC 02:de:ad:be:ef:09 in ports list
enroll-netdev-v4s8m-enroll-netdev-479259856: time="2026-07-27T14:19:55.872Z" level=info msg="sub-process exited" argo=true error="<nil>"
enroll-netdev-v4s8m-enroll-netdev-479259856: Error: exit status 1
(openstack)


``` 

 Grow (add port3, unique MAC)

```shell
argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1","mac":"02:de:ad:be:ef:09","switch":"NEWER-sw-1","intf":"Eth9/9"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"},{"label":"port3","mac":"02:de:ad:be:ef:03","switch":"sw-3","intf":"Eth1/3"}]'


  ~ 🐍 openstack on ☁️  uc-dev-infra(baremetal)
❯ openstack baremetal port list --node bf257688-2716-4527-b101-20d742e90d47  --long
+------------+------------+------------+-------+------------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+----------------+
| uuid       | address    | created_at | extra | node_uuid  | category | vendor | local_link_connection | portgroup_uuid | pxe_enabled | physical_network | updated_at | internal_info | is_smartnic | name           |
+------------+------------+------------+-------+------------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+----------------+
| 63df04bc-  | 02:de:ad:b | 2026-07-   |       | bf257688-  | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | 2026-07-   | {}            | False       | nidhi-nd:port1 |
| 14e7-4dff- | e:ef:09    | 27T13:58:5 |       | 2716-4527- |          |        | 'aa:bb:cc:dd:ee:ff',  |                |             |                  | 27T14:16:5 |               |             |                |
| b278-      |            | 4+00:00    |       | b101-      |          |        | 'switch_info':        |                |             |                  | 6+00:00    |               |             |                |
| 32b53434ed |            |            |       | 20d742e90d |          |        | 'NEWER-sw-1',         |                |             |                  |            |               |             |                |
| 4c         |            |            |       | 47         |          |        | 'port_id': 'Eth9/9'}  |                |             |                  |            |               |             |                |
| 3724dc18-  | 02:de:ad:b | 2026-07-   |       | bf257688-  | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None       | {}            | False       | nidhi-nd:port2 |
| bcbb-4533- | e:ef:02    | 27T13:58:5 |       | 2716-4527- |          |        | '00:00:00:00:00:00',  |                |             |                  |            |               |             |                |
| 9942-      |            | 5+00:00    |       | b101-      |          |        | 'switch_info':        |                |             |                  |            |               |             |                |
| e9d2e2af2a |            |            |       | 20d742e90d |          |        | 'sw-2', 'port_id':    |                |             |                  |            |               |             |                |
| f7         |            |            |       | 47         |          |        | 'Eth1/2'}             |                |             |                  |            |               |             |                |
| 36742226-  | 02:de:ad:b | 2026-07-   |       | bf257688-  | network  | None   | {'switch_id':         | None           | True        | fake-physnet     | None       | {}            | False       | nidhi-nd:port3 |
| e2bf-4361- | e:ef:03    | 27T14:21:4 |       | 2716-4527- |          |        | '00:00:00:00:00:00',  |                |             |                  |            |               |             |                |
| 9e06-      |            | 4+00:00    |       | b101-      |          |        | 'switch_info':        |                |             |                  |            |               |             |                |
| 88f8e1090e |            |            |       | 20d742e90d |          |        | 'sw-3', 'port_id':    |                |             |                  |            |               |             |                |
| db         |            |            |       | 47         |          |        | 'Eth1/3'}             |                |             |                  |            |               |             |                |
+------------+------------+------------+-------+------------+----------+--------+-----------------------+----------------+-------------+------------------+------------+---------------+-------------+----------------+


``` 

 Rename a label clear error

```shell
argo -n argo-events submit --from wftmpl/enroll-netdev \
  -p name=nidhi-nd \
  -p physical_network=fake-physnet \
  -p resource_class=switch \
  -p ports='[{"label":"port1-renamed","mac":"02:de:ad:be:ef:09","switch":"NEWER-sw-1","intf":"Eth9/9"},{"label":"port2","mac":"02:de:ad:be:ef:02","switch":"sw-2","intf":"Eth1/2"}]'


enroll-netdev-5xbqh-enroll-netdev-2233511172: 2026-07-27 14:22:48 +0000 - understack_workflows.main.enroll_netdev - INFO - No external_cmdb_id provided
enroll-netdev-5xbqh-enroll-netdev-2233511172: 2026-07-27 14:22:49 +0000 - understack_workflows.main.enroll_netdev - INFO - [node:bf257688-2716-4527-b101-20d742e90d47] Reusing existing netdev node name=nidhi-nd provision_state=available
enroll-netdev-5xbqh-enroll-netdev-2233511172: Traceback (most recent call last):
enroll-netdev-5xbqh-enroll-netdev-2233511172:   File "/opt/venv/bin/enroll-netdev", line 10, in <module>
enroll-netdev-5xbqh-enroll-netdev-2233511172:     sys.exit(main())
enroll-netdev-5xbqh-enroll-netdev-2233511172:              ^^^^^^
enroll-netdev-5xbqh-enroll-netdev-2233511172:   File "/opt/venv/lib/python3.12/site-packages/understack_workflows/main/enroll_netdev.py", line 65, in main
enroll-netdev-5xbqh-enroll-netdev-2233511172:     enroll(
enroll-netdev-5xbqh-enroll-netdev-2233511172:   File "/opt/venv/lib/python3.12/site-packages/understack_workflows/main/enroll_netdev.py", line 176, in enroll
enroll-netdev-5xbqh-enroll-netdev-2233511172:     plan_netdev_port(
enroll-netdev-5xbqh-enroll-netdev-2233511172:   File "/opt/venv/lib/python3.12/site-packages/understack_workflows/main/enroll_netdev.py", line 394, in plan_netdev_port
enroll-netdev-5xbqh-enroll-netdev-2233511172:     raise RuntimeError(
enroll-netdev-5xbqh-enroll-netdev-2233511172: RuntimeError: [node:bf257688-2716-4527-b101-20d742e90d47] Cannot create port nidhi-nd:port1-renamed with MAC 02:de:ad:be:ef:09: that MAC is already used by port 63df04bc-14e7-4dff-b278-32b53434ed4c name=nidhi-nd:port1. Delete or rename that existing port manually if this is an intentional label change.
enroll-netdev-5xbqh-enroll-netdev-2233511172: time="2026-07-27T14:22:50.202Z" level=info msg="sub-process exited" argo=true error="<nil>"
enroll-netdev-5xbqh-enroll-netdev-2233511172: Error: exit status 1
``` 
