### PR TITLE
feat(ironic): wire up dynamic portgroup via TBN

### DIFF
--- a/components/ironic/cm-trait-based-networking.yaml
+++ b/components/ironic/cm-trait-based-networking.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic-trait-based-networking
+data:
+  trait_based_networking.yaml: |
+    # Trait Based Networking (TBN) config for grouping category=network ports
+    # into a dynamic portgroup, and only ever auto-attaching category=network
+    # ports via vif_attach (category=storage ports are left alone).
+    #
+    # Applied to a node only when CUSTOM_NETWORK_PORTGROUP appears in the
+    # node's instance_info.traits (Nova copies matching flavor/image traits
+    # there during deploy). Add the trait to a node with:
+    #   openstack baremetal node add trait <node> CUSTOM_NETWORK_PORTGROUP
+    # and require it on a flavor with:
+    #   openstack flavor set --property trait:CUSTOM_NETWORK_PORTGROUP=required <flavor>
+    CUSTOM_NETWORK_PORTGROUP:
+      order: 1
+      actions:
+        # Group every free port with category=network (that shares the same
+        # physical_network as the first one matched, and has
+        # available_for_dynamic_portgroup=True) into a new dynamic portgroup,
+        # then attach that portgroup to the network being requested.
+        - action: group_and_attach_ports
+          filter: port.category == 'network'
+          min_count: 2
+        # Fallback for nodes that only have a single category=network port
+        # (group_and_attach_ports requires at least 2 and would NoMatch, so
+        # this action picks up the single remaining port instead).
+        - action: attach_port
+          filter: port.category == 'network'
+          max_count: 1
+
+    # Overrides Ironic's built-in fallback trait (CUSTOM_DEFAULT_TBN_TRAIT),
+    # which normally attaches the first available port or portgroup regardless
+    # of category. Redefining it here keeps that fallback scoped to
+    # category=network too, so a category=storage port is never auto-attached
+    # by TBN even when no other trait matches.
+    CUSTOM_DEFAULT_TBN_TRAIT:
+      actions:
+        - action: attach_port
+          filter: port.category == 'network'
+          max_count: 1

--- a/components/ironic/kustomization.yaml
+++ b/components/ironic/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ironic-rabbitmq-queue.yaml
   - dnsmasq-pvc.yaml
   - dnsmasq-ss.yaml
+  - cm-trait-based-networking.yaml
   - ironic-ks-user-baremetal.yaml
     # less than ideal addition but necessary so that we can have the ironic.conf.d loading
     # working due to the way the chart hardcodes the config-file parameter which then

--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -85,6 +85,11 @@ conf:
       # https://docs.openstack.org/ironic/latest/admin/drivers/idrac.html#nodes-go-into-maintenance-mode
       sync_power_state_interval: 300
       sync_power_state_workers: 20
+      # Trait Based Networking (TBN): dynamically portgroup category=network
+      # ports at vif_attach time. See trait-based-networking-cm.yaml for the
+      # trait definitions.
+      enable_trait_based_networking: true
+      trait_based_networking_config_file: /etc/ironic/trait-based-networking/trait_based_networking.yaml
     agent:
       # (nicholas.kuechler) tuning for idrac hardware type
       # https://docs.openstack.org/ironic/latest/admin/drivers/idrac.html#timeout-when-powering-off
@@ -254,6 +259,9 @@ pod:
           - name: ironic-inspection-rules
             mountPath: /etc/ironic/inspection-rules/
             readOnly: true
+          - name: ironic-trait-based-networking
+            mountPath: /etc/ironic/trait-based-networking/
+            readOnly: true
         volumes:
           - name: dnsmasq-ironic
             persistentVolumeClaim:
@@ -268,6 +276,9 @@ pod:
             configMap:
               name: ironic-inspection-rules
               optional: true
+          - name: ironic-trait-based-networking
+            configMap:
+              name: ironic-trait-based-networking
   replicas:
     api: 4
     conductor: 1


### PR DESCRIPTION
Utilize Ironic's trait based networking to create a trait called
NETWORK_PORTGROUP which will create a portgroup of the two ports that
are in the category=network. It also sets up a default trait attachment
operation to the port with category=network, which mirrors the current
code hack we have in our Ironic repo allowing it to be dropped for us
using TBN.
