### PR TITLE
feat(nautobot-operator): watch referenced ConfigMaps for event-driven reconcile

### DIFF
--- a/go/nautobotop/api/v1alpha1/nautobot_types.go
+++ b/go/nautobotop/api/v1alpha1/nautobot_types.go
@@ -89,6 +89,29 @@ func init() {
 	SchemeBuilder.Register(&Nautobot{}, &NautobotList{})
 }
 
+// ConfigMapRefs returns every ConfigMap reference declared in the spec.
+func (s *NautobotSpec) ConfigMapRefs() []ConfigMapRef {
+	refs := make([]ConfigMapRef, 0)
+	refs = append(refs, s.DeviceTypesRef...)
+	refs = append(refs, s.LocationTypesRef...)
+	refs = append(refs, s.LocationRef...)
+	refs = append(refs, s.RackGroupRef...)
+	refs = append(refs, s.RackRef...)
+	refs = append(refs, s.VlanGroupRef...)
+	refs = append(refs, s.VlanRef...)
+	refs = append(refs, s.PrefixRef...)
+	refs = append(refs, s.ClusterTypeRef...)
+	refs = append(refs, s.ClusterGroupRef...)
+	refs = append(refs, s.ClusterRef...)
+	refs = append(refs, s.NamespaceRef...)
+	refs = append(refs, s.RirRef...)
+	refs = append(refs, s.RoleRef...)
+	refs = append(refs, s.TenantGroupRef...)
+	refs = append(refs, s.TenantRef...)
+	refs = append(refs, s.DeviceRef...)
+	return refs
+}
+
 func (r *Nautobot) GetSyncHash(key string) string {
 	if r == nil || r.Status.SyncHash == nil {
 		return ""

--- a/go/nautobotop/internal/controller/configmap_watch_test.go
+++ b/go/nautobotop/internal/controller/configmap_watch_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	syncv1alpha1 "github.com/rackerlabs/understack/go/nautobotop/api/v1alpha1"
+)
+
+var _ = Describe("ConfigMap Watch", func() {
+
+	Context("referencesConfigMap", func() {
+		var reconciler *NautobotReconciler
+
+		BeforeEach(func() {
+			reconciler = &NautobotReconciler{}
+		})
+
+		It("returns true when the Nautobot CR references the ConfigMap by name and namespace", func() {
+			nb := &syncv1alpha1.Nautobot{
+				Spec: syncv1alpha1.NautobotSpec{
+					DeviceTypesRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "device-types-cm",
+							Namespace: ptr.To("infra"),
+						}},
+					},
+				},
+			}
+			Expect(reconciler.referencesConfigMap(nb, "device-types-cm", "infra")).To(BeTrue())
+		})
+
+		It("returns false when namespace does not match", func() {
+			nb := &syncv1alpha1.Nautobot{
+				Spec: syncv1alpha1.NautobotSpec{
+					DeviceTypesRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "device-types-cm",
+							Namespace: ptr.To("infra"),
+						}},
+					},
+				},
+			}
+			Expect(reconciler.referencesConfigMap(nb, "device-types-cm", "other-ns")).To(BeFalse())
+		})
+
+		It("returns false when name does not match", func() {
+			nb := &syncv1alpha1.Nautobot{
+				Spec: syncv1alpha1.NautobotSpec{
+					LocationRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "locations-cm",
+							Namespace: ptr.To("infra"),
+						}},
+					},
+				},
+			}
+			Expect(reconciler.referencesConfigMap(nb, "other-cm", "infra")).To(BeFalse())
+		})
+
+		It("returns false when the CR has no ConfigMap references", func() {
+			nb := &syncv1alpha1.Nautobot{
+				Spec: syncv1alpha1.NautobotSpec{},
+			}
+			Expect(reconciler.referencesConfigMap(nb, "any-cm", "any-ns")).To(BeFalse())
+		})
+
+		It("handles nil namespace in the ref (matches empty namespace)", func() {
+			nb := &syncv1alpha1.Nautobot{
+				Spec: syncv1alpha1.NautobotSpec{
+					RackRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "rack-cm",
+							Namespace: nil,
+						}},
+					},
+				},
+			}
+			// nil namespace in ref means empty string — matches a ConfigMap with empty namespace
+			Expect(reconciler.referencesConfigMap(nb, "rack-cm", "")).To(BeTrue())
+			Expect(reconciler.referencesConfigMap(nb, "rack-cm", "some-ns")).To(BeFalse())
+		})
+
+		It("matches across multiple ref fields", func() {
+			nb := &syncv1alpha1.Nautobot{
+				Spec: syncv1alpha1.NautobotSpec{
+					VlanRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "vlan-cm",
+							Namespace: ptr.To("network"),
+						}},
+					},
+					PrefixRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "prefix-cm",
+							Namespace: ptr.To("network"),
+						}},
+					},
+				},
+			}
+			Expect(reconciler.referencesConfigMap(nb, "prefix-cm", "network")).To(BeTrue())
+			Expect(reconciler.referencesConfigMap(nb, "vlan-cm", "network")).To(BeTrue())
+			Expect(reconciler.referencesConfigMap(nb, "unknown-cm", "network")).To(BeFalse())
+		})
+	})
+
+	Context("configMapToNautobotRequests", func() {
+		var reconciler *NautobotReconciler
+
+		BeforeEach(func() {
+			reconciler = &NautobotReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+		})
+
+		It("returns reconcile requests for CRs that reference the changed ConfigMap", func() {
+			ctx := context.Background()
+
+			// Create a Nautobot CR that references a specific ConfigMap
+			nb := &syncv1alpha1.Nautobot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "watch-test-cr",
+				},
+				Spec: syncv1alpha1.NautobotSpec{
+					LocationRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "locations-data",
+							Namespace: ptr.To("test-ns"),
+						}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, nb)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, nb)
+			}()
+
+			// Simulate a ConfigMap change event
+			changedCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "locations-data",
+					Namespace: "test-ns",
+				},
+			}
+
+			requests := reconciler.configMapToNautobotRequests(ctx, changedCM)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName).To(Equal(types.NamespacedName{Name: "watch-test-cr"}))
+		})
+
+		It("returns empty when no CR references the changed ConfigMap", func() {
+			ctx := context.Background()
+
+			nb := &syncv1alpha1.Nautobot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "watch-test-cr-no-match",
+				},
+				Spec: syncv1alpha1.NautobotSpec{
+					RackRef: []syncv1alpha1.ConfigMapRef{
+						{ConfigMapSelector: syncv1alpha1.ConfigMapKeySelector{
+							Name:      "racks-data",
+							Namespace: ptr.To("infra"),
+						}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, nb)).To(Succeed())
+			defer func() {
+				_ = k8sClient.Delete(ctx, nb)
+			}()
+
+			// ConfigMap that nobody references
+			changedCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-cm",
+					Namespace: "infra",
+				},
+			}
+
+			requests := reconciler.configMapToNautobotRequests(ctx, changedCM)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+})

--- a/go/nautobotop/internal/controller/nautobot_controller.go
+++ b/go/nautobotop/internal/controller/nautobot_controller.go
@@ -39,6 +39,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	syncv1alpha1 "github.com/rackerlabs/understack/go/nautobotop/api/v1alpha1"
@@ -551,9 +552,55 @@ func (r *NautobotReconciler) getAuthTokenFromSecretRef(ctx context.Context, naut
 func (r *NautobotReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&syncv1alpha1.Nautobot{}).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.configMapToNautobotRequests)).
 		WithOptions(controller.Options{RecoverPanic: ptr.To(true)}).
 		Named("nautobot").
 		Complete(r)
+}
+
+// configMapToNautobotRequests maps a changed ConfigMap to the Nautobot CR(s) that reference it.
+func (r *NautobotReconciler) configMapToNautobotRequests(ctx context.Context, obj client.Object) []ctrl.Request {
+	log := logf.FromContext(ctx)
+
+	var nautobotList syncv1alpha1.NautobotList
+	if err := r.List(ctx, &nautobotList); err != nil {
+		log.Error(err, "failed to list Nautobot CRs for ConfigMap watch")
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for i := range nautobotList.Items {
+		nb := &nautobotList.Items[i]
+		if r.referencesConfigMap(nb, obj.GetName(), obj.GetNamespace()) {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: nb.Name,
+				},
+			})
+		}
+	}
+
+	if len(requests) > 0 {
+		log.Info("ConfigMap change triggered reconcile", "configMap", obj.GetName(), "namespace", obj.GetNamespace(), "matchedCRs", len(requests))
+	}
+
+	return requests
+}
+
+// referencesConfigMap checks whether a Nautobot CR references the given ConfigMap by name and namespace.
+func (r *NautobotReconciler) referencesConfigMap(nb *syncv1alpha1.Nautobot, name, namespace string) bool {
+	for _, ref := range nb.Spec.ConfigMapRefs() {
+		if ref.ConfigMapSelector.Name == name {
+			refNS := ""
+			if ref.ConfigMapSelector.Namespace != nil {
+				refNS = *ref.ConfigMapSelector.Namespace
+			}
+			if refNS == namespace {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // SyncDecision represents the result of evaluating whether a sync should proceed


### PR DESCRIPTION
Add a Watches() on corev1.ConfigMap with EnqueueRequestsFromMapFunc so
that edits to ConfigMaps referenced by a Nautobot CR trigger an immediate
reconcile instead of waiting for the timed sync interval.

- Add ConfigMapRefs() helper on NautobotSpec to enumerate all refs
- Add configMapToNautobotRequests mapFunc to resolve ConfigMap -> Nautobot CRs
- Add referencesConfigMap helper for name+namespace matching