### PR TITLE
fix(docs): correct nav duplicate, broken links, and docs CI triggers

### DIFF
--- a/.github/workflows/properdocs.yaml
+++ b/.github/workflows/properdocs.yaml
@@ -1,18 +1,31 @@
 name: pages build and deployment
 
+# `make docs` does more than render docs/: it regenerates pages from sources
+# elsewhere in the tree and runs component-docs-check. Those sources have to be
+# listed here or a PR can merge without this workflow ever running and break
+# the docs build on main.
 on:
   push:
     branches:
       - main
-    paths:
+    paths: &docs_paths
       - "properdocs.yml"
       - "docs/**"
       - ".github/workflows/properdocs.yaml"
+      # component-docs-check validates docs/deploy-guide/components/ against these
+      - "charts/argocd-understack/templates/**"
+      # docs/workflows/ is generated from these by argo-workflows-to-mkdocs.py
+      - "workflows/**"
+      - "components/global-workflows/**"
+      # the neutron-understack sample config page is generated from this
+      - "python/neutron-understack/**"
+      # the build itself
+      - "Makefile"
+      - "requirements-docs.txt"
+      - "scripts/argo-workflows-to-mkdocs.py"
+      - "scripts/check-component-docs.py"
   pull_request:
-    paths:
-      - "properdocs.yml"
-      - "docs/**"
-      - ".github/workflows/properdocs.yaml"
+    paths: *docs_paths
   workflow_dispatch:
   merge_group:
     types: [checks_requested]

--- a/docs/operator-guide/scripts.md
+++ b/docs/operator-guide/scripts.md
@@ -15,10 +15,11 @@ export OS_CLOUD=understack-dev
 
 There are also a number of CLI tools we use:
 
-* [OpenStack CLI Setup](https://rackerlabs.github.io/understack/user-guide/openstack-cli/)
-* [Argo Workflows CLI Setup](https://rackerlabs.github.io/understack/component-argo-workflows/?h=argo#argo-cli)
+* [OpenStack CLI Setup](../user-guide/openstack-cli.md)
+* [Argo Workflows CLI Setup](../component-argo-workflows.md#argo-cli)
 
-For more about OpenStack cloud configuration, see: <https://rackerlabs.github.io/understack/user-guide/openstack-cli/>
+For more about OpenStack cloud configuration, see the
+[OpenStack CLI guide](../user-guide/openstack-cli.md).
 
 For more about Nautobot tokens, see: <https://docs.nautobot.com/projects/core/en/stable/user-guide/platform-functionality/users/token/>
 

--- a/operators/monitoring/README.md
+++ b/operators/monitoring/README.md
@@ -1,3 +1,3 @@
 # kube-prometheus-stack for monitoring
 
-Read more in the docs: <https://rackerlabs.github.io/understack/user-guide/monitoring/>
+Read more in the docs: <https://rackerlabs.github.io/understack/operator-guide/monitoring/>

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -227,7 +227,6 @@ nav:
       - operator-guide/openstack-ironic-change-boot-interface.md
       - operator-guide/baremetal-ironic-cleanup-runbook.md
       - operator-guide/openstack-ironic-console.md
-      - operator-guide/openstack-neutron.md
       - operator-guide/openstack-placement.md
     - 'Networking':
       - operator-guide/openstack-neutron.md

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -98,8 +98,14 @@ plugins:
   - callouts
   - mermaid-zoom
 
+# These only accept warn/info/ignore -- there is no "error" level -- so the
+# `--strict` flag in the Makefile is what actually turns them into build
+# failures. Do not drop `--strict`: it is what enforces that every page under
+# docs/ appears in `nav:` below (omitted_files) and that no link points at a
+# missing page or a renamed heading (not_found, anchors).
 validation:
   omitted_files: warn
+  not_found: warn
   absolute_links: warn
   unrecognized_links: warn
   anchors: warn

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -78,7 +78,6 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.snippets
   - nl2br
-  - admonition
   - pymdownx.details
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
Documentation fixes found while auditing the docs layout, plus a CI gap.

- Remove duplicate `openstack-neutron` nav entry (was under both "OpenStack" and "Networking").
- Fix broken monitoring README link (`user-guide/` → `operator-guide/`).
- Use relative links in `scripts.md` so mkdocs `--strict` validates them.
- Drop duplicate `admonition` markdown extension.
- Trigger the docs workflow on the sources `make docs` generates from, so doc-breaking changes can't merge unvalidated; enable `not_found` validation and note that `--strict` is what enforces these checks.