### PR TITLE
fix: correct switch update evaluation

### DIFF
--- a/charts/site-workflows/templates/sensor-ironic-oslo-event.yaml
+++ b/charts/site-workflows/templates/sensor-ironic-oslo-event.yaml
@@ -104,7 +104,11 @@ spec:
                               project_id_without_dashes = {{ printf "{{workflow.parameters.project_id}}" | quote }}
                               print(str(uuid.UUID(project_id_without_dashes)))
                   - - name: ansible-storage-update
-                      when: {{ printf "\"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted && \"{{workflow.parameters.previous_provision_state}}\" == deploying" | quote }}
+                      when: >-
+                        {{ printf "(
+                          \"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted ||
+                          \"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted-but-not-project
+                        ) && \"{{workflow.parameters.previous_provision_state}}\" == deploying" | quote }}
                       templateRef:
                         name: ansible-workflow-template
                         template: ansible-run

--- a/charts/site-workflows/templates/sensor-ironic-oslo-event.yaml
+++ b/charts/site-workflows/templates/sensor-ironic-oslo-event.yaml
@@ -104,11 +104,7 @@ spec:
                               project_id_without_dashes = {{ printf "{{workflow.parameters.project_id}}" | quote }}
                               print(str(uuid.UUID(project_id_without_dashes)))
                   - - name: ansible-storage-update
-                      when: >-
-                        {{ printf "(
-                          \"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted ||
-                          \"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted-but-not-project
-                        ) && \"{{workflow.parameters.previous_provision_state}}\" == deploying" | quote }}
+                      when: {{ printf "(\"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted || \"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted-but-not-project) && \"{{workflow.parameters.previous_provision_state}}\" == deploying" | quote }}
                       templateRef:
                         name: ansible-workflow-template
                         template: ansible-run


### PR DESCRIPTION
Changing the evaluation syntax to invoke the switch update automation to include when UNDERCLOUD_SVM is not present in the project tags.
The tag should not be required as we are using the default cinder driver.
