### PR TITLE
feat: Confirm the OVN maintenance-worker periodic (ovn_maintenance_periodics) fires in our deployment PUC-2030

### DIFF
--- a/components/images-openstack.yaml
+++ b/components/images-openstack.yaml
@@ -45,6 +45,7 @@ images:
     neutron_openvswitch_agent: "ghcr.io/rackerlabs/understack/neutron:2026.1"
     neutron_server: "ghcr.io/rackerlabs/understack/neutron:2026.1"
     neutron_rpc_server: "ghcr.io/rackerlabs/understack/neutron:2026.1"
+    neutron_ovn_maintenance_worker: "ghcr.io/rackerlabs/understack/neutron:2026.1"
     neutron_bagpipe_bgp: "ghcr.io/rackerlabs/understack/neutron:2026.1"
     neutron_netns_cleanup_cron: "ghcr.io/rackerlabs/understack/neutron:2026.1"
 

--- a/components/neutron/configmap-neutron-bin.yaml
+++ b/components/neutron/configmap-neutron-bin.yaml
@@ -1624,6 +1624,25 @@ data:
     }
 
     $COMMAND
+  neutron-ovn-maintenance-worker.sh: |
+    #!/bin/bash
+
+    set -ex
+    COMMAND="${@:-start}"
+
+    function start () {
+      exec neutron-ovn-maintenance-worker \
+            --config-file /etc/neutron/neutron.conf \
+            --config-file /tmp/pod-shared/ovn.ini \
+            --config-file /etc/neutron/plugins/ml2/ml2_conf.ini \
+            --config-dir /etc/neutron/neutron.conf.d
+    }
+
+    function stop () {
+      kill -TERM 1
+    }
+
+    $COMMAND
   neutron-server.sh: |
     #!/bin/bash
 

--- a/components/neutron/values.yaml
+++ b/components/neutron/values.yaml
@@ -127,6 +127,9 @@ pod:
     neutron_server:
       - secret:
           name: neutron-ks-etc
+    neutron_ovn_maintenance_worker:
+      - secret:
+          name: neutron-ks-etc
 
   use_fqdn:
     neutron_agent: false
@@ -179,6 +182,9 @@ dependencies:
     rpc_server:
       jobs:
         - neutron-db-sync
+    ovn_maintenance_worker:
+      jobs:
+        - neutron-db-sync
     ironic_agent:
       jobs:
         - neutron-db-sync
@@ -204,6 +210,10 @@ manifests:
   daemonset_metadata_agent: false
   daemonset_ovs_agent: false
   deployment_rpc_server: false
+  deployment_ovn_maintenance_worker: true
+  # The janitor only needs the OVN maintenance worker. The chart enables the
+  # generic periodic worker by default; disable it.
+  deployment_periodic_worker: false
   daemonset_sriov_agent: false
   daemonset_l2gw_agent: false
   daemonset_bagpipe_bgp: false

--- a/python/neutron-understack/neutron_understack/l3_router/vrf.py
+++ b/python/neutron-understack/neutron_understack/l3_router/vrf.py
@@ -15,6 +15,7 @@ from oslo_serialization import jsonutils
 
 from neutron_understack import config
 from neutron_understack import evpn_compat
+from neutron_understack import maintenance as understack_maintenance
 from neutron_understack.api.definitions import understack_vni as apidef
 from neutron_understack.l3_router import understack_vni_db
 
@@ -128,6 +129,12 @@ class UnderstackVniPlugin(service_base.ServicePluginBase):
 
     def get_plugin_description(self):
         return "Understack router VNI allocation plugin"
+
+    def ovn_maintenance_periodics(self, ovn_client):
+        LOG.warning("NETDEV ovn_maintenance_periodics called")
+        return [
+            understack_maintenance.NetdevRouterMaintenancePeriodics(self, ovn_client)
+        ]
 
     @staticmethod
     @resource_extend.extends([apidef.COLLECTION_NAME])

--- a/python/neutron-understack/neutron_understack/maintenance.py
+++ b/python/neutron-understack/neutron_understack/maintenance.py
@@ -1,0 +1,41 @@
+"""Periodics run in the OVN maintenance worker.
+
+Proves the mechanism fires end to end (hook discovered, worker runs, once
+cluster-wide) before the real reconciliation logic is added.
+"""
+
+# NOTE: Re-verify these symbols still exist on every neutron upgrade has_lock_periodic
+# and MAINTENANCE_NB_IDL_LOCK_NAME coz they are neutron-internal module.
+from neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb import maintenance
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+RECONCILE_SPACING = 600  # Temp
+
+
+class NetdevRouterMaintenancePeriodics:
+    """Reconcile netdev-router Ironic state from the OVN maintenance worker.
+
+    Body is a no-op log line.
+    """
+
+    def __init__(self, plugin, ovn_client):
+        self._plugin = plugin
+        # Take the maintenance lock so exactly one neutron-server runs these
+        # periodics.
+        LOG.warning(
+            "NETDEV periodic __init__; _nb_idl=%r",
+            getattr(ovn_client, "_nb_idl", "MISSING"),
+        )
+        self._idl = ovn_client._nb_idl.idl
+        self._idl.set_lock(maintenance.MAINTENANCE_NB_IDL_LOCK_NAME)
+
+    @property
+    def has_lock(self):
+        return self._idl.has_lock
+
+    @maintenance.has_lock_periodic(spacing=RECONCILE_SPACING, run_immediately=False)
+    def reconcile_netdev_routers(self):
+        # No-op: proves the periodic is scheduled and fires on exactly one
+        # neutron-server. host= lets us confirm it is not firing per-worker.
+        LOG.debug("netdev-router reconcile: placeholder, no action yet")


### PR DESCRIPTION
https://github.com/rackerlabs/understack/pull/2293  

Neutron chart upgrade introduced  CrashLoopBackOff coz of missing config map . the pr fixes that 
```shell
neutron-ovn-maintenance-worker-6f447d55c9-98w6d                   0/1     CrashLoopBackOff   5 (66s ago)   4m48s
neutron-periodic-worker-774cc5bd67-qbx4x                          0/1     CrashLoopBackOff   5 (60s ago)   4m48s
``` 

```shell
QoS Class:                   Burstable
Node-Selectors:              openstack-control-plane=enabled
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  5m8s                   default-scheduler  Successfully assigned openstack/neutron-ovn-maintenance-worker-6f447d55c9-98w6d to 1327172-hp1
  Normal   Pulling    5m7s                   kubelet            spec.initContainers{init}: Pulling image "quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_noble"
  Normal   Pulled     5m7s                   kubelet            spec.initContainers{init}: Successfully pulled image "quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_noble" in 93ms (93ms including waiting). Image size: 112391032 bytes.
  Normal   Created    5m7s                   kubelet            spec.initContainers{init}: Created container: init
  Normal   Started    5m7s                   kubelet            spec.initContainers{init}: Started container init
  Normal   Pulling    4m33s                  kubelet            spec.initContainers{ovn-neutron-init}: Pulling image "quay.io/airshipit/neutron:2026.1-ubuntu_noble"
  Normal   Started    4m26s                  kubelet            spec.initContainers{ovn-neutron-init}: Started container ovn-neutron-init
  Normal   Created    4m26s                  kubelet            spec.initContainers{ovn-neutron-init}: Created container: ovn-neutron-init
  Normal   Pulled     4m26s                  kubelet            spec.initContainers{ovn-neutron-init}: Successfully pulled image "quay.io/airshipit/neutron:2026.1-ubuntu_noble" in 93ms (7.122s including waiting). Image size: 157245781 bytes.
  Normal   Pulled     4m24s                  kubelet            spec.containers{neutron-ovn-maintenance-worker}: Successfully pulled image "quay.io/airshipit/neutron:2026.1-ubuntu_noble" in 112ms (252ms including waiting). Image size: 157245781 bytes.
  Normal   Pulled     4m23s                  kubelet            spec.containers{neutron-ovn-maintenance-worker}: Successfully pulled image "quay.io/airshipit/neutron:2026.1-ubuntu_noble" in 90ms (189ms including waiting). Image size: 157245781 bytes.
  Normal   Pulled     4m7s                   kubelet            spec.containers{neutron-ovn-maintenance-worker}: Successfully pulled image "quay.io/airshipit/neutron:2026.1-ubuntu_noble" in 728ms (728ms including waiting). Image size: 157245781 bytes.
  Normal   Pulled     3m38s                  kubelet            spec.containers{neutron-ovn-maintenance-worker}: Successfully pulled image "quay.io/airshipit/neutron:2026.1-ubuntu_noble" in 114ms (114ms including waiting). Image size: 157245781 bytes.
  Normal   Created    2m55s (x5 over 4m24s)  kubelet            spec.containers{neutron-ovn-maintenance-worker}: Created container: neutron-ovn-maintenance-worker
  Normal   Pulled     2m55s                  kubelet            spec.containers{neutron-ovn-maintenance-worker}: Successfully pulled image "quay.io/airshipit/neutron:2026.1-ubuntu_noble" in 106ms (106ms including waiting). Image size: 157245781 bytes.
  Normal   Pulling    86s (x6 over 4m24s)    kubelet            spec.containers{neutron-ovn-maintenance-worker}: Pulling image "quay.io/airshipit/neutron:2026.1-ubuntu_noble"
  Warning  Failed     86s (x6 over 4m24s)    kubelet            spec.containers{neutron-ovn-maintenance-worker}: Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/tmp/neutron-ovn-maintenance-worker.sh": is a directory
  Normal   Pulled     86s                    kubelet            spec.containers{neutron-ovn-maintenance-worker}: Successfully pulled image "quay.io/airshipit/neutron:2026.1-ubuntu_noble" in 168ms (168ms including waiting). Image size: 157245781 bytes.
  Warning  BackOff    18s (x19 over 4m22s)   kubelet            spec.containers{neutron-ovn-maintenance-worker}: Back-off restarting failed container neutron-ovn-maintenance-worker in pod neutron-ovn-maintenance-worker-6f447d55c9-98w6d_openstack(0c785f7d-9c74-410f-92ec-3b29f03757b1)
Flag --oidc-use-pkce has been deprecated, use --oidc-pkce-method instead. For the most providers, you don't need to set the flag.
Defaulted container "neutron-ovn-maintenance-worker" out of: neutron-ovn-maintenance-worker, init (init), ovn-neutron-init (init)
``` 
(openstack)
## What does this change do?
we see neutron-ovn-maintenance-worker up and running , below are the logs 
## Upgrade impact
 We see the netdev tick , which runs after every 60s 
```shell
2026-09-04 09:33:58.533 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_ha_failover finished in 0.015 seconds
2026-09-04 09:33:58.535 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_lrouter_ports_ext_ids_name_prefix finished in 0.001 seconds
2026-09-04 09:33:58.535 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_lrouter_ports_ext_ids_name_prefix finished in 0.001 seconds
2026-09-04 09:33:58.538 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_mac_aging_settings finished in 0.002 seconds
2026-09-04 09:33:58.538 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_mac_aging_settings finished in 0.002 seconds
2026-09-04 09:33:58.545 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_router_distributed_flag finished in 0.006 seconds
2026-09-04 09:33:58.545 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_router_distributed_flag finished in 0.006 seconds
2026-09-04 09:33:58.546 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_router_static_routes finished in 0.001 seconds
2026-09-04 09:33:58.546 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_router_static_routes finished in 0.001 seconds
2026-09-04 09:33:58.558 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_security_group_with_address_group finished in 0.011 seconds
2026-09-04 09:33:58.558 10 INFO neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] OVN maintenance task update_security_group_with_address_group finished in 0.011 seconds
2026-09-04 09:34:49.495 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
2026-09-04 09:34:49.495 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
2026-09-04 09:35:49.496 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
2026-09-04 09:35:49.496 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
2026-09-04 09:36:49.496 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
2026-09-04 09:36:49.496 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
2026-09-04 09:37:49.496 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
2026-09-04 09:37:49.496 10 WARNING neutron_understack.maintenance [None req-fd3ace59-0bf3-4675-9e69-9caf6cec79f7 - - - - - -] NETDEV reconcile tick (host=neutron-ovn-maintenance-worker-759f7d8784-7qqsx)
``` 