### PR TITLE
feat(images): Ubuntu image build updates and fixes, and adds ubuntu 26.04 builder

### DIFF
--- a/.github/workflows/build-ironic-images.yaml
+++ b/.github/workflows/build-ironic-images.yaml
@@ -112,7 +112,7 @@ jobs:
           mkdir -p upload
           find . -maxdepth 1 -type f \( -name '*.qcow2' -o -name '*.kernel' -o -name '*.initramfs' \) -exec cp {} upload/ \;
         env:
-          ELEMENTS_PATH: "${{ env.distro == 'ipa-debian' && format('{0}/share/ironic-python-agent-builder/dib:{1}/ironic-images/custom_elements', env.pythonLocation, github.workspace) || ''}}"
+          ELEMENTS_PATH: "${{ env.distro == 'ipa-debian' && format('{0}/share/ironic-python-agent-builder/dib:{1}/ironic-images/custom_elements', env.pythonLocation, github.workspace) || format('{0}/ironic-images/custom_elements', github.workspace) }}"
 
       - name: Set timestamp environment variable
         run: echo "TIMESTAMP=$(git show --no-patch --no-notes --pretty='%cd' --date=format:'%Y%m%d%H%M%S' ${{ github.sha }})" >>  $GITHUB_ENV

--- a/ironic-images/custom_elements/undercloud-dracut-drivers/post-install.d/90-dracut-drivers
+++ b/ironic-images/custom_elements/undercloud-dracut-drivers/post-install.d/90-dracut-drivers
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# Ubuntu 26.04 uses dracut instead of initramfs-tools. When the image is built
+# on a GitHub Actions runner (no RAID controller present), dracut in hostonly
+# mode won't include storage drivers needed for bare metal servers.
+#
+# This script:
+# 1. Drops a dracut config for generic (non-hostonly) initramfs with all
+#    necessary drivers and systemd modules
+# 2. Adds "rw" to the kernel command line so root is mounted read-write
+#    (dracut+systemd does not automatically remount rw from fstab like
+#    initramfs-tools does)
+# 3. Regenerates the initramfs after all packages are installed
+
+mkdir -p /etc/dracut.conf.d
+
+cat > /etc/dracut.conf.d/99-undercloud-baremetal.conf << 'EOF'
+# Build a generic initramfs that includes all drivers, not just those
+# for the build host. Required for bare metal deployment where the target
+# hardware differs from the image build environment.
+hostonly=no
+hostonly_cmdline=no
+
+# Process /etc/fstab for mount options
+use_fstab="yes"
+
+# Explicitly include storage controller drivers common in our fleet
+add_drivers+=" megaraid_sas mpt3sas mptsas ahci nvme sd_mod sr_mod "
+
+# Include filesystem modules
+add_drivers+=" ext4 xfs vfat "
+
+# Ensure systemd modules are present for proper root mount and remount
+add_dracutmodules+=" systemd systemd-initrd rootfs-block "
+EOF
+
+echo "Installed /etc/dracut.conf.d/99-undercloud-baremetal.conf"
+
+# Add "rw" to the kernel command line. With dracut+systemd, the root
+# filesystem must be explicitly mounted rw via the cmdline. Unlike
+# initramfs-tools, dracut does not rely on /etc/fstab for the initial
+# root mount mode.
+#
+# We use GRUB_CMDLINE_LINUX (not _DEFAULT) because the bootloader
+# element's finalise.d/50-bootloader appends its own GRUB_CMDLINE_LINUX_DEFAULT
+# line after this script runs. GRUB_CMDLINE_LINUX is applied to all
+# boot entries and isn't overwritten by the bootloader element.
+if [ -f /etc/default/grub ]; then
+    if ! grep -q 'GRUB_CMDLINE_LINUX=.*\brw\b' /etc/default/grub; then
+        echo 'GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} rw"' >> /etc/default/grub
+        echo "Added 'rw' to GRUB_CMDLINE_LINUX"
+    fi
+fi
+
+# Regenerate all initramfs images with the new configuration.
+# This runs in post-install.d so all kernel packages are already installed.
+dracut --regenerate-all --force
+echo "Regenerated initramfs for all installed kernels"

--- a/ironic-images/custom_elements/undercloud-efi-boot-fix/finalise.d/99-efi-boot-fix
+++ b/ironic-images/custom_elements/undercloud-efi-boot-fix/finalise.d/99-efi-boot-fix
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# During the DIB finalise phase, /boot/efi is mounted but the distro-specific
+# EFI directory (EFI/ubuntu) does not exist because the shim-signed package
+# installs its files to /usr/lib/shim/ rather than directly to the ESP.
+#
+# The bootloader element's 50-bootloader script runs grub-install --removable
+# which places a plain grubx64.efi as EFI/BOOT/BOOTX64.EFI. However, the
+# shim-signed package also installs a BOOTX64.CSV that references shimx64.efi,
+# which IPA then uses to create UEFI NVRAM boot entries pointing to a
+# non-existent \EFI\BOOT\shimx64.efi — causing boot failure.
+#
+# Fix: Install the signed shim and grub binaries into the proper locations
+# on the ESP so the full secure boot chain works.
+
+ESP_BOOT_DIR="/boot/efi/EFI/BOOT"
+ESP_UBUNTU_DIR="/boot/efi/EFI/ubuntu"
+
+# Signed shim location from shim-signed package
+SHIM_SIGNED="/usr/lib/shim/shimx64.efi.signed"
+# Signed grub location from grub-efi-amd64-signed package
+GRUB_SIGNED="/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed"
+
+if [ ! -f "${SHIM_SIGNED}" ]; then
+    echo "WARNING: ${SHIM_SIGNED} not found, skipping EFI boot fix"
+    exit 0
+fi
+
+# Create the distro-specific EFI directory
+mkdir -p "${ESP_UBUNTU_DIR}"
+
+# Install shimx64.efi to EFI/BOOT/ (what BOOTX64.CSV advertises)
+cp "${SHIM_SIGNED}" "${ESP_BOOT_DIR}/shimx64.efi"
+echo "Copied shimx64.efi to ${ESP_BOOT_DIR}/"
+
+# Install signed grub as grubx64.efi in EFI/BOOT/ (shim chains to this name)
+if [ -f "${GRUB_SIGNED}" ]; then
+    cp "${GRUB_SIGNED}" "${ESP_BOOT_DIR}/grubx64.efi"
+    echo "Copied grubx64.efi to ${ESP_BOOT_DIR}/"
+fi
+
+# Install shimx64.efi to EFI/ubuntu/ (standard Ubuntu location)
+cp "${SHIM_SIGNED}" "${ESP_UBUNTU_DIR}/shimx64.efi"
+echo "Copied shimx64.efi to ${ESP_UBUNTU_DIR}/"
+
+# Install signed grub to EFI/ubuntu/
+if [ -f "${GRUB_SIGNED}" ]; then
+    cp "${GRUB_SIGNED}" "${ESP_UBUNTU_DIR}/grubx64.efi"
+    echo "Copied grubx64.efi to ${ESP_UBUNTU_DIR}/"
+fi
+
+# Copy grub.cfg to EFI/ubuntu/ so shim->grub chain can find it
+if [ -f /boot/grub/grub.cfg ]; then
+    cp /boot/grub/grub.cfg "${ESP_UBUNTU_DIR}/grub.cfg"
+    echo "Copied grub.cfg to ${ESP_UBUNTU_DIR}/"
+elif [ -f /boot/efi/EFI/BOOT/grub.cfg ]; then
+    cp /boot/efi/EFI/BOOT/grub.cfg "${ESP_UBUNTU_DIR}/grub.cfg"
+    echo "Copied grub.cfg from EFI/BOOT/ to ${ESP_UBUNTU_DIR}/"
+fi
+
+# Ensure grub.cfg exists in EFI/BOOT/ for the shim->grub chain.
+# The signed grub looks for grub.cfg relative to its own prefix. If booting
+# via shimx64.efi -> grubx64.efi in EFI/BOOT/, grub needs a config here.
+if [ ! -f "${ESP_BOOT_DIR}/grub.cfg" ]; then
+    if [ -f /boot/grub/grub.cfg ]; then
+        cp /boot/grub/grub.cfg "${ESP_BOOT_DIR}/grub.cfg"
+        echo "Copied grub.cfg to ${ESP_BOOT_DIR}/"
+    fi
+fi

--- a/ironic-images/requirements.txt
+++ b/ironic-images/requirements.txt
@@ -1,2 +1,2 @@
-diskimage-builder==3.41.0
-ironic-python-agent-builder==7.2.0
+diskimage-builder==3.42.0
+ironic-python-agent-builder==7.3.0

--- a/ironic-images/ubuntu-24.yaml
+++ b/ironic-images/ubuntu-24.yaml
@@ -1,0 +1,12 @@
+- imagename: ubuntu-noble
+  environment:
+    DISTRO_NAME: 'ubuntu'
+    DIB_RELEASE: 'noble'
+  elements:
+  - ubuntu
+  - grub2
+  - block-device-efi
+  - baremetal
+  - bootloader
+  - package-installs
+  - undercloud-efi-boot-fix

--- a/ironic-images/ubuntu-26.yaml
+++ b/ironic-images/ubuntu-26.yaml
@@ -1,7 +1,7 @@
-- imagename: ubuntu-noble
+- imagename: ubuntu-resolute
   environment:
     DISTRO_NAME: 'ubuntu'
-    DIB_RELEASE: 'noble'
+    DIB_RELEASE: 'resolute'
   elements:
   - ubuntu
   - grub2
@@ -9,3 +9,5 @@
   - baremetal
   - bootloader
   - package-installs
+  - undercloud-efi-boot-fix
+  - undercloud-dracut-drivers


### PR DESCRIPTION
* Updates the disk image builder packages to latest versions
* Adds missing shim for Ubuntu 24.04 so that it now builds and works correctly. The missing shim was causing it to fail to boot after IPA deployed the image to the node.
* Adds image builder config to build Ubuntu 26.04
