### PR TITLE
chore(pre-commit): validate the shared renovate presets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,10 @@ repos:
     rev: 40.8.1
     hooks:
       - id: renovate-config-validator
+        # the hook's default pattern only matches renovate.json/.renovaterc, so
+        # extend it to the shared presets under .github/renovate/ that this repo
+        # and undercloud-deploy extend
+        files: '(^|/)\.?renovate(?:rc)?(?:\.json5?)?$|^\.github/renovate/.+\.json5?$'
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.408
     hooks:


### PR DESCRIPTION
## Why

The `renovate-config-validator` hook's default `files` pattern is `(^|/).?renovate(?:rc)?(?:\.json5?)?$`. That matches `.github/renovate.json`, but **not** `.github/renovate/*.json` — so the shared presets that this repo and `RSS-Engineering/undercloud-deploy` both extend have never been validated locally.

This was noticed concretely: the `fileMatch` → `managerFilePatterns` rename in #2212 reported `renovate-config-validator .... Skipped (no files to check)`. A typo in a preset would have shipped silently, and because both repos extend these presets **unpinned** (no `#ref`), a broken preset takes effect on the next Renovate run of either repo with no PR to catch it.

## Verification

**Coverage** — matching the new pattern against `git ls-files` (`both` = already covered, `NEW` = newly covered):

```
both  .github/renovate.json
NEW   .github/renovate/automergeGitHubActions.json
NEW   .github/renovate/default.json
NEW   .github/renovate/mariadb-operator.json
NEW   .github/renovate/matchOpenStackHelm.json
NEW   .github/renovate/nautobot.json
NEW   .github/renovate/precommit.json
NEW   .github/renovate/understackContainerMatch.json
```

No other path in the repo is pulled in.

**All seven presets pass as-is**, so this does not land red: `prek run renovate-config-validator --all-files` → `Passed` (exit 0), no warnings.

**The hook can actually fail** — injecting an unknown option (`grupName`) into `.github/renovate/nautobot.json` gives `renovate-config-validator ... Failed`. An invalid regex in `matchStrings` is caught too.

One limit worth recording: the validator is lenient about some shapes — `matchPackageNames` given a bare string instead of an array validates fine, because Renovate coerces it. So this catches unknown options and malformed regexes, not every possible mistake.

## Note

Preset files are validated as *global* config (`INFO: Validating <file> as global config`), since the hook passes filenames as arguments. That is fine for these files and is how the existing `renovate.json` check already behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)