### PR TITLE
feat(envoy): Adds more envoy replicas for higher performance. JIRA:PUC-2007

### DIFF
--- a/components/envoy-configs/templates/gw-external.yaml.tpl
+++ b/components/envoy-configs/templates/gw-external.yaml.tpl
@@ -69,6 +69,19 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
+      {{- with .Values.gateways.external.envoyDeployment }}
+      envoyDeployment:
+        {{- if .replicas }}
+        replicas: {{ .replicas }}
+        {{- end }}
+        {{- if .container }}
+        container:
+          {{- if .container.resources }}
+          resources:
+            {{- .container.resources | toYaml | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       envoyService:
         annotations:
           {{- .Values.gateways.external.serviceAnnotations | toYaml | nindent 10 }}

--- a/components/envoy-configs/templates/gw-internal.yaml.tpl
+++ b/components/envoy-configs/templates/gw-internal.yaml.tpl
@@ -32,6 +32,19 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
+      {{- with .Values.gateways.internal.envoyDeployment }}
+      envoyDeployment:
+        {{- if .replicas }}
+        replicas: {{ .replicas }}
+        {{- end }}
+        {{- if .container }}
+        container:
+          {{- if .container.resources }}
+          resources:
+            {{- .container.resources | toYaml | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       envoyService:
         annotations:
           {{- .Values.gateways.internal.serviceAnnotations | toYaml | nindent 10 }}

--- a/components/envoy-configs/values.schema.json
+++ b/components/envoy-configs/values.schema.json
@@ -27,6 +27,48 @@
             "serviceAnnotations": {
               "type": "object",
               "description": "Annotations to be placed on the Service generated for this gateway"
+            },
+            "externalTrafficPolicy": {
+              "type": "string",
+              "description": "External traffic policy for the gateway service",
+              "enum": ["Cluster", "Local"]
+            },
+            "envoyDeployment": {
+              "type": "object",
+              "description": "Configuration for the Envoy proxy deployment pods",
+              "properties": {
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Number of Envoy proxy pod replicas"
+                },
+                "container": {
+                  "type": "object",
+                  "description": "Container-level configuration for the Envoy proxy",
+                  "properties": {
+                    "resources": {
+                      "type": "object",
+                      "description": "Resource requests and limits for the Envoy proxy container",
+                      "properties": {
+                        "requests": {
+                          "type": "object",
+                          "properties": {
+                            "cpu": { "type": "string" },
+                            "memory": { "type": "string" }
+                          }
+                        },
+                        "limits": {
+                          "type": "object",
+                          "properties": {
+                            "cpu": { "type": "string" },
+                            "memory": { "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "required": [
@@ -55,6 +97,48 @@
             "serviceAnnotations": {
               "type": "object",
               "description": "Annotations to be placed on the Service generated for this gateway"
+            },
+            "externalTrafficPolicy": {
+              "type": "string",
+              "description": "External traffic policy for the gateway service",
+              "enum": ["Cluster", "Local"]
+            },
+            "envoyDeployment": {
+              "type": "object",
+              "description": "Configuration for the Envoy proxy deployment pods",
+              "properties": {
+                "replicas": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Number of Envoy proxy pod replicas"
+                },
+                "container": {
+                  "type": "object",
+                  "description": "Container-level configuration for the Envoy proxy",
+                  "properties": {
+                    "resources": {
+                      "type": "object",
+                      "description": "Resource requests and limits for the Envoy proxy container",
+                      "properties": {
+                        "requests": {
+                          "type": "object",
+                          "properties": {
+                            "cpu": { "type": "string" },
+                            "memory": { "type": "string" }
+                          }
+                        },
+                        "limits": {
+                          "type": "object",
+                          "properties": {
+                            "cpu": { "type": "string" },
+                            "memory": { "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           },
           "required": [

--- a/components/nova/values.yaml
+++ b/components/nova/values.yaml
@@ -95,8 +95,15 @@ conf:
         - ServerGroupAffinityFilter
         - JsonFilter
   nova_api_uwsgi:
+    # JIRA:PUC-2007 - tuning the osapi to survive bursts of concurrent requests.
+    # Under load the default 2 uWSGI processes + 100-deep listen queue filled up,
+    # causing connection refusals and liveness probe failures (crash loop).
     uwsgi:
-      processes: 2
+      # more worker processes to serve concurrent requests
+      processes: 8
+      # deeper listen backlog so bursts queue instead of getting refused.
+      # NOTE: values above the node's net.core.somaxconn are silently capped.
+      listen: 1024
 
     # Enable oslo.messaging notifications for Argo Events integration
     oslo_messaging_notifications:
@@ -205,11 +212,38 @@ pod:
         # this should be set to no more than (pod.replicas.osapi - 1)
         # usually set on per-deployment basis.
         min_available: 0
+  # JIRA:PUC-2007 - loosen the osapi liveness probe so a slow response during a
+  # burst of load doesn't trigger a destructive pod restart. A liveness probe
+  # should detect a dead process, not a busy one. Readiness failing under load
+  # is fine (pulls the pod from rotation briefly); liveness failing restarts it.
+  probes:
+    api:
+      default:
+        liveness:
+          enabled: true
+          params:
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 6
+        readiness:
+          enabled: true
+          params:
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
   resources:
     enabled: true
     api:
+      # JIRA:PUC-2007 - raise osapi resources. Heavy all_tenants queries with 8
+      # uWSGI workers need more headroom than the default 2Gi limit / 100m request.
       requests:
-        memory: "256Mi"
+        cpu: "500m"
+        memory: "512Mi"
+      limits:
+        cpu: "4"
+        memory: "2Gi"
     conductor:
       requests:
         memory: "256Mi"


### PR DESCRIPTION
WITHOUT THESE CHANGES:

```
 hey -n 1000 -c 100 -t 60 \
  -H "X-Auth-Token: $TOKEN" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json" \
  "https://nova.{dev}/v2.1/servers/detail?all_tenants=1"


Summary:
  Total:	88.2530 secs
  Slowest:	19.5282 secs
  Fastest:	0.1165 secs
  Average:	7.4501 secs
  Requests/sec:	11.3311

  Total data:	7561162 bytes
  Size/request:	7561 bytes

Response time histogram:
  0.116 [1]	|
  2.058 [123]	|■■■■■■■■■■
  3.999 [47]	|■■■■
  5.940 [69]	|■■■■■■
  7.881 [139]	|■■■■■■■■■■■
  9.822 [500]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  11.764 [26]	|■■
  13.705 [24]	|■■
  15.646 [26]	|■■
  17.587 [25]	|■■
  19.528 [20]	|■■


Latency distribution:
  10%% in 0.3598 secs
  25%% in 6.3442 secs
  50%% in 8.0593 secs
  75%% in 8.3804 secs
  90%% in 10.9262 secs
  95%% in 15.1646 secs
  99%% in 18.5521 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0969 secs, 0.0000 secs, 1.2773 secs
  DNS-lookup:	0.0086 secs, 0.0000 secs, 0.0886 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0012 secs
  resp wait:	7.3530 secs, 0.1163 secs, 19.5281 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0018 secs

Status code distribution:
  [200]	706 responses
  [503]	294 responses
```

WITH THESES CHANGES:

```
 hey -n 1000 -c 100 -t 60 \
  -H "X-Auth-Token: $TOKEN" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json" \
  "https://nova.{dev}/v2.1/servers/detail?all_tenants=1"


Summary:
  Total:	21.9174 secs
  Slowest:	7.5816 secs
  Fastest:	0.6259 secs
  Average:	2.0745 secs
  Requests/sec:	45.6259

  Total data:	10660000 bytes
  Size/request:	10660 bytes

Response time histogram:
  0.626 [1]	|
  1.321 [16]	|■
  2.017 [836]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  2.713 [39]	|■■
  3.408 [17]	|■
  4.104 [13]	|■
  4.799 [15]	|■
  5.495 [23]	|■
  6.190 [15]	|■
  6.886 [18]	|■
  7.582 [7]	|


Latency distribution:
  10%% in 1.5871 secs
  25%% in 1.6538 secs
  50%% in 1.7143 secs
  75%% in 1.8331 secs
  90%% in 2.9951 secs
  95%% in 5.1683 secs
  99%% in 6.8246 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0907 secs, 0.0000 secs, 1.1865 secs
  DNS-lookup:	0.0078 secs, 0.0000 secs, 0.0791 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0010 secs
  resp wait:	1.9836 secs, 0.6258 secs, 6.8937 secs
  resp read:	0.0001 secs, 0.0000 secs, 0.0002 secs

Status code distribution:
  [200]	1000 responses
```