### PR TITLE
chore(ironic-vnc): bump upstream sync ref to 738b83a3

### DIFF
--- a/containers/ironic-vnc-container/sync_from_upstream.sh
+++ b/containers/ironic-vnc-container/sync_from_upstream.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-UPSTREAM_COMMIT="ae9d181738453333c5f06ef805344e294a923824"
+UPSTREAM_COMMIT="738b83a3d42ba884393c4ba4eb15b35e758a26a7"
 
 if ! [[ -f sync_from_upstream.sh ]]; then
   echo "Run ./sync_from_upstream.sh only from the containers/ironic-vnc-console folder."


### PR DESCRIPTION
Update the vnc-container sync ref from ae9d1817 to 738b83a3, pulling in
three upstream ironic changes to tools/vnc-container:

- Manage Xvfb explicitly instead of relying on x11vnc -create. The
  start-x11vnc.py script now launches Xvfb itself on display :20
  (as FIREFOX_USER, no xauth), waits for the X socket, points x11vnc
  at the running display via -display, and terminates Xvfb on
  graceful shutdown.
- Parametrize the browser user via a new FIREFOX_USER / FIREFOX_USER_HOME
  env, replacing the hardcoded "firefox" in the Containerfiles and
  start-x11vnc.py. The ubuntu FIREFOX_CONFIG_DIR also moves from
  .mozilla/firefox-esr to .mozilla/firefox.
- Drop the x11vnc -ncache 10 flag, which was inflating the framebuffer
  height.

Upstream commits:
  - openstack/ironic@7cd056acc Start Xvfb and pass running display to x11vnc
  - openstack/ironic@8b36a9fb0 Parametize user running firefox
  - openstack/ironic@62e9a6a58 trivial: Remove x11vnc -ncache flag inflating framebuffer height
