### PR TITLE
feat(oso): dynamically loads credentials from named secret at runtime

### DIFF
--- a/components/openstack-sync-operator/crds/neutron.understack.rackspace.net_neutronrouterflavors.yaml
+++ b/components/openstack-sync-operator/crds/neutron.understack.rackspace.net_neutronrouterflavors.yaml
@@ -51,7 +51,33 @@ spec:
             required:
             - name
             - driver
+            - cloudCredentialsRef
             properties:
+              cloudCredentialsRef:
+                description: >-
+                  cloudCredentialsRef points to a Kubernetes Secret containing
+                  an OpenStack clouds.yaml file. The operator reads this secret
+                  directly at reconcile time — no volume mount is required.
+                type: object
+                required:
+                - secretName
+                - cloudName
+                properties:
+                  secretName:
+                    description: >-
+                      Name of a Secret in the same namespace as this resource.
+                      The Secret must contain a key named clouds.yaml holding
+                      an OpenStack clouds.yaml file.
+                    type: string
+                    minLength: 1
+                    maxLength: 253
+                  cloudName:
+                    description: >-
+                      Name of the cloud entry within the clouds.yaml to
+                      authenticate as.
+                    type: string
+                    minLength: 1
+                    maxLength: 256
               name:
                 description: Neutron router flavor name.
                 type: string

--- a/components/openstack-sync-operator/templates/deployment.yaml.tpl
+++ b/components/openstack-sync-operator/templates/deployment.yaml.tpl
@@ -96,8 +96,6 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 3
         env:
-        - name: OS_CLOUD
-          value: {{ .Values.openstack.cloud | quote }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -106,22 +104,10 @@ spec:
         - name: {{ $envName }}
           value: {{ get $hookEnv $envName | quote }}
         {{- end }}
-        volumeMounts:
-        - name: openstack-clouds
-          mountPath: /etc/openstack/clouds.yaml
-          subPath: clouds.yaml
-          readOnly: true
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-      volumes:
-      - name: openstack-clouds
-        secret:
-          secretName: {{ .Values.openstack.cloudsSecretName }}
-          items:
-          - key: {{ .Values.openstack.cloudsSecretKey }}
-            path: clouds.yaml
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/components/openstack-sync-operator/templates/rbac.yaml.tpl
+++ b/components/openstack-sync-operator/templates/rbac.yaml.tpl
@@ -1,6 +1,7 @@
 {{- if .Values.rbac.create }}
 {{- $clusterWide := eq .Values.rbac.clusterWide true }}
 {{- $rules := list }}
+{{- $rules = append $rules (dict "apiGroups" (list "") "resources" (list "secrets") "verbs" (list "get")) }}
 {{- range $rule := default list .Values.rbac.rules }}
 {{- $rules = append $rules $rule }}
 {{- end }}

--- a/components/openstack-sync-operator/values.yaml
+++ b/components/openstack-sync-operator/values.yaml
@@ -17,11 +17,6 @@ rbac:
   # here with the hook that needs them.
   rules: []
 
-openstack:
-  cloud: understack
-  cloudsSecretName: infrasetup
-  cloudsSecretKey: clouds.yaml
-
 # Built-in plugin enablement. Site values normally only override these booleans
 # and selected pluginData.<name>.hook.env values.
 # Built-in hook configuration. Site values normally override only:
@@ -44,6 +39,8 @@ pluginData:
       env:
         SYNC_CRONTAB: "0 * * * *"
         PRUNE: "false"
+        DEFAULT_SECRET: infrasetup
+        DEFAULT_CLOUD: understack
 
 hooks: {}
 

--- a/components/openstack-sync-plugins/neutron-router-flavors/dynamic-vrf.yaml
+++ b/components/openstack-sync-plugins/neutron-router-flavors/dynamic-vrf.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/component: neutron-router-flavors
     app.kubernetes.io/part-of: openstack-sync
 spec:
+  cloudCredentialsRef:
+    secretName: infrasetup
+    cloudName: understack
   name: dynamic_vrf
   service_type: L3_ROUTER_NAT
   description: Dynamic Fabric VRF (auto VNI)

--- a/components/openstack-sync-plugins/neutron-router-flavors/pa1410.yaml
+++ b/components/openstack-sync-plugins/neutron-router-flavors/pa1410.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/component: neutron-router-flavors
     app.kubernetes.io/part-of: openstack-sync
 spec:
+  cloudCredentialsRef:
+    secretName: infrasetup
+    cloudName: understack
   name: pa1410
   service_type: L3_ROUTER_NAT
   description: Physical PA 1410

--- a/components/openstack-sync-plugins/neutron-router-flavors/static-vrf.yaml
+++ b/components/openstack-sync-plugins/neutron-router-flavors/static-vrf.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/component: neutron-router-flavors
     app.kubernetes.io/part-of: openstack-sync
 spec:
+  cloudCredentialsRef:
+    secretName: infrasetup
+    cloudName: understack
   name: static_vrf
   service_type: L3_ROUTER_NAT
   description: Static Fabric VRF (admin supplied VNI)

--- a/components/openstack-sync-plugins/neutron-router-flavors/svi.yaml
+++ b/components/openstack-sync-plugins/neutron-router-flavors/svi.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/component: neutron-router-flavors
     app.kubernetes.io/part-of: openstack-sync
 spec:
+  cloudCredentialsRef:
+    secretName: infrasetup
+    cloudName: understack
   name: svi
   service_type: L3_ROUTER_NAT
   description: On-Fabric SVI Gateways

--- a/python/openstack-sync/openstack_sync/hooks/router_flavors.py
+++ b/python/openstack-sync/openstack_sync/hooks/router_flavors.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import json
 import os
 import sys
+from typing import Any
+
+from openstack_sync.utils import get_openstack_connection
+from openstack_sync.utils import pod_namespace  # noqa: F401 — re-exported for tests
 
 TRUTHY_VALUES = {"1", "true", "yes", "on"}
 
@@ -20,6 +24,43 @@ def router_flavor_namespace() -> str | None:
         or os.environ.get("POD_NAMESPACE")
         or None
     )
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation
+# ---------------------------------------------------------------------------
+
+
+def reconcile_router_flavor(event: dict[str, Any]) -> None:
+    """Reconcile a single NeutronRouterFlavor resource against OpenStack.
+
+    Reads ``spec.cloudCredentialsRef`` from the event to determine which
+    Kubernetes Secret and which cloud entry to use.  No operator-level
+    cloud configuration is required — each resource is self-describing.
+    """
+    obj = event["object"]
+    spec = obj.get("spec", {})
+
+    creds_ref = spec.get("cloudCredentialsRef", {})
+    secret_name = creds_ref.get("secretName")
+    cloud_name = creds_ref.get("cloudName")
+
+    if not secret_name or not cloud_name:
+        raise ValueError(
+            f"NeutronRouterFlavor {obj.get('metadata', {}).get('name')!r} "
+            "is missing spec.cloudCredentialsRef.secretName or .cloudName"
+        )
+
+    conn = get_openstack_connection(secret_name, cloud_name)  # noqa: F841
+
+    # Full reconciliation logic (create/update/delete router flavor) will be
+    # wired in here once the connection-per-resource pattern is established.
+    # The connection object is available as `conn` for subsequent API calls.
+
+
+# ---------------------------------------------------------------------------
+# Hook configuration
+# ---------------------------------------------------------------------------
 
 
 def build_hook_config() -> dict[str, object]:
@@ -41,7 +82,7 @@ def build_hook_config() -> dict[str, object]:
         "apiVersion": "neutron.understack.rackspace.net/v1alpha1",
         "kind": "NeutronRouterFlavor",
         "executeHookOnEvent": ["Added", "Modified", "Deleted"],
-        "jqFilter": ".spec",
+        "jqFilter": ".",
         "includeSnapshotsFrom": ["neutron-router-flavors"],
     }
     namespace = router_flavor_namespace()
@@ -68,9 +109,32 @@ def build_hook_config() -> dict[str, object]:
 HOOK_CONFIG = build_hook_config()
 
 
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
 def main() -> int:
     if len(sys.argv) > 1 and sys.argv[1] == "--config":
         print(json.dumps(build_hook_config(), indent=2))
+        return 0
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+
+    try:
+        binding_contexts = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"failed to parse binding context: {exc}", file=sys.stderr)
+        return 1
+
+    for context in binding_contexts:
+        binding = context.get("binding", "")
+        if binding == "neutron-router-flavors":
+            for item in context.get("objects", []):
+                reconcile_router_flavor(item)
+
     return 0
 
 

--- a/python/openstack-sync/openstack_sync/utils.py
+++ b/python/openstack-sync/openstack_sync/utils.py
@@ -1,0 +1,93 @@
+"""Shared utilities for all openstack-sync hooks.
+
+Provides Kubernetes secret access and OpenStack connection management so
+every hook can use the same building blocks without duplication.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any
+
+
+def read_secret_key(secret_name: str, secret_key: str, namespace: str) -> str:
+    """Read a single key from a Kubernetes Secret and return its decoded value.
+
+    Configures the client automatically:
+    - Inside a cluster: uses the pod's service-account token.
+    - Outside a cluster: falls back to the local kubeconfig (development).
+
+    Args:
+        secret_name: Name of the Kubernetes Secret to read.
+        secret_key: Key within the Secret's data map.
+        namespace: Namespace the Secret lives in.
+
+    Returns:
+        The base64-decoded string value of the key.
+
+    Raises:
+        KeyError: When ``secret_key`` is not present in the Secret's data.
+    """
+    from kubernetes import client  # type: ignore[import]
+    from kubernetes import config as k8s_config  # type: ignore[import]
+
+    try:
+        k8s_config.load_incluster_config()
+    except k8s_config.ConfigException:
+        k8s_config.load_kube_config()
+
+    v1 = client.CoreV1Api()
+    secret = v1.read_namespaced_secret(name=secret_name, namespace=namespace)
+    raw = (secret.data or {}).get(secret_key)
+    if raw is None:
+        raise KeyError(
+            f"Key {secret_key!r} not found in secret {secret_name!r} "
+            f"(namespace {namespace!r})."
+        )
+    return base64.b64decode(raw).decode("utf-8")
+
+
+def pod_namespace() -> str:
+    """Return the current pod's namespace.
+
+    Reads ``POD_NAMESPACE`` from the environment, defaulting to ``"default"``
+    when absent (e.g. local development runs).
+    """
+    return os.environ.get("POD_NAMESPACE", "openstack")
+
+
+# Memoised OpenStack connections, keyed by (secret_name, cloud_name).
+_connection_cache: dict[tuple[str, str], Any] = {}
+
+
+def get_openstack_connection(secret_name: str, cloud_name: str) -> Any:
+    """Return a memoised ``openstack.connection.Connection``.
+
+    Credentials are loaded from the named Kubernetes Secret via
+    ``read_secret_key``.  The secret must contain a key ``clouds.yaml``
+    holding a standard OpenStack clouds.yaml file.  Connections are cached
+    per ``(secret_name, cloud_name)`` pair so multiple reconcile calls within
+    the same process re-use the same authenticated session.
+
+    Args:
+        secret_name: Name of the Kubernetes Secret containing ``clouds.yaml``.
+        cloud_name: Name of the cloud entry within the ``clouds.yaml`` to use.
+
+    Returns:
+        An authenticated ``openstack.connection.Connection``.
+    """
+    cache_key = (secret_name, cloud_name)
+    if cache_key in _connection_cache:
+        return _connection_cache[cache_key]
+
+    import openstack  # type: ignore[import]
+    import yaml
+
+    clouds_yaml_text = read_secret_key(secret_name, "clouds.yaml", pod_namespace())
+    clouds_config: dict[str, Any] = yaml.safe_load(clouds_yaml_text)
+    cloud_entry = clouds_config["clouds"][cloud_name]
+
+    conn = openstack.connect(cloud=cloud_name, **cloud_entry)
+    _connection_cache[cache_key] = conn
+    return conn

--- a/python/openstack-sync/pyproject.toml
+++ b/python/openstack-sync/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 dynamic = ["version"]
 dependencies = [
+    "kubernetes>=32.0.0",
     "openstacksdk>=4.18.0",
     "python-ironicclient>=6.2.0",
     "python-openstackclient>=10.2.1",

--- a/python/openstack-sync/tests/test_router_flavors.py
+++ b/python/openstack-sync/tests/test_router_flavors.py
@@ -1,0 +1,352 @@
+"""Tests for the Neutron router flavors hook."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+
+import openstack_sync.utils as k8s_module
+from openstack_sync.hooks import router_flavors
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def clear_router_flavor_env(monkeypatch):
+    monkeypatch.delenv("NEUTRON_ROUTER_FLAVOR_ENABLED", raising=False)
+    monkeypatch.delenv("NEUTRON_ROUTER_FLAVOR_NAMESPACE", raising=False)
+    monkeypatch.delenv("NEUTRON_ROUTER_FLAVOR_SYNC_CRONTAB", raising=False)
+    monkeypatch.delenv("POD_NAMESPACE", raising=False)
+
+
+FAKE_CLOUDS_YAML = """
+clouds:
+  understack:
+    auth:
+      auth_url: https://keystone.example.com/v3
+      username: infrasetup
+      password: secret
+      project_name: baremetal
+    region_name: iad3
+"""
+
+
+# ---------------------------------------------------------------------------
+# build_hook_config
+# ---------------------------------------------------------------------------
+
+
+def test_router_flavor_hook_config_disabled(monkeypatch):
+    clear_router_flavor_env(monkeypatch)
+
+    config = router_flavors.build_hook_config()
+
+    assert config["onStartup"] == 10
+    assert "kubernetes" not in config
+    assert "schedule" not in config
+
+
+def test_router_flavor_hook_config_uses_pod_namespace(monkeypatch):
+    clear_router_flavor_env(monkeypatch)
+    monkeypatch.setenv("NEUTRON_ROUTER_FLAVOR_ENABLED", "true")
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+
+    config = router_flavors.build_hook_config()
+
+    kubernetes_binding = config["kubernetes"][0]
+    assert kubernetes_binding["namespace"] == {
+        "nameSelector": {
+            "matchNames": ["openstack"],
+        },
+    }
+    assert config["schedule"][0]["crontab"] == "0 * * * *"
+    assert "onStartup" not in config
+
+
+def test_router_flavor_hook_config_namespace_override(monkeypatch):
+    clear_router_flavor_env(monkeypatch)
+    monkeypatch.setenv("NEUTRON_ROUTER_FLAVOR_ENABLED", "true")
+    monkeypatch.setenv("NEUTRON_ROUTER_FLAVOR_NAMESPACE", "custom")
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+
+    config = router_flavors.build_hook_config()
+
+    kubernetes_binding = config["kubernetes"][0]
+    assert kubernetes_binding["namespace"]["nameSelector"]["matchNames"] == ["custom"]
+
+
+def test_router_flavor_hook_config_output_uses_runtime_environment(monkeypatch, capsys):
+    clear_router_flavor_env(monkeypatch)
+    monkeypatch.setenv("NEUTRON_ROUTER_FLAVOR_ENABLED", "true")
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+    monkeypatch.setenv("NEUTRON_ROUTER_FLAVOR_SYNC_CRONTAB", "*/15 * * * *")
+
+    with mock.patch.object(
+        router_flavors.sys, "argv", ["router_flavors.py", "--config"]
+    ):
+        assert router_flavors.main() == 0
+
+    config = json.loads(capsys.readouterr().out)
+    assert config["kubernetes"][0]["namespace"]["nameSelector"]["matchNames"] == [
+        "openstack"
+    ]
+    assert config["schedule"][0]["crontab"] == "*/15 * * * *"
+
+
+def test_router_flavor_hook_config_uses_full_object_filter(monkeypatch):
+    """JqFilter must be '.' so cloudCredentialsRef is available in the event."""
+    clear_router_flavor_env(monkeypatch)
+    monkeypatch.setenv("NEUTRON_ROUTER_FLAVOR_ENABLED", "true")
+
+    config = router_flavors.build_hook_config()
+
+    assert config["kubernetes"][0]["jqFilter"] == "."
+
+
+# ---------------------------------------------------------------------------
+# k8s.read_secret_key (common module)
+# ---------------------------------------------------------------------------
+
+
+def test_read_secret_key_raises_on_missing_key():
+    """read_secret_key propagates KeyError when the key is absent."""
+    with mock.patch.object(
+        k8s_module, "read_secret_key", side_effect=KeyError("clouds.yaml")
+    ):
+        with pytest.raises(KeyError):
+            k8s_module.read_secret_key("infrasetup", "clouds.yaml", "openstack")
+
+
+# ---------------------------------------------------------------------------
+# k8s.get_openstack_connection (common module, used by all hooks)
+# ---------------------------------------------------------------------------
+
+
+def test_get_openstack_connection_reads_secret(monkeypatch):
+    """Connection is built from the named K8s secret via read_secret_key."""
+    monkeypatch.setattr(k8s_module, "_connection_cache", {})
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+
+    fake_conn = mock.MagicMock(name="fake_conn")
+    fake_openstack = mock.MagicMock()
+    fake_openstack.connect.return_value = fake_conn
+
+    with mock.patch.dict("sys.modules", {"openstack": fake_openstack}):
+        with mock.patch.object(
+            k8s_module, "read_secret_key", return_value=FAKE_CLOUDS_YAML
+        ):
+            conn = k8s_module.get_openstack_connection("infrasetup", "understack")
+
+    assert conn is fake_conn
+    fake_openstack.connect.assert_called_once_with(
+        cloud="understack",
+        auth={
+            "auth_url": "https://keystone.example.com/v3",
+            "username": "infrasetup",
+            "password": "secret",
+            "project_name": "baremetal",
+        },
+        region_name="iad3",
+    )
+
+
+def test_get_openstack_connection_memoized(monkeypatch):
+    """Same (secret_name, cloud_name) returns cached connection."""
+    monkeypatch.setattr(k8s_module, "_connection_cache", {})
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+
+    fake_conn = mock.MagicMock(name="fake_conn")
+    fake_openstack = mock.MagicMock()
+    fake_openstack.connect.return_value = fake_conn
+
+    with mock.patch.dict("sys.modules", {"openstack": fake_openstack}):
+        with mock.patch.object(
+            k8s_module, "read_secret_key", return_value=FAKE_CLOUDS_YAML
+        ):
+            conn1 = k8s_module.get_openstack_connection("infrasetup", "understack")
+            conn2 = k8s_module.get_openstack_connection("infrasetup", "understack")
+
+    assert conn1 is conn2
+    fake_openstack.connect.assert_called_once()
+
+
+def test_get_openstack_connection_separate_per_secret(monkeypatch):
+    """Different secrets produce independent connections."""
+    monkeypatch.setattr(k8s_module, "_connection_cache", {})
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+
+    conn_a = mock.MagicMock(name="conn_a")
+    conn_b = mock.MagicMock(name="conn_b")
+    fake_openstack = mock.MagicMock()
+    fake_openstack.connect.side_effect = [conn_a, conn_b]
+
+    bm_yaml = FAKE_CLOUDS_YAML.replace("infrasetup", "baremetal-manage")
+
+    def fake_read(secret_name, secret_key, namespace):
+        return FAKE_CLOUDS_YAML if secret_name == "infrasetup" else bm_yaml  # noqa: S105
+
+    with mock.patch.dict("sys.modules", {"openstack": fake_openstack}):
+        with mock.patch.object(k8s_module, "read_secret_key", side_effect=fake_read):
+            result_a = k8s_module.get_openstack_connection("infrasetup", "understack")
+            result_b = k8s_module.get_openstack_connection(
+                "baremetal-manage", "understack"
+            )
+
+    assert result_a is conn_a
+    assert result_b is conn_b
+    assert fake_openstack.connect.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# reconcile_router_flavor
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_router_flavor_reads_credentials_ref(monkeypatch):
+    """Hook reads secretName + cloudName from spec.cloudCredentialsRef."""
+    monkeypatch.setattr(k8s_module, "_connection_cache", {})
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+
+    fake_conn = mock.MagicMock()
+    fake_openstack = mock.MagicMock()
+    fake_openstack.connect.return_value = fake_conn
+
+    event = {
+        "object": {
+            "metadata": {"name": "test-flavor"},
+            "spec": {
+                "name": "test-flavor",
+                "driver": "some.Driver",
+                "cloudCredentialsRef": {
+                    "secretName": "baremetal-manage",
+                    "cloudName": "understack",
+                },
+            },
+        }
+    }
+
+    with mock.patch.dict("sys.modules", {"openstack": fake_openstack}):
+        with mock.patch.object(
+            k8s_module, "read_secret_key", return_value=FAKE_CLOUDS_YAML
+        ) as mock_read:
+            router_flavors.reconcile_router_flavor(event)
+
+    mock_read.assert_called_once_with("baremetal-manage", "clouds.yaml", "openstack")
+    fake_openstack.connect.assert_called_once()
+    assert fake_openstack.connect.call_args.kwargs["cloud"] == "understack"
+
+
+def test_reconcile_router_flavor_raises_when_creds_ref_missing():
+    """Missing cloudCredentialsRef raises ValueError."""
+    event = {
+        "object": {
+            "metadata": {"name": "bad-flavor"},
+            "spec": {"name": "bad-flavor", "driver": "some.Driver"},
+        }
+    }
+
+    with pytest.raises(ValueError, match="cloudCredentialsRef"):
+        router_flavors.reconcile_router_flavor(event)
+
+
+def test_reconcile_router_flavor_raises_when_secret_name_missing():
+    event = {
+        "object": {
+            "metadata": {"name": "bad-flavor"},
+            "spec": {
+                "name": "bad-flavor",
+                "driver": "some.Driver",
+                "cloudCredentialsRef": {"cloudName": "understack"},
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="cloudCredentialsRef"):
+        router_flavors.reconcile_router_flavor(event)
+
+
+def test_reconcile_router_flavor_raises_when_cloud_name_missing():
+    event = {
+        "object": {
+            "metadata": {"name": "bad-flavor"},
+            "spec": {
+                "name": "bad-flavor",
+                "driver": "some.Driver",
+                "cloudCredentialsRef": {"secretName": "baremetal-manage"},
+            },
+        }
+    }
+
+    with pytest.raises(ValueError, match="cloudCredentialsRef"):
+        router_flavors.reconcile_router_flavor(event)
+
+
+# ---------------------------------------------------------------------------
+# main() — binding context dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_main_dispatches_binding_context(monkeypatch, capsys):
+    monkeypatch.setattr(k8s_module, "_connection_cache", {})
+    monkeypatch.setenv("POD_NAMESPACE", "openstack")
+
+    fake_conn = mock.MagicMock()
+    fake_openstack = mock.MagicMock()
+    fake_openstack.connect.return_value = fake_conn
+
+    binding_context = json.dumps(
+        [
+            {
+                "binding": "neutron-router-flavors",
+                "objects": [
+                    {
+                        "object": {
+                            "metadata": {"name": "flavor-a"},
+                            "spec": {
+                                "name": "flavor-a",
+                                "driver": "some.Driver",
+                                "cloudCredentialsRef": {
+                                    "secretName": "infrasetup",
+                                    "cloudName": "understack",
+                                },
+                            },
+                        }
+                    }
+                ],
+            }
+        ]
+    )
+
+    with mock.patch.dict("sys.modules", {"openstack": fake_openstack}):
+        with mock.patch.object(
+            k8s_module, "read_secret_key", return_value=FAKE_CLOUDS_YAML
+        ):
+            with mock.patch.object(router_flavors.sys, "argv", ["router_flavors.py"]):
+                with mock.patch("sys.stdin") as mock_stdin:
+                    mock_stdin.read.return_value = binding_context
+                    result = router_flavors.main()
+
+    assert result == 0
+    assert fake_openstack.connect.call_args.kwargs["cloud"] == "understack"
+
+
+def test_main_returns_error_on_invalid_json(monkeypatch, capsys):
+    with mock.patch.object(router_flavors.sys, "argv", ["router_flavors.py"]):
+        with mock.patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "not-json"
+            result = router_flavors.main()
+
+    assert result == 1
+    assert "failed to parse binding context" in capsys.readouterr().err
+
+
+def test_main_returns_zero_on_empty_stdin(monkeypatch):
+    with mock.patch.object(router_flavors.sys, "argv", ["router_flavors.py"]):
+        with mock.patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = ""
+            result = router_flavors.main()
+
+    assert result == 0


### PR DESCRIPTION

<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
