### PR TITLE
chore(understack-workflows): remove leftover [tool.peotry] section

### DIFF
--- a/python/understack-workflows/pyproject.toml
+++ b/python/understack-workflows/pyproject.toml
@@ -69,9 +69,6 @@ include = ["understack_workflows"]
 [tool.hatch.build.targets.wheel]
 include = ["understack_workflows"]
 
-[tool.peotry.group.test]
-optional = true
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra --cov=understack_workflows"


### PR DESCRIPTION
## What does this change do?

Removes a leftover `[tool.peotry.group.test]` section from
`python/understack-workflows/pyproject.toml`.

The section is dead configuration:

- The key is misspelled (`peotry`), so nothing reads it under that name.
- Correcting the spelling would not help either — this project builds with
  Hatchling and resolves with uv, not Poetry.
- Test dependencies are already declared properly via PEP 735
  `[dependency-groups]` with `[tool.uv] default-groups = ["test"]` a few lines
  above, so the intent it was expressing is already covered.

It looks like a remnant of an earlier Poetry setup. Removing it avoids
suggesting to readers that Poetry groups are in use here.

No behaviour change.

## Upgrade impact

- [ ] This change requires operator action to upgrade.
