### PR TITLE
fix: build the shell-operator container on changes

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -12,6 +12,7 @@ on:
       - "containers/dnsmasq/**"
       - "containers/ironic-nautobot-client/**"
       - "containers/ironic-vnc-client/**"
+      - "containers/shell-operator-ironic/**"
       - "containers/understack-tests/**"
       - "python/**"
       - ".github/workflows/containers.yaml"


### PR DESCRIPTION
When there are changes to the shell-operator container then we need to
build its changes.
