### PR TITLE
feat: Handle multiple network leaf pairs in vlan_group naming convention

### DIFF
--- a/python/ironic-understack/ironic_understack/tests/test_vlan_group_name_convention.py
+++ b/python/ironic-understack/ironic_understack/tests/test_vlan_group_name_convention.py
@@ -44,7 +44,7 @@ def test_vlan_group_name_single_cab():
     }
 
 
-def test_vlan_group_name_pair_cab():
+def test_vlan_group_name_pair_cab_dash_one():
     assert vlan_group_names(
         [
             port("a1-1-1.abc1"),
@@ -56,6 +56,23 @@ def test_vlan_group_name_pair_cab():
     ) == {
         "a1-1-1.abc1": "a1-1/a1-2-network",
         "a1-2-1.abc1": "a1-1/a1-2-network",
+        "a1-1-1f.abc1": "a1-1/a1-2-storage",
+        "a1-2-1f.abc1": "a1-1/a1-2-storage",
+    }
+
+
+def test_vlan_group_name_pair_cab_dash_two():
+    assert vlan_group_names(
+        [
+            port("a1-1-2.abc1"),
+            port("a1-2-2.abc1"),
+            port("a1-1-1f.abc1"),
+            port("a1-2-1f.abc1"),
+        ],
+        mapping,
+    ) == {
+        "a1-1-2.abc1": "a1-1-2/a1-2-2-network",
+        "a1-2-2.abc1": "a1-1-2/a1-2-2-network",
         "a1-1-1f.abc1": "a1-1/a1-2-storage",
         "a1-2-1f.abc1": "a1-1/a1-2-storage",
     }

--- a/python/ironic-understack/ironic_understack/vlan_group_name_convention.py
+++ b/python/ironic-understack/ironic_understack/vlan_group_name_convention.py
@@ -30,6 +30,10 @@ def vlan_group_names(
     racks separated by a slash:
 
     ["a11-12-1", "a11-13-1"] => "a11-12/a11-13-network"
+
+    In a pair of racks using -2 switches, we add a -2 to the cabinet name:
+
+    ["a11-12-2", "a11-13-2"] => "a11-12-2/a11-13-2-network"
     """
     assert_consistent_data_center(ports)
     assert_single_or_paired_racks(ports)
@@ -42,9 +46,16 @@ def vlan_group_names(
     vlan_group_names = {}
     for switch_category, ports_in_group in vlan_groups.items():
         rack_names = {p.rack_name for p in ports_in_group}
+        switch_suffixes = {p.switch_suffix for p in ports_in_group}
+
+        if len(rack_names) > 1 and switch_suffixes == {"2"}:
+            rack_names = {f"{rack_name}-2" for rack_name in rack_names}
+
         vlan_group_name = "/".join(sorted(rack_names)) + "-" + switch_category
+
         for p in ports_in_group:
             vlan_group_names[p.switch_system_name] = vlan_group_name
+
     return vlan_group_names
 
 

--- a/python/ironic-understack/ironic_understack/vlan_group_name_convention.py
+++ b/python/ironic-understack/ironic_understack/vlan_group_name_convention.py
@@ -48,8 +48,11 @@ def vlan_group_names(
         rack_names = {p.rack_name for p in ports_in_group}
         switch_suffixes = {p.switch_suffix for p in ports_in_group}
 
-        if len(rack_names) > 1 and switch_suffixes == {"2"}:
-            rack_names = {f"{rack_name}-2" for rack_name in rack_names}
+        # Special case naming for pairs of racks that have multiple leaf pairs.
+        # (We don't handle multiple pairs in a single rack.)
+        if switch_suffixes in [{"2"}, {"3"}, {"4"}, {"5"}, {"6"}]:
+            suffix = next(iter(switch_suffixes))
+            rack_names = {f"{rack_name}-{suffix}" for rack_name in rack_names}
 
         vlan_group_name = "/".join(sorted(rack_names)) + "-" + switch_category
 


### PR DESCRIPTION
Release note:

This change will take effect on baremetal node inspection.

Any existing data should be updated **before** any nodes are inspected.

So for each of the devices in these cabs we should be updating the `physical_network` in the Ironic baremetal ports as well as the Neutron network segments.

In addition we should ensure that nautobot picks up those changes, fixing up if necessary.

If an OVN/OVS network node is in these cabs then we might need further updates, investigation would be required there to make sure we don't break any ovn bridge mappings.  Envs where the infra nodes are connected to a "-2" switch, note the first two are already done:

```
/tmp/ports-iad3-advent-infra   infra1.iad3-advent   f8-41-2/f8-42-2-network │ f8-41-2.iad3 Ethernet1/17 [34:d8:68:da:2a:a0]
/tmp/ports-iad3-advent-infra   infra2.iad3-advent   f8-41-2/f8-42-2-network │ f8-41-2.iad3 Ethernet1/18 [34:d8:68:da:15:e0]
/tmp/ports-iad3-advent-infra   infra3.iad3-advent   f8-41-2/f8-42-2-network │ f8-41-2.iad3 Ethernet1/19 [00:62:0b:7c:49:50]
                                                   
/tmp/ports-ord1-advent-infra   infra1.ord1-advent   j2-29-2/j2-30-2-network │ j2-29-2.ord1 Ethernet1/34 [b4:83:51:03:2b:a2]
/tmp/ports-ord1-advent-infra   infra2.ord1-advent   j2-29-2/j2-30-2-network │ j2-29-2.ord1 Ethernet1/35 [b4:83:51:03:2b:52]
/tmp/ports-ord1-advent-infra   infra3.ord1-advent   j2-29-2/j2-30-2-network │ j2-29-2.ord1 Ethernet1/36 [b4:83:51:02:c6:b4]                                
                                                   
/tmp/ports-rxdb-infra-infra    infra1.iad3-rxdb-i   g6-5/g6-6-network       │ g6-5-2.iad3 Ethernet1/19 [b4:83:51:02:b3:2a]
/tmp/ports-rxdb-infra-infra    infra2-1378593-Del   g6-5/g6-6-network       │ g6-5-2.iad3 Ethernet1/38 [b4:83:51:03:2d:7c]
/tmp/ports-rxdb-infra-infra    infra3-1378594-Del   g6-5/g6-6-network       │ g6-5-2.iad3 Ethernet1/39 [b4:83:51:03:2c:ac]
                                                   
/tmp/ports-rxdb-mt-infra       infra1.iad3-rxdb-m   g6-7/g6-8-network       │ g6-7-2.iad3 Ethernet1/19 [b0:26:28:cc:9b:70]
/tmp/ports-rxdb-mt-infra       infra2.iad3-rxdb-m   g6-7/g6-8-network       │ g6-7-2.iad3 Ethernet1/41 [b0:26:28:73:9c:50]
/tmp/ports-rxdb-mt-infra       infra3.iad3-rxdb-m   g6-7/g6-8-network       │ g6-7-2.iad3 Ethernet1/42 [b0:26:28:73:9d:90]
```