### PR TITLE
fix(workflows): quote string literals in argo when expressions

### DIFF
--- a/charts/site-workflows/templates/sensor-ironic-oslo-event.yaml
+++ b/charts/site-workflows/templates/sensor-ironic-oslo-event.yaml
@@ -94,7 +94,7 @@ spec:
                         - name: event-json
                           value: {{ printf "{{workflow.parameters.event-json}}" | quote }}
                     - name: convert-project-id
-                      when: {{ printf "\"{{workflow.parameters.previous_provision_state}}\" == deploying" | quote }}
+                      when: {{ printf "\"{{workflow.parameters.previous_provision_state}}\" == 'deploying'" | quote }}
                       inline:
                         script:
                           image: python:alpine
@@ -104,7 +104,7 @@ spec:
                               project_id_without_dashes = {{ printf "{{workflow.parameters.project_id}}" | quote }}
                               print(str(uuid.UUID(project_id_without_dashes)))
                   - - name: ansible-storage-update
-                      when: {{ printf "(\"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted || \"{{steps.oslo-events.outputs.parameters.storage}}\" == wanted-but-not-project) && \"{{workflow.parameters.previous_provision_state}}\" == deploying" | quote }}
+                      when: {{ printf "(\"{{steps.oslo-events.outputs.parameters.storage}}\" == 'wanted' || \"{{steps.oslo-events.outputs.parameters.storage}}\" == 'wanted-but-not-project') && \"{{workflow.parameters.previous_provision_state}}\" == 'deploying'" | quote }}
                       templateRef:
                         name: ansible-workflow-template
                         template: ansible-run


### PR DESCRIPTION
Argo Workflows uses the `expr` expression engine to evaluate `when` conditions. Bare (unquoted) string values containing hyphens like `wanted-but-not-project` are parsed as arithmetic subtraction (`wanted - but - not - project`), which fails because these identifiers aren't numbers. The fix wraps comparison values in single quotes so they're treated as string literals.

