### PR TITLE
chore(neutron): stop mounting the unused undersync token

### DIFF
--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -127,17 +127,6 @@ pod:
     neutron_server:
       - secret:
           name: neutron-ks-etc
-  mounts:
-    neutron_server:
-      neutron_server:
-        volumeMounts:
-          - mountPath: /etc/undersync/
-            name: undersync-token
-            readOnly: true
-        volumes:
-          - name: undersync-token
-            secret:
-              secretName: undersync-token
 
   use_fqdn:
     neutron_agent: false

--- a/docs/deploy-guide/components/neutron.md
+++ b/docs/deploy-guide/components/neutron.md
@@ -46,7 +46,6 @@ Required or commonly required items:
 - `values.yaml`: Provide the Neutron-specific chart or manifest values.
 - `neutron-db-password` Secret: Provide `username` and `password` for the Neutron database user.
 - `neutron-rabbitmq-password` Secret: Provide `username` and `password` for the Neutron messaging user.
-- `undersync-token` Secret: Provide a `token` value if Neutron automation needs to call undersync.
 
 Optional additions:
 


### PR DESCRIPTION
This token file/secret is no longer used so stop mounting it by default
so we can simplify the deployment by not relying on it.
