### PR TITLE
feat(understack-workflows): add enroll-dcx-netdev command

### DIFF
--- a/python/understack-workflows/pyproject.toml
+++ b/python/understack-workflows/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pydantic>=2,<3",
     "pynautobot>=3,<4",
     "python-ironicclient>=6,<7",
+    "requests>=2,<3",
     "sushy>=5.3.0,<6",
     "kubernetes==33.1.0",
     "netapp-ontap==9.17.1.0",
@@ -32,6 +33,7 @@ dependencies = [
 [project.scripts]
 bmc-kube-password = "understack_workflows.main.bmc_display_password:main"
 bmc-password = "understack_workflows.main.print_bmc_password:main"
+enroll-dcx-netdev = "understack_workflows.main.enroll_dcx_netdev:main"
 enroll-fw = "understack_workflows.main.enroll_fw:main"
 enroll-netdev = "understack_workflows.main.enroll_netdev:main"
 enroll-server = "understack_workflows.main.enroll_server:main"

--- a/python/understack-workflows/tests/test_dcx_enroll.py
+++ b/python/understack-workflows/tests/test_dcx_enroll.py
@@ -1,0 +1,255 @@
+import pytest
+
+from understack_workflows.dcx import enroll as dcx_enroll
+from understack_workflows.dcx.client import DcxClient
+
+DEVICE_NUMBER = 1383170
+
+# Shaped like GET /devices/{id}/switch_ports: one DRACNet (management) port and
+# two Public (25G data) ports on a switch pair.
+SWITCH_PORTS = [
+    {
+        "switch_port": {
+            "name": "fa0/10",
+            "vlans": [],
+            "native_vlan": None,
+            "interface_type": "DRACNet",
+            "port_number": 10,
+            "switch_name": "f8-41-1d.iad3",
+        }
+    },
+    {
+        "switch_port": {
+            "name": "fa0/1",
+            "vlans": [3800],
+            "native_vlan": 3800,
+            "interface_type": "Public",
+            "port_number": 1,
+            "switch_name": "f8-41-2.iad3",
+        }
+    },
+    {
+        "switch_port": {
+            "name": "fa0/16",
+            "vlans": [],
+            "native_vlan": 1,
+            "interface_type": "Public",
+            "port_number": 16,
+            "switch_name": "f8-42-2.iad3",
+        }
+    },
+]
+
+# Shaped like GET /devices/locations_and_ports?device_numbers={id}
+LOCATION = {
+    "device_number": str(DEVICE_NUMBER),
+    "container": "F8-41",
+    "starting_space": "19.0",
+    "data_center": "IAD3",
+}
+
+
+def build():
+    return dcx_enroll.build_enroll_kwargs(
+        # argparse hands us the device number as a string; enroll should coerce
+        # external_cmdb_id back to an int.
+        device_number=str(DEVICE_NUMBER),
+        switch_ports=SWITCH_PORTS,
+        location=LOCATION,
+        name_prefix="Appliance",
+    )
+
+
+def test_node_name_and_cmdb_and_resource_class():
+    kwargs = build()
+    assert kwargs["name"] == "Appliance-1383170"
+    assert kwargs["external_cmdb_id"] == DEVICE_NUMBER
+    assert kwargs["resource_class"] == "appliance"
+
+
+def test_only_public_ports_are_enrolled():
+    kwargs = build()
+    interfaces = {port["intf"] for port in kwargs["ports"]}
+    # DRACNet (Ethernet1/10) is excluded; only the two Public ports remain.
+    assert interfaces == {"Ethernet1/1", "Ethernet1/16"}
+    assert len(kwargs["ports"]) == 2
+
+
+def test_port_fields():
+    kwargs = build()
+    by_switch = {port["switch"]: port for port in kwargs["ports"]}
+
+    # switch_info is the fully-qualified switch name.
+    port = by_switch["f8-41-2.iad3.rackspace.net"]
+    assert port["label"] == "fa0/1"
+    assert port["intf"] == "Ethernet1/1"
+
+    port = by_switch["f8-42-2.iad3.rackspace.net"]
+    assert port["label"] == "fa0/16"
+    assert port["intf"] == "Ethernet1/16"
+
+
+def test_physical_network_is_derived():
+    kwargs = build()
+    # The data switches are a -2 pair, so the suffix is kept in the group name.
+    assert kwargs["physical_network"] == "f8-41-2/f8-42-2-network"
+
+
+@pytest.mark.parametrize(
+    ("switch_names", "expected"),
+    [
+        (["f8-40-1.iad3", "f8-40-2.iad3"], "f8-40-network"),
+        (["f8-41-1.iad3", "f8-42-1.iad3"], "f8-41/f8-42-network"),
+        (["f8-41-2.iad3", "f8-42-2.iad3"], "f8-41-2/f8-42-2-network"),
+        (["f8-41-3.iad3", "f8-42-3.iad3"], "f8-41-3/f8-42-3-network"),
+    ],
+)
+def test_derive_physnet(switch_names, expected):
+    assert dcx_enroll.derive_physnet(switch_names) == expected
+
+
+def test_physical_network_override():
+    kwargs = dcx_enroll.build_enroll_kwargs(
+        device_number=DEVICE_NUMBER,
+        switch_ports=SWITCH_PORTS,
+        location=LOCATION,
+        name_prefix="Appliance",
+        physical_network="custom-network",
+    )
+    assert kwargs["physical_network"] == "custom-network"
+
+
+def test_resource_class_override():
+    kwargs = dcx_enroll.build_enroll_kwargs(
+        device_number=DEVICE_NUMBER,
+        switch_ports=SWITCH_PORTS,
+        location=LOCATION,
+        name_prefix="Appliance",
+        resource_class="special",
+    )
+    assert kwargs["resource_class"] == "special"
+
+
+def test_extra_carries_rack_and_position():
+    kwargs = build()
+    assert kwargs["extra"] == {
+        "external_cmdb_id": DEVICE_NUMBER,
+        "rack": "F8-41",
+        "position": 19,
+    }
+
+
+def test_no_public_ports_raises():
+    with pytest.raises(ValueError, match="no Public switch ports"):
+        dcx_enroll.build_enroll_kwargs(
+            device_number=DEVICE_NUMBER,
+            switch_ports=[SWITCH_PORTS[0]],
+            location=LOCATION,
+            name_prefix="Appliance",
+        )
+
+
+def test_deterministic_mac_is_stable_and_locally_administered():
+    mac1 = dcx_enroll.deterministic_mac(DEVICE_NUMBER, "f8-41-2.iad3", 1)
+    mac2 = dcx_enroll.deterministic_mac(DEVICE_NUMBER, "f8-41-2.iad3", 1)
+    assert mac1 == mac2
+
+    first_octet = int(mac1.split(":")[0], 16)
+    assert first_octet & 0x01 == 0  # unicast
+    assert first_octet & 0x02 == 0x02  # locally administered
+
+
+def test_deterministic_mac_is_unique_per_port():
+    mac1 = dcx_enroll.deterministic_mac(DEVICE_NUMBER, "f8-41-2.iad3", 1)
+    mac2 = dcx_enroll.deterministic_mac(DEVICE_NUMBER, "f8-42-2.iad3", 16)
+    assert mac1 != mac2
+
+
+def test_macs_reproducible_across_builds():
+    assert build()["ports"] == build()["ports"]
+
+
+def test_rack_of():
+    assert dcx_enroll.rack_of("f8-41-2.iad3") == "f8-41"
+
+
+def test_rack_of_bad_name_raises():
+    with pytest.raises(ValueError, match="Unexpected switch name"):
+        dcx_enroll.rack_of("nodashes")
+
+
+def test_dcx_client_switch_ports(requests_mock):
+    client = DcxClient(auth_token="secret", api_url="https://dcx.example")
+    requests_mock.get(
+        "https://dcx.example/devices/1383170/switch_ports",
+        json=SWITCH_PORTS,
+    )
+    assert client.switch_ports(1383170) == SWITCH_PORTS
+    assert requests_mock.last_request.headers["X-Auth-Token"] == "secret"
+
+
+def test_dcx_client_location(requests_mock):
+    client = DcxClient(auth_token="secret", api_url="https://dcx.example")
+    requests_mock.get(
+        "https://dcx.example/devices/locations_and_ports",
+        json=[LOCATION],
+    )
+    assert client.location(1383170) == LOCATION
+    assert requests_mock.last_request.qs["device_numbers"] == ["1383170"]
+
+
+def test_dcx_client_location_empty_raises(requests_mock):
+    client = DcxClient(auth_token="secret", api_url="https://dcx.example")
+    requests_mock.get(
+        "https://dcx.example/devices/locations_and_ports",
+        json=[],
+    )
+    with pytest.raises(ValueError, match="no location"):
+        client.location(1383170)
+
+
+class FakeDcxClient(DcxClient):
+    def __init__(self):
+        pass
+
+    def switch_ports(self, device_number):
+        return SWITCH_PORTS
+
+    def location(self, device_number):
+        return LOCATION
+
+
+def test_enroll_from_dcx_calls_reconciler(monkeypatch):
+    captured = {}
+
+    def fake_enroll(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(dcx_enroll.netdev_reconciler, "enroll", fake_enroll)
+
+    result = dcx_enroll.enroll_from_dcx(
+        client=FakeDcxClient(),
+        device_number=DEVICE_NUMBER,
+        name_prefix="Appliance",
+    )
+
+    assert captured == result
+    assert captured["name"] == "Appliance-1383170"
+    assert captured["physical_network"] == "f8-41-2/f8-42-2-network"
+    assert len(captured["ports"]) == 2
+
+
+def test_enroll_from_dcx_dry_run_does_not_enroll(monkeypatch):
+    def fail_enroll(**kwargs):
+        raise AssertionError("enroll must not be called on a dry run")
+
+    monkeypatch.setattr(dcx_enroll.netdev_reconciler, "enroll", fail_enroll)
+
+    result = dcx_enroll.enroll_from_dcx(
+        client=FakeDcxClient(),
+        device_number=DEVICE_NUMBER,
+        name_prefix="Appliance",
+        dry_run=True,
+    )
+
+    assert result["name"] == "Appliance-1383170"

--- a/python/understack-workflows/understack_workflows/dcx/client.py
+++ b/python/understack-workflows/understack_workflows/dcx/client.py
@@ -1,0 +1,47 @@
+import logging
+from functools import cached_property
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class DcxClient:
+    def __init__(self, auth_token: str, api_url: str) -> None:
+        """Simple read-only client for the DCX inventory API.
+
+        The auth token is sent as the X-Auth-Token header and is never logged.
+        """
+        self.token = auth_token
+        self.api_url = api_url.rstrip("/")
+
+    @cached_property
+    def client(self) -> requests.Session:
+        session = requests.Session()
+        session.headers = {"X-Auth-Token": self.token}
+        return session
+
+    def switch_ports(self, device_number: int | str) -> list[dict]:
+        """Return the raw switch_port entries for a device.
+
+        The response is a list of ``{"switch_port": {...}}`` objects.
+        """
+        url = f"{self.api_url}/devices/{device_number}/switch_ports"
+        logger.info("Fetching DCX switch_ports for device %s", device_number)
+        response = self.client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    def location(self, device_number: int | str) -> dict:
+        """Return the location record for a device (rack/space/data center).
+
+        The response is a list; we return the single matching entry.
+        """
+        url = f"{self.api_url}/devices/locations_and_ports"
+        logger.info("Fetching DCX location for device %s", device_number)
+        response = self.client.get(url, params={"device_numbers": device_number})
+        response.raise_for_status()
+        records = response.json()
+        if not records:
+            raise ValueError(f"DCX returned no location for device {device_number}")
+        return records[0]

--- a/python/understack-workflows/understack_workflows/dcx/enroll.py
+++ b/python/understack-workflows/understack_workflows/dcx/enroll.py
@@ -1,0 +1,178 @@
+import hashlib
+import logging
+
+from understack_workflows import netdev_reconciler
+from understack_workflows.dcx.client import DcxClient
+
+logger = logging.getLogger(__name__)
+
+# DCX interface_type of the tenant-facing data ports we enroll. The DRACNet
+# (iDRAC/management) port is intentionally excluded: it lives on a "bmc"
+# category switch and does not belong to the "-network" physical_network.
+DATA_INTERFACE_TYPE = "Public"
+
+# Switch-side interface name prefix. DCX only reports a bare port number, but
+# our fabric names ports Ethernet1/<n>.
+INTERFACE_PREFIX = "Ethernet1"
+
+# DCX reports the bare switch hostname; append this to form the fully-qualified
+# name expected for local_link_connection.switch_info.
+SWITCH_DOMAIN = "rackspace.net"
+
+# Switch suffixes that are folded into the VLAN group name when a node's data
+# switches all share one of them.
+MULTI_LEAF_SUFFIXES = frozenset({"2", "3", "4", "5", "6"})
+
+
+def deterministic_mac(*parts: object) -> str:
+    """Return a stable locally-administered unicast MAC for the given parts.
+
+    We have no real NIC MACs for these appliances, so we synthesise one from
+    stable identity (device number + switch + port). Being deterministic keeps
+    re-runs idempotent: the reconciler matches ports by name and would rewrite
+    the address on every run if we used a random value.
+    """
+    digest = hashlib.sha256(":".join(str(p) for p in parts).encode()).digest()
+    octets = bytearray(digest[:6])
+    # Clear the multicast bit and set the locally-administered bit so the
+    # address is a valid, unmistakably-synthetic unicast MAC.
+    octets[0] = (octets[0] & 0xFE) | 0x02
+    return ":".join(f"{octet:02x}" for octet in octets)
+
+
+def parse_switch_name(switch_name: str) -> tuple[str, str]:
+    """Split a switch hostname into ``(rack, suffix)``.
+
+    ``f8-41-2.iad3`` -> ``("f8-41", "2")``.
+    """
+    short_name = switch_name.split(".")[0]
+    rack, _, suffix = short_name.rpartition("-")
+    if not rack or not suffix:
+        raise ValueError(
+            f"Unexpected switch name {switch_name!r}; expected "
+            "<rack>-<suffix>.<data_center>"
+        )
+    return rack, suffix
+
+
+def rack_of(switch_name: str) -> str:
+    """Derive the rack name from a switch hostname: ``f8-41-2.iad3`` -> ``f8-41``."""
+    return parse_switch_name(switch_name)[0]
+
+
+def derive_physnet(switch_names: list[str]) -> str:
+    """Derive the physical_network (VLAN group) name from the data switches.
+
+    Reimplemented locally to avoid pulling in the ironic-understack package and
+    its oslo.config; it must stay in sync with that package's VLAN group naming
+    convention.
+    """
+    parsed = [parse_switch_name(name) for name in switch_names]
+    racks = {rack for rack, _ in parsed}
+    suffixes = {suffix for _, suffix in parsed}
+    if len(suffixes) == 1 and suffixes <= MULTI_LEAF_SUFFIXES:
+        (suffix,) = suffixes
+        racks = {f"{rack}-{suffix}" for rack in racks}
+    return "/".join(sorted(racks)) + "-network"
+
+
+def _data_ports(switch_ports: list[dict]) -> list[dict]:
+    """Return the inner switch_port dicts for the data (Public) ports, sorted."""
+    ports = [
+        entry["switch_port"]
+        for entry in switch_ports
+        if entry.get("switch_port", {}).get("interface_type") == DATA_INTERFACE_TYPE
+    ]
+    return sorted(ports, key=lambda sp: sp["switch_name"])
+
+
+def build_enroll_kwargs(
+    *,
+    device_number: int | str,
+    switch_ports: list[dict],
+    location: dict,
+    name_prefix: str,
+    physical_network: str | None = None,
+    resource_class: str | None = None,
+) -> dict:
+    """Transform raw DCX data into keyword args for ``netdev_reconciler.enroll``.
+
+    ``resource_class`` defaults to the lowercased ``name_prefix`` (e.g.
+    ``Appliance`` -> ``appliance``). ``physical_network`` is derived from the data
+    switches unless explicitly supplied.
+    """
+    data_ports = _data_ports(switch_ports)
+    if not data_ports:
+        raise ValueError(
+            f"Device {device_number} has no {DATA_INTERFACE_TYPE} switch ports"
+        )
+
+    ports = []
+    for switch_port in data_ports:
+        switch_name = switch_port["switch_name"]
+        port_number = switch_port["port_number"]
+        ports.append(
+            {
+                # DCX's port name (e.g. fa0/1) is the device-side interface and
+                # is a stable, unique per-port identity. It becomes the Ironic
+                # port name node_name:label (e.g. Appliance-1383170:fa0/1).
+                "label": switch_port["name"],
+                "mac": deterministic_mac(device_number, switch_name, port_number),
+                # local_link_connection.switch_info must be the fully-qualified
+                # switch name for undersync to match it in Nautobot.
+                "switch": f"{switch_name}.{SWITCH_DOMAIN}",
+                "intf": f"{INTERFACE_PREFIX}/{port_number}",
+            }
+        )
+
+    physnet = physical_network or derive_physnet([p["switch"] for p in ports])
+
+    # A DCX device number is an integer; the CLI hands it to us as a string, so
+    # coerce it for external_cmdb_id (the node name keeps the string form).
+    external_cmdb_id = int(device_number)
+
+    return {
+        "name": f"{name_prefix}-{device_number}",
+        "physical_network": physnet,
+        "ports": ports,
+        "external_cmdb_id": external_cmdb_id,
+        "resource_class": resource_class or name_prefix.lower(),
+        "extra": {
+            "external_cmdb_id": external_cmdb_id,
+            "rack": location["container"],
+            # DCX reports starting_space as a float (e.g. 19.0); a rack unit is
+            # a whole number, so store it as an int.
+            "position": int(float(location["starting_space"])),
+        },
+    }
+
+
+def enroll_from_dcx(
+    *,
+    client: DcxClient,
+    device_number: int | str,
+    name_prefix: str,
+    physical_network: str | None = None,
+    resource_class: str | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Fetch a device from DCX and enroll it as a netdev Ironic node.
+
+    Returns the computed enroll kwargs (useful for dry-run/logging). When
+    ``dry_run`` is set the Ironic API is not touched.
+    """
+    kwargs = build_enroll_kwargs(
+        device_number=device_number,
+        switch_ports=client.switch_ports(device_number),
+        location=client.location(device_number),
+        name_prefix=name_prefix,
+        physical_network=physical_network,
+        resource_class=resource_class,
+    )
+
+    if dry_run:
+        logger.info("[dry-run] Would enroll device %s: %s", device_number, kwargs)
+        return kwargs
+
+    netdev_reconciler.enroll(**kwargs)
+    return kwargs

--- a/python/understack-workflows/understack_workflows/main/enroll_dcx_netdev.py
+++ b/python/understack-workflows/understack_workflows/main/enroll_dcx_netdev.py
@@ -1,0 +1,88 @@
+import argparse
+import os
+
+from understack_workflows import helpers
+from understack_workflows.dcx.client import DcxClient
+from understack_workflows.dcx.enroll import enroll_from_dcx
+
+DCX_TOKEN_ENV = "DCX_TOKEN"  # noqa: S105 (env var name, not a secret)
+DCX_API_ENV = "DCX_API"
+
+
+def main() -> None:
+    """Create netdev baremetal nodes from DCX inventory data.
+
+    For each device number, fetch its switch ports and location from DCX, then
+    create (or idempotently reconcile) a netdev Ironic node named
+    ``<name-prefix>-<device_number>`` with a baremetal port per data (Public)
+    port. Requires the DCX auth token in the ``DCX_TOKEN`` environment variable,
+    the DCX API base URL via ``--dcx-api`` (or the ``DCX_API`` environment
+    variable), and (for a real run) ``OS_CLOUD`` set for the Ironic connection.
+    """
+    helpers.setup_logger()
+    args = argument_parser().parse_args()
+
+    token = os.getenv(DCX_TOKEN_ENV)
+    if not token:
+        raise SystemExit(f"{DCX_TOKEN_ENV} environment variable must be set")
+
+    api_url = args.dcx_api or os.getenv(DCX_API_ENV)
+    if not api_url:
+        raise SystemExit(f"DCX API base URL must be set via --dcx-api or {DCX_API_ENV}")
+
+    client = DcxClient(auth_token=token, api_url=api_url)
+
+    for device_number in args.device_number:
+        enroll_from_dcx(
+            client=client,
+            device_number=device_number,
+            name_prefix=args.name_prefix,
+            physical_network=args.physical_network,
+            resource_class=args.resource_class,
+            dry_run=args.dry_run,
+        )
+
+
+def argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=os.path.basename(__file__),
+        description="Enroll netdev baremetal nodes from DCX inventory data",
+    )
+    parser.add_argument(
+        "device_number",
+        nargs="+",
+        help="One or more DCX device numbers (external_cmdb_id)",
+    )
+    parser.add_argument(
+        "--name-prefix",
+        required=True,
+        help="Node name prefix, e.g. Appliance -> Appliance-<device_number>",
+    )
+    parser.add_argument(
+        "--physical-network",
+        required=False,
+        default=None,
+        help="Override the physical_network (default: derived from the switches)",
+    )
+    parser.add_argument(
+        "--resource-class",
+        required=False,
+        default=None,
+        help="Ironic resource class (default: lowercased --name-prefix)",
+    )
+    parser.add_argument(
+        "--dcx-api",
+        required=False,
+        default=None,
+        help=f"DCX API base URL (falls back to the {DCX_API_ENV} env var)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and build the payload but do not touch Ironic",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/python/understack-workflows/uv.lock
+++ b/python/understack-workflows/uv.lock
@@ -1103,6 +1103,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pynautobot" },
     { name = "python-ironicclient" },
+    { name = "requests" },
     { name = "sushy" },
     { name = "tenacity" },
 ]
@@ -1127,6 +1128,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pynautobot", specifier = ">=3,<4" },
     { name = "python-ironicclient", specifier = ">=6,<7" },
+    { name = "requests", specifier = ">=2,<3" },
     { name = "sushy", specifier = ">=5.3.0,<6" },
     { name = "tenacity", specifier = ">=8.0.0" },
 ]


### PR DESCRIPTION
Onboard baremetal appliances into Ironic from Rackspace
DCX inventory data alone, when there is no BMC access and no NIC MACs.

The new `enroll-dcx-netdev <device_number> --name-prefix Thing` command
fetches a device's switch ports and location from the DCX API, then
reuses `netdev_reconciler.enroll()` to create (idempotently) a netdev
Ironic node `<prefix>-<device_number>` with a baremetal port per data
port.

Per port it sets local_link_connection (placeholder switch_id,
switch_info from the DCX switch hostname, port_id Ethernet1/<n>),
category=network, a deterministic locally-administered MAC (stable
across re-runs), and a physical_network derived from the switch pair.
The node's extra carries external_cmdb_id,
rack, and position. resource_class defaults to the lowercased name
prefix.

DCX auth token is read from DCX_TOKEN; OS_CLOUD selects the Ironic
target. --dry-run builds and logs the payload without touching Ironic.
