### PR TITLE
fix(understackctl): make version stamping actually work

### DIFF
--- a/go/understackctl/Makefile
+++ b/go/understackctl/Makefile
@@ -43,7 +43,7 @@ build-all:
 			OUTFILE=$$DIR/$(BINARY_NAME)$$EXT; \
 			mkdir -p $$DIR; \
 			echo "Building $$OUTFILE..."; \
-			CGO_ENABLED=0 GOOS=$$GOOS GOARCH=$$GOARCH go build $() -o $$OUTFILE . || echo "Failed to build $$GOOS/$$GOARCH"; \
+			CGO_ENABLED=0 GOOS=$$GOOS GOARCH=$$GOARCH go build $(LDFLAGS) -o $$OUTFILE . || echo "Failed to build $$GOOS/$$GOARCH"; \
 		done \
 	done
 

--- a/go/understackctl/cmd/root/root.go
+++ b/go/understackctl/cmd/root/root.go
@@ -43,6 +43,11 @@ func init() {
 	rootCmd.AddCommand(other.NewCmdOtherSecrets())
 }
 
+// SetVersion sets the version reported by `understackctl --version`.
+func SetVersion(version, commit string) {
+	rootCmd.Version = fmt.Sprintf("%s (%s)", version, commit)
+}
+
 // Execute will execute the root command
 func Execute() error {
 	return rootCmd.Execute()

--- a/go/understackctl/main.go
+++ b/go/understackctl/main.go
@@ -6,7 +6,15 @@ import (
 	"github.com/rackerlabs/understack/go/understackctl/cmd/root"
 )
 
+// Populated at build time by the -X linker flags set in the Makefile.
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
 func main() {
+	root.SetVersion(version, commit)
+
 	err := root.Execute()
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
The Makefile has always built LDFLAGS with -X main.version and
-X main.commit, but neither variable existed and nothing exposed a
--version flag. build-all also expanded $() instead of $(LDFLAGS).
Declare both variables, wire them into `understackctl --version`.
