### PR TITLE
feat(openstack-sync-operator): follow on openstack sync operator reviews

### DIFF
--- a/components/openstack-sync-operator/templates/_crd.tpl
+++ b/components/openstack-sync-operator/templates/_crd.tpl
@@ -5,7 +5,10 @@ Read hook CRD metadata used by RBAC and shell-operator environment wiring.
 {{- $root := index . 0 -}}
 {{- $hookName := index . 1 -}}
 {{- $hook := index . 2 -}}
-{{- $crdPath := required (printf "hooks.%s.crd is required when hook is enabled" $hookName) $hook.crd -}}
+{{- $crdPath := get $hook "crd" -}}
+{{- if not $crdPath -}}
+{{- fail (printf "hooks.%s.crd is required for CRD metadata" $hookName) -}}
+{{- end -}}
 {{- $crdYaml := required (printf "hooks.%s.crd file %s is empty or missing" $hookName $crdPath) ($root.Files.Get $crdPath) -}}
 {{- $crd := fromYaml $crdYaml -}}
 {{- if ne $crd.kind "CustomResourceDefinition" -}}

--- a/components/openstack-sync-operator/templates/_helpers.tpl
+++ b/components/openstack-sync-operator/templates/_helpers.tpl
@@ -74,15 +74,21 @@ Normalize built-in plugin hooks and direct hook definitions.
 {{- define "openstack-sync-operator.configuredHooks" -}}
 {{- $hooks := dict -}}
 {{- $enabledPlugins := default dict .Values.plugins -}}
-{{- range $pluginName, $plugin := default dict .Values.pluginData -}}
+{{- $pluginData := default dict .Values.pluginData -}}
+{{- range $pluginName, $_ := $enabledPlugins -}}
+{{- if not (hasKey $pluginData $pluginName) -}}
+{{- fail (printf "plugins.%s has no matching pluginData.%s entry" $pluginName $pluginName) -}}
+{{- end -}}
+{{- end -}}
+{{- range $pluginName, $plugin := $pluginData -}}
 {{- $hook := default dict $plugin.hook -}}
 {{- if gt (len $hook) 0 -}}
 {{- $hookValues := dict -}}
 {{- range $key, $value := $hook -}}
 {{- $_ := set $hookValues $key $value -}}
 {{- end -}}
-{{- $_ := set $hookValues "enabled" (eq (get $enabledPlugins $pluginName) true) -}}
-{{- $_ := set $hooks $pluginName $hookValues -}}
+{{- $_1 := set $hookValues "enabled" (eq (get $enabledPlugins $pluginName) true) -}}
+{{- $_2 := set $hooks $pluginName $hookValues -}}
 {{- end -}}
 {{- end -}}
 {{- range $hookName, $hook := default dict .Values.hooks -}}

--- a/components/openstack-sync-operator/templates/deployment.yaml.tpl
+++ b/components/openstack-sync-operator/templates/deployment.yaml.tpl
@@ -1,28 +1,29 @@
 {{- $enabledHooks := dict -}}
 {{- $hookEnv := dict -}}
+{{- $_ := dict -}}
 {{- $configuredHooks := include "openstack-sync-operator.configuredHooks" . | fromYaml -}}
 {{- range $hookName, $hook := default dict $configuredHooks -}}
 {{- $hookEnabled := eq $hook.enabled true -}}
 {{- if $hookEnabled -}}
-{{- $_ := set $enabledHooks $hookName $hook -}}
+{{- $_ = set $enabledHooks $hookName $hook -}}
 {{- end -}}
 {{- $envPrefix := get $hook "envPrefix" -}}
 {{- if $envPrefix -}}
-{{- $_ := set $hookEnv (printf "%s_ENABLED" $envPrefix) (ternary "true" "false" $hookEnabled) -}}
+{{- $_ = set $hookEnv (printf "%s_ENABLED" $envPrefix) (ternary "true" "false" $hookEnabled) -}}
 {{- $crdPath := get $hook "crd" -}}
-{{- if or $hookEnabled $crdPath -}}
+{{- if $crdPath -}}
 {{- $crd := include "openstack-sync-operator.hookCrd" (list $ $hookName $hook) | fromYaml -}}
-{{- $_ := set $hookEnv (printf "%s_CRD_API_VERSION" $envPrefix) $crd.apiVersion -}}
-{{- $_ := set $hookEnv (printf "%s_CRD_KIND" $envPrefix) $crd.kind -}}
-{{- $_ := set $hookEnv (printf "%s_CRD_RESOURCE" $envPrefix) $crd.resource -}}
-{{- $_ := set $hookEnv (printf "%s_STATUS_ENABLED" $envPrefix) (ternary "true" "false" $crd.hasStatus) -}}
+{{- $_ = set $hookEnv (printf "%s_CRD_API_VERSION" $envPrefix) $crd.apiVersion -}}
+{{- $_ = set $hookEnv (printf "%s_CRD_KIND" $envPrefix) $crd.kind -}}
+{{- $_ = set $hookEnv (printf "%s_CRD_RESOURCE" $envPrefix) $crd.resource -}}
+{{- $_ = set $hookEnv (printf "%s_STATUS_ENABLED" $envPrefix) (ternary "true" "false" $crd.hasStatus) -}}
 {{- end -}}
 {{- range $envName, $envValue := default dict $hook.env }}
 {{- $name := printf "%s_%s" $envPrefix $envName -}}
 {{- if hasKey $hookEnv $name }}
 {{- fail (printf "duplicate hook environment variable %s" $name) }}
 {{- end }}
-{{- $_ := set $hookEnv $name (toString $envValue) -}}
+{{- $_ = set $hookEnv $name (toString $envValue) -}}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/components/openstack-sync-operator/templates/rbac.yaml.tpl
+++ b/components/openstack-sync-operator/templates/rbac.yaml.tpl
@@ -7,10 +7,13 @@
 {{- $configuredHooks := include "openstack-sync-operator.configuredHooks" . | fromYaml }}
 {{- range $hookName, $hook := default dict $configuredHooks }}
 {{- if eq $hook.enabled true }}
+{{- $crdPath := get $hook "crd" }}
+{{- if $crdPath }}
 {{- $crd := include "openstack-sync-operator.hookCrd" (list $ $hookName $hook) | fromYaml }}
 {{- $rules = append $rules (dict "apiGroups" (list $crd.group) "resources" (list $crd.plural) "verbs" (list "get" "list" "watch")) }}
 {{- if $crd.hasStatus }}
 {{- $rules = append $rules (dict "apiGroups" (list $crd.group) "resources" (list (printf "%s/status" $crd.plural)) "verbs" (list "get" "patch" "update")) }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/docs/deploy-guide/components/openstack-sync-operator.md
+++ b/docs/deploy-guide/components/openstack-sync-operator.md
@@ -159,10 +159,11 @@ initContainers:
     exit "${missing}"
 ```
 
-For Neutron router flavors, the enabled hook watches `NeutronRouterFlavor` CRs,
-runs on the configured schedule, reads a full snapshot of current CRs, reconciles
-Neutron flavors and service profiles through `openstacksdk`, and patches CR
-status when the CRD exposes the status subresource.
+For Neutron router flavors, the enabled hook registers a `kubernetes` binding
+that watches `NeutronRouterFlavor` CRs and a `schedule` binding for periodic
+sync. Reconciliation logic (reading CRs, calling `openstacksdk`, and patching CR
+status) is not yet implemented; the hook currently exits 0 without taking action
+on events.
 
 When no hook is enabled, the operator can still start. In that state the Role
 has no custom-resource permissions and no OpenStack sync work is expected.


### PR DESCRIPTION
improvements for validation of [values.yaml](https://github.com/rackerlabs/understack/blob/main/components/openstack-sync-operator/values.yaml)

<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
