### PR TITLE
fix(shell-operator-runbooks): fix applying updates to runbacks and correct display of runbooks

### DIFF
--- a/components/ironic/runbook-crd/bases/baremetal.ironicproject.org_runbooks.yaml
+++ b/components/ironic/runbook-crd/bases/baremetal.ironicproject.org_runbooks.yaml
@@ -185,10 +185,6 @@ spec:
           description: Human-readable description of the runbook
           jsonPath: .spec.description
           priority: 1
-        - name: Steps
-          type: integer
-          description: Number of steps in the runbook
-          jsonPath: .spec.steps[*]
         - name: Public
           type: boolean
           description: Whether the runbook is public

--- a/components/ironic/runbook-crd/runbooks/runbook_bmc_maintenance.yaml
+++ b/components/ironic/runbook-crd/runbooks/runbook_bmc_maintenance.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   runbookName: bmc-maintenance
   description: "Performs BMC maintenance operations including clearing the job queue and synchronizing the BMC clock."
+  disableRamdisk: true
   traits:
     - CUSTOM_DELL_IDRAC
 

--- a/containers/shell-operator-ironic/hooks/create_runbook.sh
+++ b/containers/shell-operator-ironic/hooks/create_runbook.sh
@@ -62,17 +62,17 @@ PATCH
     local obj_path="$1"
     local resource_name namespace kind runbook_name description public owner
 
-    resource_name=$(jq -r "${obj_path}.metadata.name" "${BINDING_CONTEXT_PATH}")
-    namespace=$(jq -r "${obj_path}.metadata.namespace" "${BINDING_CONTEXT_PATH}")
-    kind=$(jq -r "${obj_path}.kind" "${BINDING_CONTEXT_PATH}")
-    runbook_name=$(jq -r "${obj_path}.spec.runbookName" "${BINDING_CONTEXT_PATH}")
-    description=$(jq -r "${obj_path}.spec.description // empty" "${BINDING_CONTEXT_PATH}")
-    public=$(jq -r "${obj_path}.spec.public // empty" "${BINDING_CONTEXT_PATH}")
-    owner=$(jq -r "${obj_path}.spec.owner // empty" "${BINDING_CONTEXT_PATH}")
+    resource_name=$(jq -r "${obj_path} | .metadata.name" "${BINDING_CONTEXT_PATH}")
+    namespace=$(jq -r "${obj_path} | .metadata.namespace" "${BINDING_CONTEXT_PATH}")
+    kind=$(jq -r "${obj_path} | .kind" "${BINDING_CONTEXT_PATH}")
+    runbook_name=$(jq -r "${obj_path} | .spec.runbookName" "${BINDING_CONTEXT_PATH}")
+    description=$(jq -r "${obj_path} | .spec.description // empty" "${BINDING_CONTEXT_PATH}")
+    public=$(jq -r "${obj_path} | .spec.public // empty" "${BINDING_CONTEXT_PATH}")
+    owner=$(jq -r "${obj_path} | .spec.owner // empty" "${BINDING_CONTEXT_PATH}")
 
     echo "[create_runbook] Creating runbook kind=${kind} name=${resource_name} namespace=${namespace} runbookName=${runbook_name} description=${description} public=${public} owner=${owner}"
 
-    jq -r "${obj_path}.spec.steps" "${BINDING_CONTEXT_PATH}" > /tmp/steps.json
+    jq -r "${obj_path} | .spec.steps" "${BINDING_CONTEXT_PATH}" > /tmp/steps.json
 
     if ! jq -e 'type == "array" and length > 0' /tmp/steps.json >/dev/null 2>&1; then
         echo "[create_runbook] FAILED: name=${resource_name} error=spec.steps is missing, null, or empty" >&2
@@ -97,7 +97,7 @@ PATCH
     if output=$(openstack "${command_args[@]}" 2>&1); then
         echo "[create_runbook] SUCCESS: Runbook created in Ironic name=${resource_name} output=${output}"
 
-        traits_json=$(jq -c "${obj_path}.spec.traits // []" "${BINDING_CONTEXT_PATH}")
+        traits_json=$(jq -c "${obj_path} | .spec.traits // []" "${BINDING_CONTEXT_PATH}")
         if [[ "${traits_json}" != "[]" ]]; then
             echo "[create_runbook] Setting traits name=${resource_name} traits=${traits_json}"
             ironic_endpoint=$(openstack endpoint list --service baremetal --interface internal -f value -c URL 2>/dev/null | head -1)

--- a/containers/shell-operator-ironic/hooks/update_runbook.sh
+++ b/containers/shell-operator-ironic/hooks/update_runbook.sh
@@ -62,17 +62,17 @@ PATCH
     local obj_path="$1"
     local resource_name namespace kind runbook_name description public owner
 
-    resource_name=$(jq -r "${obj_path}.metadata.name" "${BINDING_CONTEXT_PATH}")
-    namespace=$(jq -r "${obj_path}.metadata.namespace" "${BINDING_CONTEXT_PATH}")
-    kind=$(jq -r "${obj_path}.kind" "${BINDING_CONTEXT_PATH}")
-    runbook_name=$(jq -r "${obj_path}.spec.runbookName" "${BINDING_CONTEXT_PATH}")
-    description=$(jq -r "${obj_path}.spec.description // empty" "${BINDING_CONTEXT_PATH}")
-    public=$(jq -r "${obj_path}.spec.public // empty" "${BINDING_CONTEXT_PATH}")
-    owner=$(jq -r "${obj_path}.spec.owner // empty" "${BINDING_CONTEXT_PATH}")
+    resource_name=$(jq -r "${obj_path} | .metadata.name" "${BINDING_CONTEXT_PATH}")
+    namespace=$(jq -r "${obj_path} | .metadata.namespace" "${BINDING_CONTEXT_PATH}")
+    kind=$(jq -r "${obj_path} | .kind" "${BINDING_CONTEXT_PATH}")
+    runbook_name=$(jq -r "${obj_path} | .spec.runbookName" "${BINDING_CONTEXT_PATH}")
+    description=$(jq -r "${obj_path} | .spec.description // empty" "${BINDING_CONTEXT_PATH}")
+    public=$(jq -r "${obj_path} | .spec.public // empty" "${BINDING_CONTEXT_PATH}")
+    owner=$(jq -r "${obj_path} | .spec.owner // empty" "${BINDING_CONTEXT_PATH}")
 
     echo "[update_runbook] Updating runbook kind=${kind} name=${resource_name} namespace=${namespace} runbookName=${runbook_name} description=${description} public=${public} owner=${owner}"
 
-    jq -r "${obj_path}.spec.steps" "${BINDING_CONTEXT_PATH}" > /tmp/steps.json
+    jq -r "${obj_path} | .spec.steps" "${BINDING_CONTEXT_PATH}" > /tmp/steps.json
 
     if ! jq -e 'type == "array" and length > 0' /tmp/steps.json >/dev/null 2>&1; then
         echo "[update_runbook] FAILED: name=${resource_name} error=spec.steps is missing, null, or empty" >&2
@@ -95,7 +95,7 @@ PATCH
     if output=$(openstack "${command_args[@]}" 2>&1); then
         echo "[update_runbook] SUCCESS: Runbook updated in Ironic name=${resource_name} output=${output}"
 
-        traits_json=$(jq -c "${obj_path}.spec.traits // []" "${BINDING_CONTEXT_PATH}")
+        traits_json=$(jq -c "${obj_path} | .spec.traits // []" "${BINDING_CONTEXT_PATH}")
         if [[ "${traits_json}" != "[]" ]]; then
             echo "[update_runbook] Setting traits name=${resource_name} traits=${traits_json}"
             ironic_endpoint=$(openstack endpoint list --service baremetal --interface internal -f value -c URL 2>/dev/null | head -1)


### PR DESCRIPTION
The same bug as #2199 was present on the update case as the creation case so this fixes the update case. Removed the broken display of `Steps` as it would never work. Fixed the bmc-maintenance runback to not try and boot the Ramdisk.
