### PR TITLE
feat(keystone): system-scope service account

### DIFF
--- a/charts/site-workflows/templates/sensor-keystone-automation-user-upsert.yaml
+++ b/charts/site-workflows/templates/sensor-keystone-automation-user-upsert.yaml
@@ -75,6 +75,10 @@ spec:
                               infra-readwrite)
                                 openstack role add --user "${SVC_ID}" --project-domain infra --project baremetal admin
                                 ;;
+                              system-readwrite)
+                                openstack role add --user "${SVC_ID}" --system all reader
+                                openstack role add --user "${SVC_ID}" --system all member
+                                ;;
                               *)
                                 echo "Invalid role ${svc_role}"
                                 ;;

--- a/components/openstack/templates/automation-infrasetup-system.yaml.tpl
+++ b/components/openstack/templates/automation-infrasetup-system.yaml.tpl
@@ -1,0 +1,46 @@
+---
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: "infrasetup-system-{{ .Values.regionName }}"
+spec:
+  length: 32
+  digits: 6
+  symbols: 6
+  symbolCharacters: "~!@#$%^*()_+-={}[]<>?"
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: "infrasetup-system-{{ .Values.regionName }}"
+spec:
+  refreshInterval: 20160m
+  target:
+    name: infrasetup-system
+    template:
+      engineVersion: v2
+      type: Opaque
+      metadata:
+        labels:
+          understack.rackspace.com/keystone-role: system-readwrite
+          understack.rackspace.com/keystone-user: "infrasetup-system-{{ .Values.regionName }}"
+      data:
+        password: "{{ `{{ .password }}` }}"
+        clouds.yaml: |
+          clouds:
+            understack:
+              auth:
+                auth_url: "{{ .Values.keystoneUrl }}"
+                user_domain_name: "service"
+                username: "infrasetup-system-{{ .Values.regionName }}"
+                password: "{{ `{{ .password }}` }}"
+                system_scope: "all"
+              region_name: "{{ .Values.regionName }}"
+              interface: "public"
+              identity_api_version: 3
+  dataFrom:
+  - sourceRef:
+      generatorRef:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: Password
+        name: "infrasetup-system-{{ .Values.regionName }}"


### PR DESCRIPTION
automation-infrasetup-system.yaml.tpl — modelled on the existing automation-infrasetup.yaml.tpl: a Password generator plus an ExternalSecret producing Secret infrasetup-system, labelled keystone-role: system-readwrite, whose clouds.yaml sets system_scope: "all" and carries no project keys.

sensor-keystone-automation-user-upsert.yaml — new system-readwrite case granting reader + member on --system all. member is the minimum SYSTEM_MEMBER requires; no cloud-wide admin.

<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
