### PR TITLE
fix: enroll-fw invalid default resource_class ("generic") breaks submissions that don't override it PUC-2000

### DIFF
--- a/workflows/argo-events/workflowtemplates/enroll-fw.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-fw.yaml
@@ -28,7 +28,6 @@ spec:
       - name: external_cmdb_id
         value: ""
       - name: resource_class
-        value: generic
       # Firewall management/identity metadata. management_* land in the node's
       # driver_info; mate_serial lands in extra. Omit (leave "") to skip.
       - name: management_ip


### PR DESCRIPTION
enroll-fw fails immediately with ValueError when resource_class is left at its default

## What does this change do?
removes default  resource_class value from yaml 
## Upgrade impact

- [ ] None
