### PR TITLE
chore(ironic): bump IRONIC_GIT_REF to rebased understack/2026.1 PUC-2001

### DIFF
--- a/containers/ironic/Dockerfile
+++ b/containers/ironic/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # renovate: name=openstack/ironic repo=https://github.com/rackerlabs/ironic.git branch=understack/2026.1
-ARG IRONIC_GIT_REF=4ee113c63d0c92bd3f61c31c313016c594438ef6
+ARG IRONIC_GIT_REF=e07d9818e08c634f1341cb31f109d986932dd301
 ADD --keep-git-dir=true https://github.com/rackerlabs/ironic.git#${IRONIC_GIT_REF} /src/ironic
 RUN git -C /src/ironic fetch --unshallow --tags
 


### PR DESCRIPTION

## What does this change do?
Bumps `IRONIC_GIT_REF` in `containers/ironic/Dockerfile` from `4ee113c63d0c92bd3f61c31c313016c594438ef6` to `e07d9818e08c634f1341cb31f109d986932dd301`, following the rebase of `rackerlabs/ironic` `understack/2026.1` onto upstream `stable/2026.1`
(PUC-2001)

`stable/2026.1` moved  to `9083648f1`. Two of our seven patches were dropped because they had landed upstream:
- `Interpolate values for comparison operators in inspection rules`
  (upstream `43bc25db6`) - git dropped it automatically
- `Fix BIOS firmware update failure detection on Dell iDRAC`
  (upstream `c5a9737a4`) - code byte-identical, release note reworded before
  merge, so it conflicted rather than dropping cleanly

The five remaining patches now on top of `stable/2026.1`: 
Verified `rackerlabs/understack/2026.1` and the local branch are in sync at
`e07d9818e`, 5 commits ahead of `stable/2026.1` and 0 behind. https://github.com/rackerlabs/ironic/compare/stable/2026.1...rackerlabs:ironic:understack/2026.1?expand=1
## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

