### PR TITLE
fix(ironic): correct the chassis/model trait

### DIFF
--- a/docs/operator-guide/openstack-ironic-inspection-guide.md
+++ b/docs/operator-guide/openstack-ironic-inspection-guide.md
@@ -221,9 +221,9 @@ The `chassis_model` hook adds a custom trait identifying the specific hardware c
 
 1. Extracts chassis model from `system_vendor.product_name`
 2. Normalizes manufacturer name (handles "DELL", "HP" variants)
-3. Creates a trait in the format: `CUSTOM_{MANUFACTURER}#{CHASSIS_MODEL}`
+3. Creates a trait in the format: `CUSTOM_{MANUFACTURER}_{CHASSIS_MODEL}`
 
-**Example**: A Dell PowerEdge R7615 receives the trait `CUSTOM_DELL#POWEREDGE_R7615`
+**Example**: A Dell PowerEdge R7615 receives the trait `CUSTOM_DELL_POWEREDGE_R7615`
 
 This trait enables [flavor definitions](../design-guide/flavors.md) to target specific hardware models. See [hardware traits](../design-guide/hardware-traits.md) for more on how traits work.
 

--- a/python/ironic-understack/ironic_understack/inspect_hook_chassis_model.py
+++ b/python/ironic-understack/ironic_understack/inspect_hook_chassis_model.py
@@ -19,7 +19,7 @@ class InspectHookChassisModel(base.InspectionHook):
         chassis_model = _extract_chassis_model(node, inventory)
         manufacturer = _extract_manufacturer(node, inventory)
         trait_name = _trait_name(manufacturer, chassis_model)
-        _set_node_traits(task, "CUSTOM_CHASSIS_MODEL_", trait_name)
+        _set_node_traits(task, "CUSTOM_", trait_name)
 
 
 def _set_node_traits(task, prefix: str, required_trait: str):


### PR DESCRIPTION
Correct the documentation and the code to match each other.
