### PR TITLE
chore(neutron): bump NEUTRON_GIT_REF to rebased understack/2026.1 PUC-2002

### DIFF
--- a/containers/neutron/Dockerfile
+++ b/containers/neutron/Dockerfile
@@ -6,7 +6,7 @@ FROM quay.io/airshipit/neutron:${OPENSTACK_VERSION}-ubuntu_noble AS build
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # renovate: name=openstack/neutron repo=https://github.com/rackerlabs/neutron.git branch=understack/2026.1
-ARG NEUTRON_GIT_REF=7cad1b179a9645f9cd0256a5d90a97ebfb95d8d0
+ARG NEUTRON_GIT_REF=b0678e56e9c5a7ec2f335c4271465fc1c3202e2a
 ADD --keep-git-dir=true https://github.com/rackerlabs/neutron.git#${NEUTRON_GIT_REF} /src/neutron
 RUN git -C /src/neutron fetch --unshallow --tags
 


### PR DESCRIPTION
Done. Followed the  containers/neutron/README.md using scripts/git-understack-rebase.
https://github.com/rackerlabs/neutron/compare/stable/2026.1...rackerlabs:neutron:understack/2026.1?expand=1


  stable/2026.1      bd12dd49f2 to 3f1ce7f950  
  understack/2026.1  7cad1b179a to  b0678e56e9  

No conflicts. 
```shell
./scripts/git-understack-rebase ~/UC-dev-work/neutron 2026.1
[INFO]  Step 1: pre-flight checks

Checkout path:        /Users/nidhi.rai/UC-dev-work/neutron
Version:               2026.1
Current branch:        master
upstream remote:       https://github.com/openstack/neutron.git
rackerlabs remote:     https://github.com/rackerlabs/neutron.git
local stable/2026.1: bd12dd49f220f23b45342426d3bd4c9ba781b66b
local understack/2026.1: 7cad1b179a9645f9cd0256a5d90a97ebfb95d8d0

Proceed to fetch upstream and rackerlabs? [y/N] y
[INFO]  Step 2: fetching remotes
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Total 5 (delta 4), reused 5 (delta 4), pack-reused 0 (from 0)
Unpacking objects: 100% (5/5), 870 bytes | 79.00 KiB/s, done.
From https://github.com/openstack/neutron
   794cfbe187..3f1ce7f950  stable/2026.1 -> upstream/stable/2026.1

upstream/stable/2026.1:
3f1ce7f950 (upstream/stable/2026.1) [CI][FT] Tempoarary skip failing tests centos 9 stream

rackerlabs/stable/2026.1:
bd12dd49f2 (rackerlabs/stable/2026.1, stable/2026.1) Merge "quota: Fix reservation under-counting in ``get_total_reservations_map()``" into stable/2026.1

rackerlabs/understack/2026.1:
7cad1b179a (rackerlabs/understack/2026.1, understack/2026.1) ovn: Don't wipe network HA_Chassis_Group on empty Gateway_Chassis

[INFO]  Step 2b: checking for fork patches that already landed upstream
About to run:
  git rebase --onto upstream/stable/2026.1 (3f1ce7f95041b7f9d5896ef6274266dd9253655d) rackerlabs/stable/2026.1 (bd12dd49f220f23b45342426d3bd4c9ba781b66b) understack/2026.1

Proceed with the rebase? [y/N] y
[INFO]  Step 3: rebasing
[INFO]  Created local backup tags: backup/understack/2026.1/20260824232036, backup/stable/2026.1/20260824232036
Switched to branch 'understack/2026.1'
Your branch is up to date with 'rackerlabs/understack/2026.1'.
Successfully rebased and updated refs/heads/understack/2026.1.
Switched to branch 'stable/2026.1'
Your branch is up to date with 'rackerlabs/stable/2026.1'.
Updating bd12dd49f2..3f1ce7f950
Fast-forward
 neutron/agent/linux/ip_conntrack.py                                    |   2 +-
 neutron/cmd/upgrade_checks/checks.py                                   |  63 ++++++++++++++++++-
 neutron/db/db_base_plugin_v2.py                                        |  11 ++++
 neutron/db/l3_db.py                                                    |  11 ++--
 neutron/extensions/rbac.py                                             |  27 +++++++-
 neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/api.py               |   8 +++
 neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/commands.py          |  15 ++++-
 neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py        |   5 +-
 neutron/services/logapi/drivers/ovn/driver.py                          |  20 +++++-
 neutron/services/network_segment_range/plugin.py                       |  25 +++++---
 .../functional/plugins/ml2/drivers/ovn/mech_driver/test_mech_driver.py |   1 +
 neutron/tests/functional/services/logapi/drivers/ovn/test_driver.py    |  36 +++++++++++
 .../tests/functional/services/trunk/drivers/ovn/test_trunk_driver.py   |   4 +-
 neutron/tests/unit/agent/linux/test_ip_conntrack.py                    |  39 +++++++++++-
 neutron/tests/unit/cmd/upgrade_checks/test_checks.py                   |  40 ++++++++++++
 neutron/tests/unit/db/test_rbac_db_mixin.py                            |  29 +++++++++
 neutron/tests/unit/extensions/test_l3.py                               |  25 ++++++++
 neutron/tests/unit/extensions/test_subnet_onboard.py                   |  32 ++++++++++
 .../tests/unit/plugins/ml2/drivers/ovn/mech_driver/test_mech_driver.py |   8 +--
 neutron/tests/unit/services/logapi/drivers/ovn/test_driver.py          |   7 ++-
 neutron/tests/unit/services/network_segment_range/test_plugin.py       | 105 +++++++++++++++++++++++++++++---
 .../notes/fix-network-segment-range-overlap-6da0ecd784269105.yaml      |   7 +++
 .../notes/fix-network-segment-range-shrink-202881cfd8236605.yaml       |   9 +++
 .../notes/validate-rbac-target-project-uuid-a3f2e8b1c4d5f6a9.yaml      |  24 ++++++++
 tox.ini                                                                |  13 ++++
 zuul.d/base.yaml                                                       |   1 +
 26 files changed, 528 insertions(+), 39 deletions(-)
 create mode 100644 releasenotes/notes/fix-network-segment-range-overlap-6da0ecd784269105.yaml
 create mode 100644 releasenotes/notes/fix-network-segment-range-shrink-202881cfd8236605.yaml
 create mode 100644 releasenotes/notes/validate-rbac-target-project-uuid-a3f2e8b1c4d5f6a9.yaml
Switched to branch 'understack/2026.1'
Your branch and 'rackerlabs/understack/2026.1' have diverged,
and have 21 and 9 different commits each, respectively.
  (use "git pull" if you want to integrate the remote branch with yours)

Patches ahead of stable/2026.1 before rebase: 9
Patches ahead of stable/2026.1 after rebase:  9

[INFO]  Step 4: pre-push safety check

rackerlabs stable/2026.1:      bd12dd49f220f23b45342426d3bd4c9ba781b66b -> 3f1ce7f95041b7f9d5896ef6274266dd9253655d
rackerlabs understack/2026.1: 7cad1b179a9645f9cd0256a5d90a97ebfb95d8d0 -> b0678e56e9c5a7ec2f335c4271465fc1c3202e2a

Force-push stable/2026.1 and understack/2026.1 to rackerlabs? [y/N] y
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/rackerlabs/neutron.git
   bd12dd49f2..3f1ce7f950  stable/2026.1 -> stable/2026.1
Enumerating objects: 225, done.
Counting objects: 100% (225/225), done.
Delta compression using up to 10 threads
Compressing objects: 100% (144/144), done.
Writing objects: 100% (173/173), 53.11 KiB | 13.28 MiB/s, done.
Total 173 (delta 121), reused 56 (delta 23), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (121/121), completed with 47 local objects.
To https://github.com/rackerlabs/neutron.git
 + 7cad1b179a...b0678e56e9 understack/2026.1 -> understack/2026.1 (forced update)

[INFO]  Done.
rackerlabs stable/2026.1:      bd12dd49f220f23b45342426d3bd4c9ba781b66b -> 3f1ce7f95041b7f9d5896ef6274266dd9253655d
rackerlabs understack/2026.1: 7cad1b179a9645f9cd0256a5d90a97ebfb95d8d0 -> b0678e56e9c5a7ec2f335c4271465fc1c3202e2a

[INFO]  Local backup tags (delete once you're satisfied): git -C /Users/nidhi.rai/UC-dev-work/neutron tag -d backup/understack/2026.1/20260824232036 backup/stable/2026.1/20260824232036

[INFO]  Next: update containers/neutron/Dockerfile to pin the new understack/2026.1 HEAD commit: b0678e56e9c5a7ec2f335c4271465fc1c3202e2a

``` 
## What does this change do?

## Upgrade impact - None
