### PR TITLE
chore(renovate): use managerFilePatterns in understackContainerMatch

### DIFF
--- a/.github/renovate/understackContainerMatch.json
+++ b/.github/renovate/understackContainerMatch.json
@@ -3,7 +3,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)images-openstack\\.ya?ml$"],
+      "managerFilePatterns": ["/(^|/)images-openstack\\.ya?ml$/"],
       "matchStrings": [
         ":\\s+\"?(?<depName>[^\\s:@\"]+):(?<currentValue>[-a-zA-Z_0-9.]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\"?"
       ],


### PR DESCRIPTION
## Why

`fileMatch` is the legacy key for custom managers. Every other Renovate config in this repo and in `RSS-Engineering/undercloud-deploy` already uses `managerFilePatterns`, and both repos set `configMigration: true` — this preset was the last holdout.

To be straight about the urgency: Renovate 44.24.3 emits **no** deprecation warning for `fileMatch` and it still works, so this is forward-looking consistency rather than a latent break.

## Verification

Behaviour is unchanged. Running each variant of the custom manager in isolation against a real `images-openstack.yaml` via `renovate --platform=local --dry-run=full`:

| key | result |
|---|---|
| `managerFilePatterns: ["/(^\|/)images-openstack\\.ya?ml$/"]` | `{"regex": {"fileCount": 1, "depCount": 74}}` |
| `fileMatch: ["(^\|/)images-openstack\\.ya?ml$"]` | `{"regex": {"fileCount": 1, "depCount": 74}}` |

Note the regex form needs the `/.../` delimiters under the new key, since bare strings are treated as globs.

`renovate-config-validator` passes on the edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)