### PR TITLE
chore(argocd-understack): remove unnecessary ref in multi-source app

### DIFF
--- a/charts/argocd-understack/templates/application-argo-events-workflows.yaml
+++ b/charts/argocd-understack/templates/application-argo-events-workflows.yaml
@@ -16,11 +16,9 @@ spec:
   project: understack
   sources:
   - path: workflows/argo-events
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   - path: {{ include "understack.deploy_path" $ }}/argo-events-workflows
-    ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-argo-events.yaml
+++ b/charts/argocd-understack/templates/application-argo-events.yaml
@@ -15,11 +15,9 @@ spec:
   project: understack
   sources:
   - path: components/argo-events
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   - path: {{ include "understack.deploy_path" $ }}/argo-events
-    ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}
     kustomize:

--- a/charts/argocd-understack/templates/application-external-secrets.yaml
+++ b/charts/argocd-understack/templates/application-external-secrets.yaml
@@ -19,7 +19,6 @@ spec:
   sources:
   {{- if $installApp }}
   - path: operators/external-secrets
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   {{- end }}

--- a/charts/argocd-understack/templates/application-global-workflows.yaml
+++ b/charts/argocd-understack/templates/application-global-workflows.yaml
@@ -16,11 +16,9 @@ spec:
   project: understack
   sources:
   - path: components/global-workflows
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   - path: {{ include "understack.deploy_path" $ }}/global-workflows
-    ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-openstack-sync-plugins.yaml
+++ b/charts/argocd-understack/templates/application-openstack-sync-plugins.yaml
@@ -20,11 +20,9 @@ spec:
   project: understack
   sources:
   - path: components/openstack-sync-plugins
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
   - path: {{ include "understack.deploy_path" $ }}/openstack-sync-plugins
-    ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}
   syncPolicy:

--- a/charts/argocd-understack/templates/application-openstack.yaml
+++ b/charts/argocd-understack/templates/application-openstack.yaml
@@ -16,7 +16,6 @@ spec:
   project: understack
   sources:
   - path: components/openstack
-    ref: understack
     repoURL: {{ include "understack.understack_url" $ }}
     targetRevision: {{ include "understack.understack_ref" $ }}
     helm:

--- a/charts/argocd-understack/templates/application-snmp-exporter.yaml
+++ b/charts/argocd-understack/templates/application-snmp-exporter.yaml
@@ -23,9 +23,6 @@ spec:
       - $deploy/{{ include "understack.deploy_path" $ }}/prometheus-snmp-exporter/values.yaml
     repoURL: https://prometheus-community.github.io/helm-charts
     targetRevision: 5.6.0
-  - ref: understack
-    repoURL: {{ include "understack.understack_url" $ }}
-    targetRevision: {{ include "understack.understack_ref" $ }}
   - ref: deploy
     repoURL: {{ include "understack.deploy_url" $ }}
     targetRevision: {{ include "understack.deploy_ref" $ }}


### PR DESCRIPTION
Fast follow to #2205, addressing item 3 from the pass-4 review.

These `ref:` fields are never dereferenced — no source in these Applications uses `$understack/` or `$deploy/` in `helm.valueFiles` or anywhere else. Per 8f9e2d73 and 92ee95eb, an unnecessary ref causes ArgoCD to crash with a runtime exception due to argoproj/argo-cd#25460, and that fix still has not been backported to any release branch.

Those two commits only covered the single-source Applications. This covers the multi-source ones that were missed:

| Application | Removed |
| --- | --- |
| `application-argo-events.yaml` | `ref: understack`, `ref: deploy` |
| `application-argo-events-workflows.yaml` | `ref: understack`, `ref: deploy` |
| `application-global-workflows.yaml` | `ref: understack`, `ref: deploy` |
| `application-openstack-sync-plugins.yaml` | `ref: understack`, `ref: deploy` |
| `application-external-secrets.yaml` | `ref: understack` |
| `application-openstack.yaml` | `ref: understack` |
| `application-snmp-exporter.yaml` | the whole ref-only `- ref: understack` source |

`application-openstack.yaml` keeps `ref: deploy`, which its `valueFiles` dereferences. `application-snmp-exporter.yaml` had a source consisting only of `ref: understack` with no `path`, referenced by nothing, so the source is dropped rather than just the ref. `application-openstack-sync-operator.yaml` keeps both of its refs since its `helm.valueFiles` dereferences each one.

## Verification

Every `ref: understack`/`ref: deploy` in the chart was checked against whether its Application dereferences `$understack/`/`$deploy/`. After this change no unused refs remain, and no Application references a ref it no longer declares.

Rendering `charts/argocd-understack` against both `ci/example.yaml` and `ci/example-global.yaml`, with all affected components enabled, gives 13 lines removed and 0 added versus `main` — only the `ref:` lines and the dead snmp-exporter source. No other manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)