### PR TITLE
chore(ironic): rebase to latest stable/2026.1 and cherry-pick fixes

### DIFF
--- a/containers/ironic/Dockerfile
+++ b/containers/ironic/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # renovate: name=openstack/ironic repo=https://github.com/rackerlabs/ironic.git branch=understack/2026.1
-ARG IRONIC_GIT_REF=403d18a0d6fbe7110f47d390fbaeb77bb678e6f3
+ARG IRONIC_GIT_REF=4ee113c63d0c92bd3f61c31c313016c594438ef6
 ADD --keep-git-dir=true https://github.com/rackerlabs/ironic.git#${IRONIC_GIT_REF} /src/ironic
 RUN git -C /src/ironic fetch --unshallow --tags
 


### PR DESCRIPTION
Rebased the ironic container to the latest upstream stable/2026.1 and
cherry-picked the following changes into our understack/2026.1:

- https://review.opendev.org/c/openstack/ironic/+/997366
- https://review.opendev.org/c/openstack/ironic/+/1000050
- https://review.opendev.org/c/openstack/ironic/+/999910
- https://review.opendev.org/c/openstack/ironic/+/1000059
