### PR TITLE
feat: include Intel ice DDP firmware in IPA trixie ramdisk

### DIFF
--- a/ironic-images/custom_elements/undercloud-ice-ddp/element-deps
+++ b/ironic-images/custom_elements/undercloud-ice-ddp/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/ironic-images/custom_elements/undercloud-ice-ddp/package-installs.yaml
+++ b/ironic-images/custom_elements/undercloud-ice-ddp/package-installs.yaml
@@ -1,0 +1,15 @@
+# Intel E810/ice Dynamic Device Personalization (DDP) package.
+#
+# Without this the ice driver cannot find /lib/firmware/intel/ice/ddp/ice.pkg
+# and drops every E810 port into Safe Mode, which keeps the NIC firmware
+# LLDP/DCBX agent active (breaking host-side LLDP inspection and causing switch
+# ports to err-disable).
+#
+# On Debian trixie/sid the ice DDP ships in firmware-intel-misc (amd64), which
+# lives in the non-free-firmware component (enable via DIB_DEBIAN_COMPONENTS in
+# the image build environment).
+#
+# NOTE: This element is release-specific. firmware-intel-misc only exists on
+# trixie/sid; on bookworm the ice DDP is in firmware-misc-nonfree instead. Only
+# add this element to trixie (or newer) image definitions.
+firmware-intel-misc:

--- a/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
+++ b/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
@@ -4,11 +4,3 @@ mtr-tiny:
 tcpdump:
 bind9-dnsutils:
 util-linux-extra:
-# Intel E810/ice Dynamic Device Personalization (DDP) package. Without this the
-# ice driver cannot find /lib/firmware/intel/ice/ddp/ice.pkg and drops every
-# E810 port into Safe Mode, which keeps the NIC firmware LLDP/DCBX agent active
-# (breaking host-side LLDP inspection and causing switch ports to err-disable).
-# On Debian trixie/sid the ice DDP ships in firmware-intel-misc (amd64), which
-# lives in the non-free-firmware component (enabled via DIB_DEBIAN_COMPONENTS
-# in the image build environment).
-firmware-intel-misc:

--- a/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
+++ b/ironic-images/custom_elements/undercloud-ipa/package-installs.yaml
@@ -4,3 +4,11 @@ mtr-tiny:
 tcpdump:
 bind9-dnsutils:
 util-linux-extra:
+# Intel E810/ice Dynamic Device Personalization (DDP) package. Without this the
+# ice driver cannot find /lib/firmware/intel/ice/ddp/ice.pkg and drops every
+# E810 port into Safe Mode, which keeps the NIC firmware LLDP/DCBX agent active
+# (breaking host-side LLDP inspection and causing switch ports to err-disable).
+# On Debian trixie/sid the ice DDP ships in firmware-intel-misc (amd64), which
+# lives in the non-free-firmware component (enabled via DIB_DEBIAN_COMPONENTS
+# in the image build environment).
+firmware-intel-misc:

--- a/ironic-images/ipa-debian-trixie.yaml
+++ b/ironic-images/ipa-debian-trixie.yaml
@@ -2,6 +2,10 @@
   environment:
     DISTRO_NAME: 'debian'
     DIB_RELEASE: 'trixie'
+    # Enable non-free-firmware (and contrib/non-free) so firmware-intel-misc,
+    # which provides the Intel E810 ice DDP, is installable. diskimage-builder's
+    # debootstrap defaults DIB_DEBIAN_COMPONENTS to "main" only.
+    DIB_DEBIAN_COMPONENTS: 'main,contrib,non-free,non-free-firmware'
   elements:
   - ironic-python-agent-ramdisk
   - debian-minimal

--- a/ironic-images/ipa-debian-trixie.yaml
+++ b/ironic-images/ipa-debian-trixie.yaml
@@ -15,3 +15,6 @@
   - undercloud-ipa
   - install-static
   - undercloud-proliant-tools
+  # Intel E810 ice DDP (firmware-intel-misc). Trixie-only: the package name
+  # differs on bookworm, so this element must not be added to the bookworm image.
+  - undercloud-ice-ddp


### PR DESCRIPTION
Include the Intel E810 `ice` Dynamic Device Personalization (DDP) package in the IPA trixie ramdisk so E810 (`ice`) NICs load their DDP instead of entering Safe Mode.

## Problem

Without the DDP, the `ice` driver cannot find `/lib/firmware/intel/ice/ddp/ice.pkg` and drops every E810 port into Safe Mode. In Safe Mode the NIC firmware LLDP/DCBX agent stays active and consumes inbound LLDPDUs before they reach the host, so IPA inspection collects no LLDP. This produces an empty `parsed_lldp` and fails node inspection (`KeyError: 'parsed_lldp'`), and can cause switch ports to err-disable on bring-up.

The base IPA image ships no firmware, and `undercloud-ipa` installed only networking/diagnostic tools — no `ice` DDP.

## Change

- Add `firmware-intel-misc` to `custom_elements/undercloud-ipa/package-installs.yaml`. On Debian trixie/sid the `ice` DDP ships in `firmware-intel-misc` (amd64); the file lands at `/usr/lib/firmware/intel/ice/ddp/ice.pkg`.
- Set `DIB_DEBIAN_COMPONENTS: 'main,contrib,non-free,non-free-firmware'` in `ipa-debian-trixie.yaml`. `firmware-intel-misc` is in `non-free-firmware`; diskimage-builder's debootstrap defaults `DIB_DEBIAN_COMPONENTS` to `main` only, so the component must be enabled or the package is not installable.

## Validation (hardware-tested on Dell R7515 with Intel E810-XXV)

- Built the ramdisk locally; the initramfs contains `/usr/lib/firmware/intel/ice/ddp/ice.pkg` (-> `ice-1.3.41.0.pkg`).
- Booted on the R7515: `dmesg` shows the DDP loaded and `FW LLDP is disabled, DCBx/LLDP in SW mode` (no Safe Mode).
- Host now receives inbound switch LLDP (`tcpdump ... 'ether proto 0x88cc'`) with the full TLV set including System Name:
  - Chassis ID `ec:19:2e:c9:85:97`, Port ID `Ethernet1/19`, System Name `g16-45-1.iad3`.
- Before the fix, the same NIC in Safe Mode delivered no inbound switch LLDP to the host.

## Notes

- Build host must be Debian trixie-aware (Ubuntu 24.04 / Debian 13); the CI runner is fine.
- `firmware-intel-misc` is amd64; other arches use a different package/path for the DDP.
- Related: AMMO-1323 adds a defensive `.get()` in the inspection hook so a node with genuinely no LLDP skips gracefully rather than raising `KeyError`.

PUC-2035
