### PR TITLE
feat(understack-workflows): Management_switch_port and Management_switch required in enroll-fw PUC-2006

### DIFF
--- a/python/understack-workflows/tests/test_enroll_fw.py
+++ b/python/understack-workflows/tests/test_enroll_fw.py
@@ -112,14 +112,23 @@ def test_enroll_fw_hands_metadata_to_the_engine(mocker):
     )
 
 
-def test_enroll_fw_without_fw_fields_passes_empty_metadata(mocker):
+def test_enroll_fw_optional_fw_fields_can_be_omitted(mocker):
+    # management_switch/port are required; management_ip, mate_serial and
+    # external_cmdb_id are optional and are simply absent from the metadata.
     _mock_client(mocker, node=None)
     engine = mocker.patch.object(enroll_fw.netdev_reconciler, "enroll")
 
-    enroll_fw.enroll_fw(**BASE_ARGS)
+    enroll_fw.enroll_fw(
+        **BASE_ARGS,
+        management_switch="n11-22-1d.dfw3",
+        management_switch_port="Ethernet1/24",
+    )
 
     _, kwargs = engine.call_args
-    assert kwargs["driver_info"] == {}
+    assert kwargs["driver_info"] == {
+        "management_switch": "n11-22-1d.dfw3",
+        "management_switch_port": "Ethernet1/24",
+    }
     assert kwargs["extra"] == {}
 
 
@@ -154,6 +163,29 @@ def test_enroll_fw_normalizes_resource_class_whitespace(mocker):
     enroll_fw.enroll_fw(**args, **FW_FIELDS)
 
     assert engine.call_args.kwargs["resource_class"] == "pa1410"
+
+
+def test_enroll_fw_requires_management_switch(mocker):
+    engine = mocker.patch.object(enroll_fw.netdev_reconciler, "enroll")
+
+    for bad in ("", "   "):
+        args = {**BASE_ARGS, **FW_FIELDS, "management_switch": bad}
+        with pytest.raises(ValueError, match="management-switch"):
+            enroll_fw.enroll_fw(**args)
+
+    # Rejected before the engine (or any Ironic call) is ever invoked.
+    engine.assert_not_called()
+
+
+def test_enroll_fw_requires_management_switch_port(mocker):
+    engine = mocker.patch.object(enroll_fw.netdev_reconciler, "enroll")
+
+    for bad in ("", "   "):
+        args = {**BASE_ARGS, **FW_FIELDS, "management_switch_port": bad}
+        with pytest.raises(ValueError, match="management-switch-port"):
+            enroll_fw.enroll_fw(**args)
+
+    engine.assert_not_called()
 
 
 # --- in-service (active) node: metadata-only in place -----------------------
@@ -272,5 +304,23 @@ def test_argument_parser_requires_resource_class():
                 "net",
                 "--ports",
                 "[]",
+            ]
+        )
+
+
+def test_argument_parser_requires_management_switch_and_port():
+    # Everything except the management switch/port -> argparse rejects it.
+    parser = enroll_fw.argument_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--name",
+                "fw1",
+                "--physical-network",
+                "net",
+                "--ports",
+                "[]",
+                "--resource-class",
+                "pa1410",
             ]
         )

--- a/python/understack-workflows/understack_workflows/main/enroll_fw.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_fw.py
@@ -44,11 +44,29 @@ def _require_specific_resource_class(resource_class: str | None) -> str:
     normalized = (resource_class or "").strip()
     if not normalized or normalized.lower() == netdev_reconciler.DEFAULT_RESOURCE_CLASS:
         raise ValueError(
-            "enroll-fw requires an explicit, purpose-made --resource-class "
-            f"got {resource_class!r}. The generic default is not "
-            "allowed"
+            "enroll-fw requires an explicit, purpose-made --resource-class; "
+            f"got {resource_class!r}. The generic default is not allowed."
         )
     return normalized
+
+
+def _require_management_location(
+    management_switch: str, management_switch_port: str
+) -> tuple[str, str]:
+    """Return (switch, port) after checking both are non-empty."""
+    switch = (management_switch or "").strip()
+    port = (management_switch_port or "").strip()
+    missing = []
+    if not switch:
+        missing.append("--management-switch")
+    if not port:
+        missing.append("--management-switch-port")
+    if missing:
+        raise ValueError(
+            f"enroll-fw requires {' and '.join(missing)}: the management switch "
+            "and port cannot be blank."
+        )
+    return switch, port
 
 
 def enroll_fw(
@@ -64,6 +82,9 @@ def enroll_fw(
     mate_serial: str = "",
 ) -> None:
     resource_class = _require_specific_resource_class(resource_class)
+    management_switch, management_switch_port = _require_management_location(
+        management_switch, management_switch_port
+    )
     driver_info, extra = firewall.firewall_metadata(
         management_ip=management_ip,
         management_switch=management_switch,
@@ -244,14 +265,12 @@ def argument_parser():
     )
     parser.add_argument(
         "--management-switch",
-        required=False,
-        default="",
+        required=True,
         help="Management switch name -> driver_info.management_switch",
     )
     parser.add_argument(
         "--management-switch-port",
-        required=False,
-        default="",
+        required=True,
         help="Management switch port -> driver_info.management_switch_port",
     )
     parser.add_argument(

--- a/workflows/argo-events/workflowtemplates/enroll-fw.yaml
+++ b/workflows/argo-events/workflowtemplates/enroll-fw.yaml
@@ -29,13 +29,12 @@ spec:
         value: ""
       - name: resource_class
       # Firewall management/identity metadata. management_* land in the node's
-      # driver_info; mate_serial lands in extra. Omit (leave "") to skip.
+      # driver_info; mate_serial lands in extra.
+      # management_switch + management_switch_port are REQUIRED (no default)
       - name: management_ip
         value: ""
       - name: management_switch
-        value: ""
       - name: management_switch_port
-        value: ""
       - name: mate_serial
         value: ""
   templates:


### PR DESCRIPTION

## What does this change do?
makes Management_switch_port and Management_switch required in enroll-fw


