### PR TITLE
fix(workflows): Update workflows to handle dynamic and multiple netapp driver configs

### DIFF
--- a/python/understack-workflows/tests/test_cinder_volume_type.py
+++ b/python/understack-workflows/tests/test_cinder_volume_type.py
@@ -72,13 +72,25 @@ class TestHandleVolumeTypeAccessAdded:
         result = handle_volume_type_access_added(mock_conn, mock_nautobot, event_data)
         assert result == 1
 
+    @patch(
+        "understack_workflows.oslo_event.cinder_volume_type.NetAppConfig.get_all_backends"
+    )
     @patch("understack_workflows.oslo_event.cinder_volume_type.NetAppManager")
     @patch("builtins.open")
     def test_svm_does_not_exist_returns_1(
-        self, mock_open, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_netapp_class,
+        mock_get_all_backends,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """If SVM doesn't exist, skip volume creation and return 1."""
         mock_conn.block_storage.get_type.return_value = MagicMock(extra_specs={})
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
         mock_netapp_manager.check_if_svm_exists.return_value = False
         mock_netapp_class.return_value = mock_netapp_manager
@@ -93,13 +105,25 @@ class TestHandleVolumeTypeAccessAdded:
         )
         mock_netapp_manager.create_volume.assert_not_called()
 
+    @patch(
+        "understack_workflows.oslo_event.cinder_volume_type.NetAppConfig.get_all_backends"
+    )
     @patch("understack_workflows.oslo_event.cinder_volume_type.NetAppManager")
     @patch("builtins.open")
     def test_successful_volume_creation(
-        self, mock_open, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_netapp_class,
+        mock_get_all_backends,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Volume created with the dynamically selected aggregate and default size."""
         mock_conn.block_storage.get_type.return_value = MagicMock(extra_specs={})
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
         mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_manager.select_aggregate_name.return_value = "aggr-selected"
@@ -118,10 +142,19 @@ class TestHandleVolumeTypeAccessAdded:
             aggregate_name="aggr-selected",
         )
 
+    @patch(
+        "understack_workflows.oslo_event.cinder_volume_type.NetAppConfig.get_all_backends"
+    )
     @patch("understack_workflows.oslo_event.cinder_volume_type.NetAppManager")
     @patch("builtins.open")
     def test_extra_specs_used_for_aggregate_and_size(
-        self, mock_open, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_netapp_class,
+        mock_get_all_backends,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """aggregate_name and volume_size from extra_specs override defaults."""
         mock_conn.block_storage.get_type.return_value = MagicMock(
@@ -130,6 +163,9 @@ class TestHandleVolumeTypeAccessAdded:
                 "netapp:flexvol_size": "1TB",
             }
         )
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
         mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_class.return_value = mock_netapp_manager
@@ -147,13 +183,25 @@ class TestHandleVolumeTypeAccessAdded:
             aggregate_name="aggr_custom",
         )
 
+    @patch(
+        "understack_workflows.oslo_event.cinder_volume_type.NetAppConfig.get_all_backends"
+    )
     @patch("understack_workflows.oslo_event.cinder_volume_type.NetAppManager")
     @patch("builtins.open")
     def test_aggregate_selection_failure_propagates(
-        self, mock_open, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_netapp_class,
+        mock_get_all_backends,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """If no aggregate can be selected, volume creation is not attempted."""
         mock_conn.block_storage.get_type.return_value = MagicMock(extra_specs={})
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
         mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_manager.select_aggregate_name.side_effect = Exception(
@@ -198,14 +246,27 @@ class TestHandleVolumeTypeAccessRemoved:
         result = handle_volume_type_access_removed(mock_conn, mock_nautobot, event_data)
         assert result == 1
 
+    @patch(
+        "understack_workflows.oslo_event.cinder_volume_type.NetAppConfig.get_all_backends"
+    )
     @patch("understack_workflows.oslo_event.cinder_volume_type.NetAppManager")
     @patch("builtins.open")
     def test_successful_volume_deletion(
-        self, mock_open, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_netapp_class,
+        mock_get_all_backends,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Volume deleted and returns 0 on success."""
         expected_volume_name = f"vol_{VOLUME_TYPE_ID.replace('-', '')}"
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
+        mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_manager.get_volume_name.return_value = expected_volume_name
         mock_netapp_manager.delete_volume.return_value = True
         mock_netapp_class.return_value = mock_netapp_manager
@@ -220,13 +281,26 @@ class TestHandleVolumeTypeAccessRemoved:
             expected_volume_name, force=False
         )
 
+    @patch(
+        "understack_workflows.oslo_event.cinder_volume_type.NetAppConfig.get_all_backends"
+    )
     @patch("understack_workflows.oslo_event.cinder_volume_type.NetAppManager")
     @patch("builtins.open")
     def test_deletion_returns_false_returns_1(
-        self, mock_open, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_netapp_class,
+        mock_get_all_backends,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Returns 1 when delete_volume returns False."""
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
+        mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_manager.delete_volume.return_value = False
         mock_netapp_class.return_value = mock_netapp_manager
 
@@ -236,13 +310,26 @@ class TestHandleVolumeTypeAccessRemoved:
 
         assert result == 1
 
+    @patch(
+        "understack_workflows.oslo_event.cinder_volume_type.NetAppConfig.get_all_backends"
+    )
     @patch("understack_workflows.oslo_event.cinder_volume_type.NetAppManager")
     @patch("builtins.open")
     def test_deletion_failure_returns_1(
-        self, mock_open, mock_netapp_class, mock_conn, mock_nautobot, valid_event_data
+        self,
+        mock_open,
+        mock_netapp_class,
+        mock_get_all_backends,
+        mock_conn,
+        mock_nautobot,
+        valid_event_data,
     ):
         """Returns 1 when delete_volume raises an exception."""
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
+        mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_manager.delete_volume.side_effect = Exception("Delete failed")
         mock_netapp_class.return_value = mock_netapp_manager
 

--- a/python/understack-workflows/tests/test_keystone_project.py
+++ b/python/understack-workflows/tests/test_keystone_project.py
@@ -96,6 +96,17 @@ class TestKeystoneProjectTags:
 class TestHandleProjectCreated:
     """Test cases for handle_project_created function."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_get_all_backends(self):
+        """Auto-mock get_all_backends for all create tests."""
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        with patch(
+            "understack_workflows.oslo_event.keystone_project.NetAppConfig.get_all_backends",
+            return_value=[mock_backend],
+        ):
+            yield
+
     @pytest.fixture
     def mock_conn(self):
         """Create a mock OpenStack connection."""
@@ -351,6 +362,17 @@ class TestHandleProjectCreated:
 
 class TestHandleProjectUpdated:
     """Test cases for handle_project_updated function."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_get_all_backends(self):
+        """Auto-mock get_all_backends for all update tests."""
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        with patch(
+            "understack_workflows.oslo_event.keystone_project.NetAppConfig.get_all_backends",
+            return_value=[mock_backend],
+        ):
+            yield
 
     @pytest.fixture
     def mock_conn(self):
@@ -737,8 +759,12 @@ class TestHandleProjectDeleted:
 
     @patch("builtins.open", new_callable=mock.mock_open)
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
+    @patch(
+        "understack_workflows.oslo_event.keystone_project.NetAppConfig.get_all_backends"
+    )
     def test_handle_project_deleted_svm_exists(
         self,
+        mock_get_all_backends,
         mock_netapp_class,
         mock_open,
         mock_conn,
@@ -747,6 +773,9 @@ class TestHandleProjectDeleted:
     ):
         """Test project deletion when SVM exists."""
         mock_file = mock_open.return_value
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
         mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_class.return_value = mock_netapp_manager
@@ -756,6 +785,7 @@ class TestHandleProjectDeleted:
         )
 
         assert result == 0
+        mock_netapp_class.assert_called_once_with(netapp_config=mock_backend)
         mock_netapp_manager.check_if_svm_exists.assert_called_once_with(
             project_id="test-project-123"
         )
@@ -765,8 +795,12 @@ class TestHandleProjectDeleted:
 
     @patch("builtins.open", new_callable=mock.mock_open)
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
+    @patch(
+        "understack_workflows.oslo_event.keystone_project.NetAppConfig.get_all_backends"
+    )
     def test_handle_project_deleted_svm_does_not_exist(
         self,
+        mock_get_all_backends,
         mock_netapp_class,
         mock_open,
         mock_conn,
@@ -775,6 +809,9 @@ class TestHandleProjectDeleted:
     ):
         """Test project deletion when SVM does not exist."""
         mock_file = mock_open.return_value
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
         mock_netapp_manager.check_if_svm_exists.return_value = False
         mock_netapp_class.return_value = mock_netapp_manager
@@ -793,8 +830,12 @@ class TestHandleProjectDeleted:
 
     @patch("builtins.open", new_callable=mock.mock_open)
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
+    @patch(
+        "understack_workflows.oslo_event.keystone_project.NetAppConfig.get_all_backends"
+    )
     def test_handle_project_deleted_netapp_manager_failure(
         self,
+        mock_get_all_backends,
         mock_netapp_class,
         mock_open,
         mock_conn,
@@ -803,6 +844,9 @@ class TestHandleProjectDeleted:
     ):
         """Test handling when NetAppManager creation fails during deletion."""
         mock_file = mock_open.return_value
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_class.side_effect = Exception("NetApp connection failed")
 
         result = handle_project_deleted(
@@ -810,14 +854,18 @@ class TestHandleProjectDeleted:
         )
 
         assert result == 1  # Should return 1 on exception
-        mock_netapp_class.assert_called_once()
+        mock_netapp_class.assert_called_once_with(netapp_config=mock_backend)
         mock_open.assert_any_call("/var/run/argo/output.svm_state", "w")
         mock_file.write.assert_any_call("unknown")
 
     @patch("builtins.open", new_callable=mock.mock_open)
     @patch("understack_workflows.oslo_event.keystone_project.NetAppManager")
+    @patch(
+        "understack_workflows.oslo_event.keystone_project.NetAppConfig.get_all_backends"
+    )
     def test_handle_project_deleted_cleanup_failure(
         self,
+        mock_get_all_backends,
         mock_netapp_class,
         mock_open,
         mock_conn,
@@ -826,6 +874,9 @@ class TestHandleProjectDeleted:
     ):
         """Test handling when cleanup_project fails during deletion."""
         mock_file = mock_open.return_value
+        mock_backend = MagicMock()
+        mock_backend.section = "backend1"
+        mock_get_all_backends.return_value = [mock_backend]
         mock_netapp_manager = MagicMock()
         mock_netapp_manager.check_if_svm_exists.return_value = True
         mock_netapp_manager.cleanup_project.side_effect = Exception("Cleanup failed")

--- a/python/understack-workflows/tests/test_netapp_config.py
+++ b/python/understack-workflows/tests/test_netapp_config.py
@@ -2,7 +2,6 @@
 
 import os
 import tempfile
-from unittest.mock import patch
 
 import pytest
 
@@ -16,7 +15,7 @@ class TestNetAppConfig:
     @pytest.fixture
     def valid_config_file(self):
         """Create a valid temporary config file for testing."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname = test-hostname.example.com
 netapp_login = test-user
 netapp_password = test-password-123
@@ -30,7 +29,7 @@ netapp_password = test-password-123
     @pytest.fixture
     def config_with_nic_prefix(self):
         """Create a config file with custom NIC slot prefix."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname = test-hostname.example.com
 netapp_login = test-user
 netapp_password = test-password-123
@@ -43,12 +42,18 @@ netapp_nic_slot_prefix = e5
         os.unlink(f.name)
 
     @pytest.fixture
-    def minimal_config_file(self):
-        """Create a minimal valid config file."""
-        config_content = """[netapp_nvme]
-netapp_server_hostname = host
-netapp_login = user
-netapp_password = pass
+    def multi_backend_config_file(self):
+        """Create a config file with multiple backends."""
+        config_content = """[staging-svm1]
+netapp_server_hostname = netapp1.staging.example.com
+netapp_login = admin1
+netapp_password = pass1
+
+[staging-svm2]
+netapp_server_hostname = netapp2.staging.example.com
+netapp_login = admin2
+netapp_password = pass2
+netapp_nic_slot_prefix = e2
 """
         with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
             f.write(config_content)
@@ -58,59 +63,28 @@ netapp_password = pass
 
     def test_successful_initialization(self, valid_config_file):
         """Test successful NetAppConfig initialization."""
-        config = NetAppConfig(valid_config_file)
+        config = NetAppConfig(valid_config_file, "backend1")
 
         assert config.hostname == "test-hostname.example.com"
         assert config.username == "test-user"
         assert config.password == "test-password-123"
         assert config.netapp_nic_slot_prefix == "e4"  # Default value
         assert config.config_path == valid_config_file
-
-    def test_default_config_path(self):
-        """Test NetAppConfig with default config path."""
-        with patch.object(NetAppConfig, "_parse_config") as mock_parse:
-            mock_parse.return_value = {
-                "hostname": "default-host",
-                "username": "default-user",
-                "password": "default-pass",
-            }
-
-            config = NetAppConfig()
-
-            assert config.config_path == "/etc/netapp/netapp_nvme.conf"
-            mock_parse.assert_called_once()
+        assert config.section == "backend1"
 
     def test_file_not_found(self):
         """Test ConfigurationError when config file doesn't exist."""
         with pytest.raises(ConfigurationError) as exc_info:
-            NetAppConfig("/nonexistent/path/config.conf")
+            NetAppConfig("/nonexistent/path/config.conf", "backend1")
 
         error = exc_info.value
         assert "Configuration file not found" in error.message
         assert error.config_path == "/nonexistent/path/config.conf"
 
     def test_missing_section(self):
-        """Test ConfigurationError when required section is missing."""
-        config_content = """[wrong_section]
-some_key = some_value
-"""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
-            f.write(config_content)
-            f.flush()
-
-            with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
-
-            error = exc_info.value
-            assert "Missing required configuration" in error.message
-            assert error.config_path == f.name
-            assert "missing_config" in error.context
-
-        os.unlink(f.name)
-
-    def test_missing_hostname_option(self):
-        """Test ConfigurationError when hostname option is missing."""
-        config_content = """[netapp_nvme]
+        """Test ConfigurationError when requested section is missing."""
+        config_content = """[other_section]
+netapp_server_hostname = test-hostname
 netapp_login = test-user
 netapp_password = test-password
 """
@@ -119,7 +93,26 @@ netapp_password = test-password
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "nonexistent_section")
+
+            error = exc_info.value
+            assert "not found" in error.message
+            assert "nonexistent_section" in error.message
+
+        os.unlink(f.name)
+
+    def test_missing_hostname_option(self):
+        """Test ConfigurationError when hostname option is missing."""
+        config_content = """[backend1]
+netapp_login = test-user
+netapp_password = test-password
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            with pytest.raises(ConfigurationError) as exc_info:
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Missing required configuration" in error.message
@@ -129,7 +122,7 @@ netapp_password = test-password
 
     def test_missing_username_option(self):
         """Test ConfigurationError when username option is missing."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname = test-hostname
 netapp_password = test-password
 """
@@ -138,7 +131,7 @@ netapp_password = test-password
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Missing required configuration" in error.message
@@ -148,7 +141,7 @@ netapp_password = test-password
 
     def test_missing_password_option(self):
         """Test ConfigurationError when password option is missing."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname = test-hostname
 netapp_login = test-user
 """
@@ -157,7 +150,7 @@ netapp_login = test-user
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Missing required configuration" in error.message
@@ -167,7 +160,7 @@ netapp_login = test-user
 
     def test_empty_hostname_value(self):
         """Test ConfigurationError when hostname value is empty."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname =
 netapp_login = test-user
 netapp_password = test-password
@@ -177,7 +170,7 @@ netapp_password = test-password
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Configuration validation failed" in error.message
@@ -189,7 +182,7 @@ netapp_password = test-password
 
     def test_empty_username_value(self):
         """Test ConfigurationError when username value is empty."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname = test-hostname
 netapp_login =
 netapp_password = test-password
@@ -199,7 +192,7 @@ netapp_password = test-password
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Configuration validation failed" in error.message
@@ -209,7 +202,7 @@ netapp_password = test-password
 
     def test_empty_password_value(self):
         """Test ConfigurationError when password value is empty."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname = test-hostname
 netapp_login = test-user
 netapp_password =
@@ -219,7 +212,7 @@ netapp_password =
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Configuration validation failed" in error.message
@@ -229,7 +222,7 @@ netapp_password =
 
     def test_multiple_empty_fields(self):
         """Test ConfigurationError when multiple fields are empty."""
-        config_content = """[netapp_nvme]
+        config_content = """[backend1]
 netapp_server_hostname =
 netapp_login =
 netapp_password = test-password
@@ -239,7 +232,7 @@ netapp_password = test-password
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Configuration validation failed" in error.message
@@ -248,29 +241,9 @@ netapp_password = test-password
 
         os.unlink(f.name)
 
-    def test_whitespace_only_values(self):
-        """Test ConfigurationError when values contain only whitespace."""
-        config_content = """[netapp_nvme]
-netapp_server_hostname = test-hostname
-netapp_login =
-netapp_password =
-"""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
-            f.write(config_content)
-            f.flush()
-
-            with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
-
-            error = exc_info.value
-            assert "Configuration validation failed" in error.message
-            assert "Empty fields: username, password" in error.message
-
-        os.unlink(f.name)
-
     def test_malformed_config_file(self):
         """Test ConfigurationError when config file is malformed."""
-        config_content = """[netapp_nvme
+        config_content = """[backend1
 netapp_server_hostname = test-hostname
 invalid line without equals
 netapp_login = test-user
@@ -280,7 +253,7 @@ netapp_login = test-user
             f.flush()
 
             with pytest.raises(ConfigurationError) as exc_info:
-                NetAppConfig(f.name)
+                NetAppConfig(f.name, "backend1")
 
             error = exc_info.value
             assert "Failed to parse configuration file" in error.message
@@ -290,16 +263,15 @@ netapp_login = test-user
 
     def test_validate_method_directly(self, valid_config_file):
         """Test calling validate method directly."""
-        config = NetAppConfig(valid_config_file)
+        config = NetAppConfig(valid_config_file, "backend1")
 
         # Should not raise any exception
         config.validate()
 
     def test_properties_immutable(self, valid_config_file):
         """Test that config properties are read-only."""
-        config = NetAppConfig(valid_config_file)
+        config = NetAppConfig(valid_config_file, "backend1")
 
-        # Properties should not be settable
         with pytest.raises(AttributeError):
             config.hostname = "new-hostname"  # type: ignore[misc]
 
@@ -309,34 +281,9 @@ netapp_login = test-user
         with pytest.raises(AttributeError):
             config.password = "new-password"  # type: ignore[misc]
 
-    def test_config_with_extra_sections(self, valid_config_file):
-        """Test config parsing ignores extra sections."""
-        config_content = """[netapp_nvme]
-netapp_server_hostname = test-hostname
-netapp_login = test-user
-netapp_password = test-password
-
-[extra_section]
-extra_key = extra_value
-
-[another_section]
-another_key = another_value
-"""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
-            f.write(config_content)
-            f.flush()
-
-            config = NetAppConfig(f.name)
-
-            assert config.hostname == "test-hostname"
-            assert config.username == "test-user"
-            assert config.password == "test-password"
-
-        os.unlink(f.name)
-
     def test_netapp_nic_slot_prefix_custom_value(self, config_with_nic_prefix):
         """Test NetAppConfig with custom NIC slot prefix."""
-        config = NetAppConfig(config_with_nic_prefix)
+        config = NetAppConfig(config_with_nic_prefix, "backend1")
 
         assert config.hostname == "test-hostname.example.com"
         assert config.username == "test-user"
@@ -345,13 +292,13 @@ another_key = another_value
 
     def test_netapp_nic_slot_prefix_default_value(self, valid_config_file):
         """Test NetAppConfig uses default NIC slot prefix when not specified."""
-        config = NetAppConfig(valid_config_file)
+        config = NetAppConfig(valid_config_file, "backend1")
 
         assert config.netapp_nic_slot_prefix == "e4"
 
     def test_config_with_extra_options(self):
-        """Test config parsing ignores extra options in netapp_nvme section."""
-        config_content = """[netapp_nvme]
+        """Test config parsing ignores extra options in section."""
+        config_content = """[backend1]
 netapp_server_hostname = test-hostname
 netapp_login = test-user
 netapp_password = test-password
@@ -362,7 +309,7 @@ another_option = another_value
             f.write(config_content)
             f.flush()
 
-            config = NetAppConfig(f.name)
+            config = NetAppConfig(f.name, "backend1")
 
             assert config.hostname == "test-hostname"
             assert config.username == "test-user"
@@ -370,67 +317,128 @@ another_option = another_value
 
         os.unlink(f.name)
 
+
+class TestNetAppConfigGetAllBackends:
+    """Test cases for NetAppConfig.get_all_backends()."""
+
+    @pytest.fixture
+    def multi_backend_config_file(self):
+        """Create a config file with multiple backends."""
+        config_content = """[staging-svm1]
+netapp_server_hostname = netapp1.staging.example.com
+netapp_login = admin1
+netapp_password = pass1
+
+[staging-svm2]
+netapp_server_hostname = netapp2.staging.example.com
+netapp_login = admin2
+netapp_password = pass2
+netapp_nic_slot_prefix = e2
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+            yield f.name
+        os.unlink(f.name)
+
+    def test_get_all_backends_returns_all_sections(self, multi_backend_config_file):
+        """Test that get_all_backends returns one config per section."""
+        backends = NetAppConfig.get_all_backends(multi_backend_config_file)
+
+        assert len(backends) == 2
+        assert backends[0].section == "staging-svm1"
+        assert backends[0].hostname == "netapp1.staging.example.com"
+        assert backends[0].username == "admin1"
+        assert backends[0].password == "pass1"
+        assert backends[0].netapp_nic_slot_prefix == "e4"  # default
+
+        assert backends[1].section == "staging-svm2"
+        assert backends[1].hostname == "netapp2.staging.example.com"
+        assert backends[1].username == "admin2"
+        assert backends[1].password == "pass2"
+        assert backends[1].netapp_nic_slot_prefix == "e2"
+
+    def test_get_all_backends_file_not_found(self):
+        """Test ConfigurationError when file doesn't exist."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            NetAppConfig.get_all_backends("/nonexistent/path.conf")
+
+        assert "Configuration file not found" in exc_info.value.message
+
+    def test_get_all_backends_empty_file(self):
+        """Test ConfigurationError when file has no sections."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
+            f.write("# just a comment\n")
+            f.flush()
+
+            with pytest.raises(ConfigurationError) as exc_info:
+                NetAppConfig.get_all_backends(f.name)
+
+            assert "No sections found" in exc_info.value.message
+
+        os.unlink(f.name)
+
+    def test_get_all_backends_single_section(self):
+        """Test get_all_backends with a single section."""
+        config_content = """[prod-svm1]
+netapp_server_hostname = netapp.prod.example.com
+netapp_login = prod-admin
+netapp_password = prod-pass
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
+            f.write(config_content)
+            f.flush()
+
+            backends = NetAppConfig.get_all_backends(f.name)
+
+            assert len(backends) == 1
+            assert backends[0].section == "prod-svm1"
+            assert backends[0].hostname == "netapp.prod.example.com"
+
+        os.unlink(f.name)
+
     def test_integration_netapp_config_with_from_nautobot_response(
-        self, config_with_nic_prefix
+        self,
     ):
         """Test integration between NetAppConfig and NetappIPInterfaceConfig."""
         from unittest.mock import MagicMock
 
         from understack_workflows.netapp.value_objects import NetappIPInterfaceConfig
 
-        # Create config with custom NIC prefix
-        config = NetAppConfig(config_with_nic_prefix)
-        assert config.netapp_nic_slot_prefix == "e5"
+        config_content = """[backend1]
+netapp_server_hostname = test-hostname.example.com
+netapp_login = test-user
+netapp_password = test-password-123
+netapp_nic_slot_prefix = e5
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
+            f.write(config_content)
+            f.flush()
 
-        # Create a mock nautobot response
-        mock_interface_a = MagicMock()
-        mock_interface_a.name = "N1-lif-A"
-        mock_interface_a.address = "192.168.1.10/24"
-        mock_interface_a.vlan = 100
+            config = NetAppConfig(f.name, "backend1")
+            assert config.netapp_nic_slot_prefix == "e5"
 
-        mock_interface_b = MagicMock()
-        mock_interface_b.name = "N1-lif-B"
-        mock_interface_b.address = "192.168.1.11/24"
-        mock_interface_b.vlan = 100
+            mock_interface_a = MagicMock()
+            mock_interface_a.name = "N1-lif-A"
+            mock_interface_a.address = "192.168.1.10/24"
+            mock_interface_a.vlan = 100
 
-        mock_response = MagicMock()
-        mock_response.interfaces = [mock_interface_a, mock_interface_b]
+            mock_interface_b = MagicMock()
+            mock_interface_b.name = "N1-lif-B"
+            mock_interface_b.address = "192.168.1.11/24"
+            mock_interface_b.vlan = 100
 
-        # Test that from_nautobot_response uses the custom prefix
-        configs = NetappIPInterfaceConfig.from_nautobot_response(mock_response, config)
+            mock_response = MagicMock()
+            mock_response.interfaces = [mock_interface_a, mock_interface_b]
 
-        assert len(configs) == 2
-        assert configs[0].base_port_name == "e5a"
-        assert configs[1].base_port_name == "e5b"
-        assert configs[0].nic_slot_prefix == "e5"
-        assert configs[1].nic_slot_prefix == "e5"
+            configs = NetappIPInterfaceConfig.from_nautobot_response(
+                mock_response, config
+            )
 
-    def test_from_nautobot_response_default_prefix(self, valid_config_file):
-        """Test that from_nautobot_response uses default when no config provided."""
-        from unittest.mock import MagicMock
+            assert len(configs) == 2
+            assert configs[0].base_port_name == "e5a"
+            assert configs[1].base_port_name == "e5b"
+            assert configs[0].nic_slot_prefix == "e5"
+            assert configs[1].nic_slot_prefix == "e5"
 
-        from understack_workflows.netapp.value_objects import NetappIPInterfaceConfig
-
-        # Create a mock nautobot response
-        mock_interface = MagicMock()
-        mock_interface.name = "N1-lif-A"
-        mock_interface.address = "192.168.1.10/24"
-        mock_interface.vlan = 100
-
-        mock_response = MagicMock()
-        mock_response.interfaces = [mock_interface]
-
-        # Test without config (should use default)
-        configs = NetappIPInterfaceConfig.from_nautobot_response(mock_response)
-        assert len(configs) == 1
-        assert configs[0].base_port_name == "e4a"
-        assert configs[0].nic_slot_prefix == "e4"
-
-        # Test with config that has default prefix
-        config = NetAppConfig(valid_config_file)
-        configs_with_config = NetappIPInterfaceConfig.from_nautobot_response(
-            mock_response, config
-        )
-        assert len(configs_with_config) == 1
-        assert configs_with_config[0].base_port_name == "e4a"
-        assert configs_with_config[0].nic_slot_prefix == "e4"
+        os.unlink(f.name)

--- a/python/understack-workflows/tests/test_netapp_configure_net.py
+++ b/python/understack-workflows/tests/test_netapp_configure_net.py
@@ -1749,6 +1749,17 @@ class TestArgumentParserNetappConfigPath:
 class TestMainFunctionWithNetAppManager:
     """Test cases for main function with NetAppManager integration."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_get_all_backends(self):
+        """Auto-mock get_all_backends for all main function tests."""
+        mock_backend = Mock()
+        mock_backend.section = "backend1"
+        with patch(
+            "understack_workflows.main.netapp_configure_net.NetAppConfig.get_all_backends",
+            return_value=[mock_backend],
+        ):
+            yield
+
     @patch("understack_workflows.main.netapp_configure_net.NetAppManager")
     @patch("understack_workflows.main.netapp_configure_net.Nautobot")
     @patch("understack_workflows.main.netapp_configure_net.credential")
@@ -1805,10 +1816,8 @@ class TestMainFunctionWithNetAppManager:
         # Verify successful execution
         assert result == 0
 
-        # Verify NetAppManager was initialized with default path
-        mock_netapp_manager_class.assert_called_once_with(
-            "/etc/netapp/netapp_nvme.conf"
-        )
+        # Verify NetAppManager was initialized with a backend config
+        mock_netapp_manager_class.assert_called_once()
 
     @patch("understack_workflows.main.netapp_configure_net.NetAppManager")
     @patch("understack_workflows.main.netapp_configure_net.Nautobot")
@@ -1865,8 +1874,8 @@ class TestMainFunctionWithNetAppManager:
         # Verify successful execution
         assert result == 0
 
-        # Verify NetAppManager was initialized with custom path
-        mock_netapp_manager_class.assert_called_once_with(custom_path)
+        # Verify NetAppManager was initialized with a backend config
+        mock_netapp_manager_class.assert_called_once()
 
     @patch("understack_workflows.main.netapp_configure_net.NetAppManager")
     @patch("understack_workflows.main.netapp_configure_net.Nautobot")
@@ -1907,9 +1916,7 @@ class TestMainFunctionWithNetAppManager:
             main()
 
         # Verify NetAppManager initialization was attempted
-        mock_netapp_manager_class.assert_called_once_with(
-            "/etc/netapp/netapp_nvme.conf"
-        )
+        mock_netapp_manager_class.assert_called_once()
 
     @patch(
         "understack_workflows.main.netapp_configure_net.netapp_create_interfaces_and_routes"

--- a/python/understack-workflows/tests/test_netapp_configure_net_integration.py
+++ b/python/understack-workflows/tests/test_netapp_configure_net_integration.py
@@ -21,6 +21,17 @@ def load_json_sample(filename: str) -> dict:
 class TestIntegrationTests:
     """Integration tests for complete script execution with mock Nautobot."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_get_all_backends(self):
+        """Auto-mock get_all_backends for all integration tests."""
+        mock_backend = Mock()
+        mock_backend.section = "backend1"
+        with patch(
+            "understack_workflows.main.netapp_configure_net.NetAppConfig.get_all_backends",
+            return_value=[mock_backend],
+        ):
+            yield
+
     @patch("understack_workflows.main.netapp_configure_net.NetAppManager")
     @patch("understack_workflows.main.netapp_configure_net.Nautobot")
     @patch("understack_workflows.main.netapp_configure_net.credential")
@@ -522,6 +533,17 @@ class TestIntegrationWithNetAppManager:
     NetAppManager initialization and network configuration operations.
     """
 
+    @pytest.fixture(autouse=True)
+    def _mock_get_all_backends(self):
+        """Auto-mock get_all_backends for all integration tests."""
+        mock_backend = Mock()
+        mock_backend.section = "backend1"
+        with patch(
+            "understack_workflows.main.netapp_configure_net.NetAppConfig.get_all_backends",
+            return_value=[mock_backend],
+        ):
+            yield
+
     @patch("understack_workflows.main.netapp_configure_net.NetAppManager")
     @patch("understack_workflows.main.netapp_configure_net.Nautobot")
     @patch("understack_workflows.main.netapp_configure_net.credential")
@@ -575,9 +597,7 @@ class TestIntegrationWithNetAppManager:
         assert result == 0
 
         # Verify NetAppManager was initialized with default config path
-        mock_netapp_manager_class.assert_called_once_with(
-            "/etc/netapp/netapp_nvme.conf"
-        )
+        mock_netapp_manager_class.assert_called_once()
 
         # Verify Nautobot client was created and GraphQL query was executed
         mock_nautobot_class.assert_called_once()
@@ -657,7 +677,7 @@ class TestIntegrationWithNetAppManager:
         assert result == 0
 
         # Verify NetAppManager was initialized with custom config path
-        mock_netapp_manager_class.assert_called_once_with(custom_config_path)
+        mock_netapp_manager_class.assert_called_once()
 
         # Verify NetApp LIF creation was called (single sample has 2 interfaces)
         assert mock_netapp_manager_instance.create_lif.call_count == 2
@@ -725,9 +745,7 @@ class TestIntegrationWithNetAppManager:
             main()
 
         # Verify NetAppManager was initialized
-        mock_netapp_manager_class.assert_called_once_with(
-            "/etc/netapp/netapp_nvme.conf"
-        )
+        mock_netapp_manager_class.assert_called_once()
 
         # Verify GraphQL query was executed successfully before NetApp error
         mock_nautobot_instance.session.graphql.query.assert_called_once()
@@ -790,9 +808,7 @@ class TestIntegrationWithNetAppManager:
         assert result == 0
 
         # Verify NetAppManager was initialized
-        mock_netapp_manager_class.assert_called_once_with(
-            "/etc/netapp/netapp_nvme.conf"
-        )
+        mock_netapp_manager_class.assert_called_once()
 
         # Verify GraphQL query was executed
         mock_nautobot_instance.session.graphql.query.assert_called_once()
@@ -862,9 +878,7 @@ class TestIntegrationWithNetAppManager:
         assert result == 0
 
         # Verify NetAppManager was initialized
-        mock_netapp_manager_class.assert_called_once_with(
-            "/etc/netapp/netapp_nvme.conf"
-        )
+        mock_netapp_manager_class.assert_called_once()
 
         # Verify GraphQL query was executed with normalized project ID
         mock_nautobot_instance.session.graphql.query.assert_called_once_with(
@@ -907,6 +921,17 @@ class TestIntegrationWithNetAppManager:
 
 class TestRouteCreationIntegration:
     """Integration tests for route creation workflow."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_get_all_backends(self):
+        """Auto-mock get_all_backends for all route creation tests."""
+        mock_backend = Mock()
+        mock_backend.section = "backend1"
+        with patch(
+            "understack_workflows.main.netapp_configure_net.NetAppConfig.get_all_backends",
+            return_value=[mock_backend],
+        ):
+            yield
 
     @patch("understack_workflows.main.netapp_configure_net.NetAppManager")
     @patch("understack_workflows.main.netapp_configure_net.Nautobot")
@@ -978,9 +1003,7 @@ class TestRouteCreationIntegration:
         assert result == 0
 
         # Verify NetAppManager was initialized
-        mock_netapp_manager_class.assert_called_once_with(
-            "/etc/netapp/netapp_nvme.conf"
-        )
+        mock_netapp_manager_class.assert_called_once()
 
         # Verify GraphQL query was executed
         mock_nautobot_instance.session.graphql.query.assert_called_once()
@@ -1384,8 +1407,7 @@ class TestRouteCreationIntegration:
 
         # Mock NetAppManager with SVM not found error during route creation
         svm_error = SvmOperationError(
-            "Route creation failed: SVM 'os-12345678123456789abc123456789012'"
-            "not found",
+            "Route creation failed: SVM 'os-12345678123456789abc123456789012'not found",
             svm_name="os-12345678123456789abc123456789012",
             context={
                 "operation": "Route creation",

--- a/python/understack-workflows/tests/test_netapp_manager.py
+++ b/python/understack-workflows/tests/test_netapp_manager.py
@@ -20,7 +20,7 @@ class TestNetAppManagerOrchestration:
 
     @pytest.fixture
     def mock_config_file(self):
-        """Create a temporary config file for testing."""
+        """Create a temporary config file and return a NetAppConfig for testing."""
         config_content = """[netapp_nvme]
 netapp_server_hostname = test-hostname
 netapp_login = test-user
@@ -29,8 +29,13 @@ netapp_password = test-password
         with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
             f.write(config_content)
             f.flush()
-            yield f.name
-        os.unlink(f.name)
+            config_path = f.name
+
+        from understack_workflows.netapp.config import NetAppConfig
+
+        netapp_config = NetAppConfig(config_path, "netapp_nvme")
+        yield netapp_config
+        os.unlink(config_path)
 
     @patch("understack_workflows.netapp.manager.config")
     @patch("understack_workflows.netapp.manager.HostConnection")
@@ -38,7 +43,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test manager initialization sets up all required services."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Verify all services are initialized
         assert hasattr(manager, "_client")
@@ -58,7 +63,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test create_svm delegates to SvmService with correct parameters."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._svm_service.create_svm = MagicMock(return_value="os-test-project")
 
         result = manager.create_svm("test-project", "test-aggregate")
@@ -75,7 +80,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test create_volume delegates to VolumeService with correct parameters."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._volume_service.create_volume = MagicMock(
             return_value="vol_test-project"
         )
@@ -96,7 +101,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test get_aggregates delegates to NetAppClient."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         aggregates = [
             AggregateResult(name="aggr_b", state="online", used_percent=40),
             AggregateResult(name="aggr_a", state="online", used_percent=20),
@@ -114,7 +119,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test aggregate selection prefers the least-used online aggregate."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._client.get_aggregates = MagicMock(
             return_value=[
                 AggregateResult(name="aggr_b", state="online", used_percent=40),
@@ -133,7 +138,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test aggregate selection remains deterministic on equal utilization."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._client.get_aggregates = MagicMock(
             return_value=[
                 AggregateResult(name="aggr_b", state="online", used_percent=20),
@@ -151,7 +156,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test aggregate selection fails when the cluster reports none."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._client.get_aggregates = MagicMock(return_value=[])
 
         with pytest.raises(NetAppManagerError, match="No NetApp aggregates"):
@@ -163,7 +168,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test aggregate selection fails when usage data is unavailable."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._client.get_aggregates = MagicMock(
             return_value=[
                 AggregateResult(name="aggr_a", state="offline", used_percent=10),
@@ -180,7 +185,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test delete_svm with standard naming delegates to SvmService."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._svm_service.delete_svm = MagicMock(return_value=True)
 
         result = manager.delete_svm("os-test-project")
@@ -195,7 +200,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test delete_svm with non-standard naming falls back to client."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._client.delete_svm = MagicMock(return_value=True)
 
         result = manager.delete_svm("custom-svm-name")
@@ -210,7 +215,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test delete_volume with standard naming delegates to VolumeService."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._volume_service.delete_volume = MagicMock(return_value=True)
 
         result = manager.delete_volume("vol_test-project", force=True)
@@ -227,7 +232,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test check_if_svm_exists delegates to SvmService."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._svm_service.exists = MagicMock(return_value=True)
 
         result = manager.check_if_svm_exists("test-project")
@@ -241,7 +246,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test mapped_namespaces with standard naming delegates to VolumeService."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         expected_namespaces = ["namespace1", "namespace2"]
         manager._volume_service.get_mapped_namespaces = MagicMock(
             return_value=expected_namespaces
@@ -261,7 +266,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test create_lif delegates to LifService."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._lif_service.create_lif = MagicMock()
 
         config_obj = NetappIPInterfaceConfig(
@@ -283,7 +288,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test naming convention utility methods."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Test SVM naming (delegated to SvmService)
         assert manager._svm_service.get_svm_name("test-project") == "os-test-project"
@@ -297,7 +302,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test that errors from services are properly propagated."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Test SVM service error propagation
         from understack_workflows.netapp.exceptions import SvmOperationError
@@ -327,7 +332,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test cleanup_project orchestrates services correctly."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock service methods
         manager._volume_service.exists = MagicMock(return_value=True)
@@ -353,7 +358,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test cleanup_project stops SVM deletion when volume deletion fails."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock volume deletion failure
         manager._volume_service.exists = MagicMock(return_value=True)
@@ -377,7 +382,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test that all public method signatures are maintained."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock all service methods to avoid actual calls
         manager._svm_service.create_svm = MagicMock(return_value="test-svm")
@@ -483,7 +488,7 @@ class TestNetAppManagerRouteIntegration:
 
     @pytest.fixture
     def mock_config_file(self):
-        """Create a temporary config file for testing."""
+        """Create a temporary config file and return a NetAppConfig for testing."""
         config_content = """[netapp_nvme]
 netapp_server_hostname = test-hostname
 netapp_login = test-user
@@ -492,8 +497,13 @@ netapp_password = test-password
         with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
             f.write(config_content)
             f.flush()
-            yield f.name
-        os.unlink(f.name)
+            config_path = f.name
+
+        from understack_workflows.netapp.config import NetAppConfig
+
+        netapp_config = NetAppConfig(config_path, "netapp_nvme")
+        yield netapp_config
+        os.unlink(config_path)
 
     @pytest.fixture
     def sample_interface_configs(self):
@@ -525,7 +535,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test that RouteService is properly initialized in NetAppManager."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Verify route service is initialized
         assert hasattr(manager, "_route_service")
@@ -543,7 +553,7 @@ netapp_password = test-password
         """Test create_routes_for_project delegates to RouteService."""
         from understack_workflows.netapp.value_objects import RouteResult
 
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock route service
         expected_results = [
@@ -586,7 +596,7 @@ netapp_password = test-password
         """Test create_routes_for_project error handling and propagation."""
         from understack_workflows.netapp.exceptions import NetworkOperationError
 
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock route service to raise an error
         manager._route_service.create_routes_from_interfaces = MagicMock(
@@ -608,7 +618,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test create_routes_for_project with empty interface list."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock route service
         manager._route_service.create_routes_from_interfaces = MagicMock(
@@ -636,7 +646,7 @@ netapp_password = test-password
         mock_route_service = MagicMock(spec=RouteService)
 
         manager = NetAppManager(
-            config_path=mock_config_file,
+            netapp_config=mock_config_file,
             netapp_client=mock_client,
             route_service=mock_route_service,
         )

--- a/python/understack-workflows/tests/test_netapp_manager_integration.py
+++ b/python/understack-workflows/tests/test_netapp_manager_integration.py
@@ -18,7 +18,7 @@ class TestNetAppManagerIntegration:
 
     @pytest.fixture
     def mock_config_file(self):
-        """Create a temporary config file for testing."""
+        """Create a temporary config file and return a NetAppConfig for testing."""
         config_content = """[netapp_nvme]
 netapp_server_hostname = test-hostname
 netapp_login = test-user
@@ -27,8 +27,13 @@ netapp_password = test-password
         with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
             f.write(config_content)
             f.flush()
-            yield f.name
-        os.unlink(f.name)
+            config_path = f.name
+
+        from understack_workflows.netapp.config import NetAppConfig
+
+        netapp_config = NetAppConfig(config_path, "netapp_nvme")
+        yield netapp_config
+        os.unlink(config_path)
 
     # ========================================================================
     # Service Coordination Tests
@@ -40,7 +45,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test that all services are properly initialized and coordinated."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Verify all services are initialized with proper dependencies
         from understack_workflows.netapp.client import NetAppClient
@@ -66,7 +71,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test error propagation across service boundaries."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Test SVM service error propagation
         manager._svm_service.create_svm = MagicMock(
@@ -96,7 +101,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test successful coordination between services during cleanup."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         project_id = "test-project-123"
 
         # Mock all service methods for successful cleanup
@@ -123,7 +128,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test coordination when volume deletion fails."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         project_id = "test-project-123"
 
         # Mock volume deletion failure
@@ -148,7 +153,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test coordination when volume succeeds but SVM deletion fails."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         project_id = "test-project-123"
 
         # Mock volume success, SVM failure
@@ -173,7 +178,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test coordination when resources don't exist."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         project_id = "nonexistent-project"
 
         # Mock resources don't exist
@@ -198,7 +203,7 @@ netapp_password = test-password
     ):
         """Test cleanup coordination with mixed resource existence scenarios."""
         # Scenario 1: Only volume exists
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         manager._volume_service.exists = MagicMock(return_value=True)
         manager._svm_service.exists = MagicMock(return_value=False)
         manager._volume_service.delete_volume = MagicMock(return_value=True)
@@ -213,7 +218,7 @@ netapp_password = test-password
         assert result == {"volume": True, "svm": True}
 
         # Scenario 2: Only SVM exists (create new manager instance)
-        manager2 = NetAppManager(mock_config_file)
+        manager2 = NetAppManager(netapp_config=mock_config_file)
         manager2._volume_service.exists = MagicMock(return_value=False)
         manager2._svm_service.exists = MagicMock(return_value=True)
         manager2._volume_service.delete_volume = MagicMock()
@@ -232,7 +237,7 @@ netapp_password = test-password
     ):
         """Test exception handling during cleanup coordination."""
         # Test volume service exception
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         project_id = "test-project-123"
 
         manager._volume_service.exists = MagicMock(return_value=True)
@@ -250,7 +255,7 @@ netapp_password = test-password
 
         # Test SVM service exception after successful volume deletion (new
         # manager instance)
-        manager2 = NetAppManager(mock_config_file)
+        manager2 = NetAppManager(netapp_config=mock_config_file)
         manager2._volume_service.exists = MagicMock(return_value=True)
         manager2._volume_service.delete_volume = MagicMock(return_value=True)
         manager2._svm_service.exists = MagicMock(return_value=True)
@@ -273,7 +278,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test cleanup coordination when existence checks fail."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         project_id = "test-project-123"
 
         # Mock existence check failures
@@ -305,7 +310,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test complete project lifecycle across all services."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
         project_id = "lifecycle-test-project"
 
         # Mock successful creation workflow
@@ -352,7 +357,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test that service state remains consistent across multiple operations."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Verify all services share the same dependencies
         client_id = id(manager._client)
@@ -367,7 +372,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test that logging is properly coordinated across services."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock service methods
         manager._volume_service.exists = MagicMock(return_value=True)
@@ -400,7 +405,7 @@ netapp_password = test-password
         self, mock_host_connection, mock_config, mock_config_file
     ):
         """Test that refactored manager maintains backward compatibility."""
-        manager = NetAppManager(mock_config_file)
+        manager = NetAppManager(netapp_config=mock_config_file)
 
         # Mock all service methods to avoid actual calls
         manager._svm_service.create_svm = MagicMock(return_value="test-svm")

--- a/python/understack-workflows/understack_workflows/main/netapp_configure_net.py
+++ b/python/understack-workflows/understack_workflows/main/netapp_configure_net.py
@@ -7,6 +7,7 @@ from understack_workflows.helpers import credential
 from understack_workflows.helpers import parser_nautobot_args
 from understack_workflows.helpers import setup_logger
 from understack_workflows.nautobot import Nautobot
+from understack_workflows.netapp.config import NetAppConfig
 from understack_workflows.netapp.manager import NetAppManager
 from understack_workflows.netapp.value_objects import NetappIPInterfaceConfig
 from understack_workflows.netapp.value_objects import VirtualMachineNetworkInfo
@@ -375,7 +376,24 @@ def main():
         # Establish Nautobot connection using parsed arguments
         logger.info("Connecting to Nautobot at: %s", args.nautobot_url)
         nautobot_client = Nautobot(args.nautobot_url, nb_token, logger=logger)
-        netapp_manager = NetAppManager(args.netapp_config_path)
+
+        # Find the backend where this project's SVM lives
+        backends = NetAppConfig.get_all_backends(args.netapp_config_path)
+        netapp_manager = None
+        for backend_config in backends:
+            mgr = NetAppManager(netapp_config=backend_config)
+            if mgr.check_if_svm_exists(project_id=args.project_id):
+                netapp_manager = mgr
+                logger.info(
+                    "Found SVM for project %s on backend '%s'",
+                    args.project_id,
+                    backend_config.section,
+                )
+                break
+
+        if netapp_manager is None:
+            logger.error("SVM for project %s not found on any backend", args.project_id)
+            return 1
 
         # Call do_action() with appropriate parameters
         raw_response, structured_data = do_action(

--- a/python/understack-workflows/understack_workflows/netapp/client.py
+++ b/python/understack-workflows/understack_workflows/netapp/client.py
@@ -222,9 +222,16 @@ class NetAppClient(NetAppClientInterface):
     def _setup_connection(self) -> None:
         """Set up the NetApp SDK connection."""
         try:
-            # Only create connection if one doesn't already exist
-            # This supports cases where NetAppManager sets up the connection first
-            if not hasattr(config, "CONNECTION") or config.CONNECTION is None:
+            # Create a new connection if none exists, or if targeting a different host
+            needs_connection = (
+                not hasattr(config, "CONNECTION")
+                or config.CONNECTION is None
+                or (
+                    hasattr(config.CONNECTION, "_host")
+                    and config.CONNECTION._host != self._config.hostname
+                )
+            )
+            if needs_connection:
                 config.CONNECTION = HostConnection(
                     self._config.hostname,
                     username=self._config.username,

--- a/python/understack-workflows/understack_workflows/netapp/config.py
+++ b/python/understack-workflows/understack_workflows/netapp/config.py
@@ -7,18 +7,24 @@ from understack_workflows.netapp.exceptions import ConfigurationError
 
 
 class NetAppConfig:
-    """Handles NetApp configuration parsing and validation."""
+    """Handles NetApp configuration parsing and validation.
 
-    def __init__(self, config_path: str = "/etc/netapp/netapp_nvme.conf"):
-        """Initialize NetApp configuration.
+    Each section in the INI file represents a backend with its own
+    credentials and optional settings.
+    """
+
+    def __init__(self, config_path: str, section: str):
+        """Initialize NetApp configuration for a specific backend section.
 
         Args:
             config_path: Path to the NetApp configuration file
+            section: INI section name identifying the backend
 
         Raises:
             ConfigurationError: If configuration file is missing or invalid
         """
         self._config_path = config_path
+        self._section = section
         self._config_data = self._parse_config()
         self.validate()
 
@@ -48,19 +54,29 @@ class NetAppConfig:
                 context={"parsing_error": str(e)},
             ) from e
 
+        if self._section not in parser.sections():
+            raise ConfigurationError(
+                f"Section '{self._section}' not found in {self._config_path}",
+                config_path=self._config_path,
+                context={
+                    "requested_section": self._section,
+                    "available_sections": parser.sections(),
+                },
+            )
+
         try:
             config_data = {
-                "hostname": parser.get("netapp_nvme", "netapp_server_hostname"),
-                "username": parser.get("netapp_nvme", "netapp_login"),
-                "password": parser.get("netapp_nvme", "netapp_password"),
+                "hostname": parser.get(self._section, "netapp_server_hostname"),
+                "username": parser.get(self._section, "netapp_login"),
+                "password": parser.get(self._section, "netapp_password"),
             }
 
             # Optional netapp_nic_slot_prefix with default value
             try:
                 config_data["netapp_nic_slot_prefix"] = parser.get(
-                    "netapp_nvme", "netapp_nic_slot_prefix"
+                    self._section, "netapp_nic_slot_prefix"
                 )
-            except (configparser.NoSectionError, configparser.NoOptionError):
+            except configparser.NoOptionError:
                 config_data["netapp_nic_slot_prefix"] = "e4"
 
             return config_data
@@ -68,7 +84,7 @@ class NetAppConfig:
             raise ConfigurationError(
                 f"Missing required configuration in {self._config_path}: {e}",
                 config_path=self._config_path,
-                context={"missing_config": str(e)},
+                context={"missing_config": str(e), "section": self._section},
             ) from e
 
     def validate(self) -> None:
@@ -127,3 +143,50 @@ class NetAppConfig:
     def config_path(self) -> str:
         """Get the configuration file path."""
         return self._config_path
+
+    @property
+    def section(self) -> str:
+        """Get the backend section name this config was loaded from."""
+        return self._section
+
+    @staticmethod
+    def get_all_backends(
+        config_path: str = "/etc/netapp/netapp_nvme.conf",
+    ) -> list["NetAppConfig"]:
+        """Load all backend configurations from the config file.
+
+        Each section in the INI file is treated as a separate backend.
+
+        Args:
+            config_path: Path to the NetApp configuration file
+
+        Returns:
+            List of NetAppConfig instances, one per section
+
+        Raises:
+            ConfigurationError: If the file is missing or has no valid sections
+        """
+        if not os.path.exists(config_path):
+            raise ConfigurationError(
+                f"Configuration file not found at {config_path}",
+                config_path=config_path,
+            )
+
+        parser = configparser.ConfigParser()
+        try:
+            parser.read(config_path)
+        except configparser.Error as e:
+            raise ConfigurationError(
+                f"Failed to parse configuration file: {e}",
+                config_path=config_path,
+                context={"parsing_error": str(e)},
+            ) from e
+
+        sections = parser.sections()
+        if not sections:
+            raise ConfigurationError(
+                f"No sections found in configuration file {config_path}",
+                config_path=config_path,
+            )
+
+        return [NetAppConfig(config_path=config_path, section=s) for s in sections]

--- a/python/understack-workflows/understack_workflows/netapp/manager.py
+++ b/python/understack-workflows/understack_workflows/netapp/manager.py
@@ -6,7 +6,6 @@ from netapp_ontap.host_connection import HostConnection
 from netapp_ontap.resources.nvme_namespace import NvmeNamespace
 
 from understack_workflows.netapp.client import NetAppClient
-from understack_workflows.netapp.config import NetAppConfig
 from understack_workflows.netapp.exceptions import NetAppManagerError
 from understack_workflows.netapp.lif_service import LifService
 from understack_workflows.netapp.route_service import RouteService
@@ -31,7 +30,6 @@ class NetAppManager:
 
     def __init__(
         self,
-        config_path="/etc/netapp/netapp_nvme.conf",
         netapp_config=None,
         netapp_client=None,
         svm_service=None,
@@ -42,8 +40,8 @@ class NetAppManager:
         """Initialize NetAppManager with dependency injection support.
 
         Args:
-            config_path: Path to NetApp configuration file
-            netapp_config: NetAppConfig instance (optional, for dependency injection)
+            netapp_config: NetAppConfig instance (required unless netapp_client
+                           is provided)
             netapp_client: NetAppClient instance (optional, for dependency injection)
             svm_service: SvmService instance (optional, for dependency injection)
             volume_service: VolumeService instance (optional, for dependency injection)
@@ -52,7 +50,6 @@ class NetAppManager:
         """
         # Set up dependencies with dependency injection or create defaults
         self._setup_dependencies(
-            config_path,
             netapp_config,
             netapp_client,
             svm_service,
@@ -63,7 +60,6 @@ class NetAppManager:
 
     def _setup_dependencies(
         self,
-        config_path,
         netapp_config,
         netapp_client,
         svm_service,
@@ -75,17 +71,15 @@ class NetAppManager:
         # Initialize configuration
         if netapp_config is not None:
             self._config = netapp_config
+        elif netapp_client is not None:
+            # Client provided via dependency injection - config not needed
+            self._config = None
         else:
-            # Create config from file if client is not provided (client needs config)
-            # Only skip config creation if client is provided via dependency injection
-            if netapp_client is None:
-                # Need to create config since we'll need to create a client
-                self._config = NetAppConfig(config_path)
-            else:
-                # Client provided via dependency injection - config not needed
-                self._config = None
+            raise ValueError(
+                "netapp_config is required when netapp_client is not provided"
+            )
 
-        # Set up connection if using traditional constructor pattern
+        # Set up connection if config is provided and services are not injected
         if (
             self._config is not None
             and netapp_client is None
@@ -94,7 +88,6 @@ class NetAppManager:
             and lif_service is None
             and route_service is None
         ):
-            # Traditional constructor usage - set up connection directly
             # Check if connection needs to be established (handle both real and
             # mocked config)
             needs_connection = (
@@ -105,6 +98,12 @@ class NetAppManager:
                 (
                     hasattr(config.CONNECTION, "_mock_name")
                     and config.CONNECTION._mock_name  # pyright: ignore
+                )
+                or
+                # Force new connection when targeting a different host
+                (
+                    hasattr(config.CONNECTION, "_host")
+                    and config.CONNECTION._host != self._config.hostname  # pyright: ignore[reportAttributeAccessIssue]
                 )
             )
             if needs_connection:
@@ -118,8 +117,7 @@ class NetAppManager:
         if netapp_client is not None:
             self._client = netapp_client
         else:
-            # Create client with config - config should always exist for
-            # traditional usage
+            # Create client with config
             if self._config is None:
                 raise ValueError(
                     "NetAppConfig is required when NetAppClient is not provided"

--- a/python/understack-workflows/understack_workflows/oslo_event/cinder_volume_type.py
+++ b/python/understack-workflows/understack_workflows/oslo_event/cinder_volume_type.py
@@ -5,6 +5,7 @@ from openstack.connection import Connection
 from pynautobot.core.api import Api as Nautobot
 
 from understack_workflows.helpers import save_output
+from understack_workflows.netapp.config import NetAppConfig
 from understack_workflows.netapp.manager import NetAppManager
 from understack_workflows.oslo_event.constants import VOLUME_SIZE
 
@@ -52,11 +53,18 @@ def handle_volume_type_access_added(
     extra_specs = getattr(vol_type, "extra_specs", {}) or {}
     volume_size = extra_specs.get("netapp:flexvol_size", VOLUME_SIZE)
 
-    netapp_manager = NetAppManager()
+    backends = NetAppConfig.get_all_backends()
+    netapp_manager = None
+    for backend_config in backends:
+        mgr = NetAppManager(netapp_config=backend_config)
+        if mgr.check_if_svm_exists(project_id=event.project_id):
+            netapp_manager = mgr
+            break
 
-    if not netapp_manager.check_if_svm_exists(project_id=event.project_id):
+    if netapp_manager is None:
         logger.warning(
-            "SVM for project %s does not exist, skipping FlexVol creation",
+            "SVM for project %s does not exist on any backend, "
+            "skipping FlexVol creation",
             event.project_id,
         )
         save_output("volume_created", str(False))
@@ -92,9 +100,14 @@ def handle_volume_type_access_removed(
     )
 
     try:
-        netapp_manager = NetAppManager()
-        volume_name = netapp_manager.get_volume_name(event.volume_type_id)
-        deleted = netapp_manager.delete_volume(volume_name, force=False)
+        backends = NetAppConfig.get_all_backends()
+        deleted = False
+        for backend_config in backends:
+            netapp_manager = NetAppManager(netapp_config=backend_config)
+            if netapp_manager.check_if_svm_exists(project_id=event.project_id):
+                volume_name = netapp_manager.get_volume_name(event.volume_type_id)
+                deleted = netapp_manager.delete_volume(volume_name, force=False)
+                break
         save_output("volume_deleted", str(deleted))
     except Exception as e:
         logger.error(

--- a/python/understack-workflows/understack_workflows/oslo_event/keystone_project.py
+++ b/python/understack-workflows/understack_workflows/oslo_event/keystone_project.py
@@ -6,6 +6,7 @@ from openstack.connection import Connection
 from pynautobot.core.api import Api as Nautobot
 
 from understack_workflows.helpers import save_output
+from understack_workflows.netapp.config import NetAppConfig
 from understack_workflows.netapp.manager import NetAppManager
 
 logger = logging.getLogger(__name__)
@@ -71,10 +72,14 @@ def handle_project_created(
     svm_name = None
     svm_state = "unknown"
     try:
-        netapp_manager = NetAppManager()
-        svm_name = _create_svm(netapp_manager, event)
-        save_output("svm_created", str(True))
-        svm_state = "created"
+        backends = NetAppConfig.get_all_backends()
+        for backend_config in backends:
+            netapp_manager = NetAppManager(netapp_config=backend_config)
+            svm_name = _create_svm(netapp_manager, event)
+            if svm_name:
+                save_output("svm_created", str(True))
+                svm_state = "created"
+                break
     finally:
         if not svm_name:
             svm_name = "not_returned"
@@ -98,25 +103,35 @@ def handle_project_updated(
     svm_name = None
     svm_state = "unknown"
     try:
-        netapp_manager = NetAppManager()
-        svm_exists = netapp_manager.check_if_svm_exists(project_id=event.project_id)
+        backends = NetAppConfig.get_all_backends()
+
+        # Find which backend has the SVM (if any)
+        existing_manager = None
+        for backend_config in backends:
+            netapp_manager = NetAppManager(netapp_config=backend_config)
+            if netapp_manager.check_if_svm_exists(project_id=event.project_id):
+                existing_manager = netapp_manager
+                break
 
         # Tag removed
-        if not project_is_svm_enabled and svm_exists:
+        if not project_is_svm_enabled and existing_manager:
             logger.warning(
                 "SVM os-%s exists on NetApp but project %s is no longer tagged with %s",
                 event.project_id,
                 event.project_id,
                 SVM_PROJECT_TAG,
             )
-            netapp_manager.cleanup_project(event.project_id)
+            existing_manager.cleanup_project(event.project_id)
             svm_state = "removed"
         # Tag added
         elif project_is_svm_enabled:
-            if svm_exists:
+            if existing_manager:
                 save_output("svm_created", str(False))
                 svm_state = "present"
             else:
+                # Create on first backend
+                first_backend = backends[0]
+                netapp_manager = NetAppManager(netapp_config=first_backend)
                 svm_name = _create_svm(netapp_manager, event)
                 save_output("svm_created", str(True))
                 svm_state = "created"
@@ -138,15 +153,34 @@ def handle_project_deleted(
     event = KeystoneProjectEvent.from_event_dict(event_data)
     logger.info("Starting ONTAP SVM and Volume delete workflow.")
     try:
-        netapp_manager = NetAppManager()
-        svm_exists = netapp_manager.check_if_svm_exists(project_id=event.project_id)
+        backends = NetAppConfig.get_all_backends()
+        logger.info("Loaded %d backend(s) from config.", len(backends))
 
-        if svm_exists:
-            logger.info("SVM for project %s exists - cleaning it up.", event.project_id)
-            netapp_manager.cleanup_project(event.project_id)
-            save_output("svm_state", "removed")
-        else:
-            logger.info("SVM for project %s did not exist.", event.project_id)
+        svm_found = False
+        for backend_config in backends:
+            logger.info(
+                "Checking backend '%s' for project %s SVM.",
+                backend_config.section,
+                event.project_id,
+            )
+            netapp_manager = NetAppManager(netapp_config=backend_config)
+            svm_exists = netapp_manager.check_if_svm_exists(project_id=event.project_id)
+
+            if svm_exists:
+                svm_found = True
+                logger.info(
+                    "SVM for project %s found on backend '%s' - cleaning it up.",
+                    event.project_id,
+                    backend_config.section,
+                )
+                netapp_manager.cleanup_project(event.project_id)
+                save_output("svm_state", "removed")
+                break
+
+        if not svm_found:
+            logger.info(
+                "SVM for project %s did not exist on any backend.", event.project_id
+            )
             save_output("svm_state", "nonexistent")
     except Exception as e:
         logger.error(e)


### PR DESCRIPTION
Deleting projects kicks off a workflow which ultimately fails because it's using the old legacy netapp driver config and was looking for a `[netapp_nvme]` config which no longer exists. This updates it so the workflows use the new dynamic netapp driver configs which can have multiple config sections.

``` text
keystone-project-mbv9v-main-3445415451: 2026-08-07 19:04:38 +0000 - understack_workflows.main.openstack_oslo_event - DEBUG - Initializing Nautobot client with URL: https://nautobot.undercloud
keystone-project-mbv9v-main-3445415451: 2026-08-07 19:04:38 +0000 - understack_workflows.main.openstack_oslo_event - DEBUG - Nautobot client initialized successfully
keystone-project-mbv9v-main-3445415451: 2026-08-07 19:04:38 +0000 - understack_workflows.main.openstack_oslo_event - INFO - [identity.project.deleted] Running handler 1/1: understack_workflows.oslo_event.keystone_project.handle_project_deleted
keystone-project-mbv9v-main-3445415451: 2026-08-07 19:04:38 +0000 - understack_workflows.oslo_event.keystone_project - INFO - Starting ONTAP SVM and Volume delete workflow.
keystone-project-mbv9v-main-3445415451: 2026-08-07 19:04:38 +0000 - understack_workflows.oslo_event.keystone_project - ERROR - Missing required configuration in /etc/netapp/netapp_nvme.conf: No section: 'netapp_nvme' | context={'missing_config': "No section: 'netapp_nvme'"}
```