### PR TITLE
feat: Add/remove subnet: trunk-based VIF attach and cleanup PUC-1921

### DIFF
--- a/python/neutron-understack/neutron_understack/l3_router/palo_alto.py
+++ b/python/neutron-understack/neutron_understack/l3_router/palo_alto.py
@@ -7,6 +7,7 @@ from neutron_lib import context as n_context
 from neutron_lib import exceptions as n_exc
 from neutron_lib.api.definitions import portbindings
 from neutron_lib.callbacks import events
+from neutron_lib.callbacks import priority_group
 from neutron_lib.callbacks import registry
 from neutron_lib.callbacks import resources
 from neutron_lib.plugins import constants as plugin_constants
@@ -30,6 +31,7 @@ TRUNK_NAME_PREFIX = "palo-alto-router-trunk"
 # the existing allowed/gap VLAN validation path. Replace with a configured or
 # allocated model once the trunk-tag semantics are revisited.
 GATEWAY_SUBPORT_VLAN = 200
+INTERFACE_SUBPORT_VLAN_START = GATEWAY_SUBPORT_VLAN + 1
 
 
 # Conflict -> HTTP 409: the request cannot be satisfied because the hardware
@@ -46,6 +48,13 @@ class PaloAltoFlavorMisconfigured(n_exc.BadRequest):
     message = (
         "Router %(router_id)s flavor %(flavor_id)s does not define a "
         "resource_class in its service profile metainfo."
+    )
+
+
+class NoPaloAltoSubportVlanAvailable(n_exc.Conflict):
+    message = (
+        "No Palo Alto trunk subport VLAN is available for router %(router_id)s "
+        "on trunk %(trunk_id)s. Allowed ranges: %(network_segment_ranges)s."
     )
 
 
@@ -98,6 +107,22 @@ class PaloAlto(base.L3ServiceProvider):
             self._process_gateway_delete,
             resources.ROUTER_GATEWAY,
             events.BEFORE_DELETE,
+            cancellable=True,
+        )
+        registry.subscribe(
+            self._process_router_interface_create,
+            resources.ROUTER_INTERFACE,
+            events.AFTER_CREATE,
+            cancellable=True,
+        )
+        # Run before neutron.services.trunk.rules.enforce_port_deletion_rules
+        # (PRIORITY_DEFAULT) so a Palo Alto router-interface port can be removed
+        # from its trunk before Neutron checks whether the port is in use.
+        registry.subscribe(
+            self._process_router_interface_port_delete,
+            resources.PORT,
+            events.BEFORE_DELETE,
+            priority=priority_group.PRIORITY_DEFAULT - 1000,
             cancellable=True,
         )
         LOG.info(
@@ -315,6 +340,31 @@ class PaloAlto(base.L3ServiceProvider):
         admin_context = n_context.get_admin_context()
         return core_plugin.get_port(admin_context, port_id)
 
+    def _confirm_parent_vif_attach_after_error(
+        self, router_id: str, node, parent_port_id: str
+    ) -> dict | None:
+        """Return the fresh parent port if an errored attach actually landed.
+
+        Ironic VIF attach can time out waiting for the conductor/RPC reply even
+        after the conductor has applied the binding.
+        """
+        try:
+            vif_ids = self._ironic.node_vif_ids(node)
+        except Exception:
+            LOG.debug(
+                "Could not re-check VIF attachments for Palo Alto router %s "
+                "after an attach error",
+                router_id,
+                exc_info=True,
+            )
+            return None
+        if parent_port_id not in vif_ids:
+            return None
+
+        fresh = self._fresh_port(parent_port_id)
+        self._verify_parent_annotated(router_id, fresh)
+        return fresh
+
     def _ensure_parent_vif_attached(self, router: dict, parent_port: dict) -> dict:
         """VIF-attach the parent port to the router's node (idempotent).
 
@@ -343,7 +393,24 @@ class PaloAlto(base.L3ServiceProvider):
                 node.id,
             )
         else:
-            self._ironic.attach_vif_to_node(node, parent_port_id)
+            try:
+                self._ironic.attach_vif_to_node(node, parent_port_id)
+            except Exception:
+                fresh = self._confirm_parent_vif_attach_after_error(
+                    router_id, node, parent_port_id
+                )
+                if fresh is None:
+                    raise
+                LOG.warning(
+                    "Ironic VIF attach for Palo Alto router %s parent port %s "
+                    "on node %s raised, but the VIF is attached and annotated; "
+                    "continuing",
+                    router_id,
+                    parent_port_id,
+                    getattr(node, "id", node),
+                    exc_info=True,
+                )
+                return fresh
 
         fresh = self._fresh_port(parent_port_id)
         self._verify_parent_annotated(router_id, fresh)
@@ -420,38 +487,72 @@ class PaloAlto(base.L3ServiceProvider):
             return existing
         return self._create_trunk(router, parent_port)
 
-    def _add_gateway_subport(self, router: dict, trunk: dict, gateway_port: dict):
-        """Add the gateway port to the trunk as a VLAN subport (idempotent).
+    def _used_subport_vlans(self, trunk: dict) -> set[int]:
+        """Return VLAN segmentation IDs already used on a router trunk."""
+        return {
+            sp["segmentation_id"]
+            for sp in trunk.get("sub_ports", [])
+            if sp.get("segmentation_type") == "vlan"
+            and sp.get("segmentation_id") is not None
+        }
+
+    def _next_available_subport_vlan(
+        self, router_id: str, trunk: dict, start_vlan: int
+    ) -> int:
+        """Pick the first allowed, unused Palo Alto subport VLAN from start."""
+        used = self._used_subport_vlans(trunk)
+        ranges = sorted(utils.allowed_tenant_vlan_id_ranges())
+        for start, end in ranges:
+            for vlan in range(max(start, start_vlan), end + 1):
+                if vlan not in used:
+                    return vlan
+        raise NoPaloAltoSubportVlanAvailable(
+            router_id=router_id,
+            trunk_id=trunk["id"],
+            network_segment_ranges=utils.printable_ranges(ranges),
+        )
+
+    def _add_router_port_subport(
+        self,
+        router: dict,
+        trunk: dict,
+        port: dict,
+        segmentation_id: int,
+        label: str,
+    ):
+        """Add a router-owned port to the trunk as a VLAN subport.
 
         Adding the subport fires the understack trunk driver (SUBPORTS events),
         which allocates the fabric segment, binds it, and calls undersync to
-        program the switch. No-ops if the gateway port is already a subport.
+        program the switch. No-ops if the port is already a subport.
         """
-        gateway_port_id = gateway_port["id"]
+        port_id = port["id"]
         existing = {sp["port_id"] for sp in trunk.get("sub_ports", [])}
-        if gateway_port_id in existing:
+        if port_id in existing:
             LOG.debug(
-                "Gateway port %s already a subport on trunk %s",
-                gateway_port_id,
+                "Palo Alto %s port %s already a subport on trunk %s",
+                label,
+                port_id,
                 trunk["id"],
             )
             return trunk
 
         admin_context = n_context.get_admin_context()
         LOG.info(
-            "Adding gateway port %s to trunk %s as VLAN %s subport for router %s",
-            gateway_port_id,
+            "Adding Palo Alto %s port %s to trunk %s as VLAN %s subport for router %s",
+            label,
+            port_id,
             trunk["id"],
-            GATEWAY_SUBPORT_VLAN,
+            segmentation_id,
             router["id"],
         )
         # The trunk subport validator rejects a port that has device_id set
-        # (rules.py check_not_in_use). The gateway port has device_id=router_id,
-        # so clear it for the add and restore it afterwards so the router keeps
-        # its gateway-port association (our own lookups depend on it).
-        original_device_id = gateway_port["device_id"]
-        original_device_owner = gateway_port["device_owner"]
-        utils.clear_device_id_for_port(gateway_port_id)
+        # (rules.py check_not_in_use). Router-owned ports have
+        # device_id=router_id, so clear it for the add and restore it
+        # afterwards so the router keeps its port association.
+        original_device_id = port["device_id"]
+        original_device_owner = port["device_owner"]
+        utils.clear_device_id_for_port(port_id)
         try:
             return self._trunk_plugin.add_subports(
                 admin_context,
@@ -459,41 +560,91 @@ class PaloAlto(base.L3ServiceProvider):
                 {
                     "sub_ports": [
                         {
-                            "port_id": gateway_port_id,
+                            "port_id": port_id,
                             "segmentation_type": "vlan",
-                            "segmentation_id": GATEWAY_SUBPORT_VLAN,
+                            "segmentation_id": segmentation_id,
                         }
                     ]
                 },
             )
         finally:
             utils.set_device_id_and_owner_for_port(
-                gateway_port_id, original_device_id, original_device_owner
+                port_id, original_device_id, original_device_owner
             )
 
-    def _remove_gateway_subport(self, trunk: dict, gateway_port_id: str):
-        """Remove the gateway port from the trunk (idempotent).
+    def _add_gateway_subport(self, router: dict, trunk: dict, gateway_port: dict):
+        """Add the gateway port to the trunk as a VLAN subport (idempotent)."""
+        port_id = gateway_port["id"]
+        if port_id in {sp["port_id"] for sp in trunk.get("sub_ports", [])}:
+            LOG.debug(
+                "Palo Alto gateway port %s already a subport on trunk %s",
+                port_id,
+                trunk["id"],
+            )
+            return trunk
+        return self._add_router_port_subport(
+            router,
+            trunk,
+            gateway_port,
+            GATEWAY_SUBPORT_VLAN,
+            "gateway",
+        )
+
+    def _add_interface_subport(self, router: dict, trunk: dict, interface_port: dict):
+        """Add a router-interface port to the trunk as a VLAN subport."""
+        port_id = interface_port["id"]
+        if port_id in {sp["port_id"] for sp in trunk.get("sub_ports", [])}:
+            LOG.debug(
+                "Palo Alto interface port %s already a subport on trunk %s",
+                port_id,
+                trunk["id"],
+            )
+            return trunk
+        return self._add_router_port_subport(
+            router,
+            trunk,
+            interface_port,
+            self._next_available_subport_vlan(
+                router["id"], trunk, INTERFACE_SUBPORT_VLAN_START
+            ),
+            "interface",
+        )
+
+    def _remove_router_port_subport(self, trunk: dict, port_id: str, label: str):
+        """Remove a router-owned port from the trunk (idempotent).
 
         Fires the trunk driver's SUBPORTS delete events, which release the
         fabric segment and update the switchport. No-ops if it is not a subport.
         """
         existing = {sp["port_id"] for sp in trunk.get("sub_ports", [])}
-        if gateway_port_id not in existing:
+        if port_id not in existing:
             LOG.debug(
-                "Gateway port %s is not a subport on trunk %s; skip removal",
-                gateway_port_id,
+                "Palo Alto %s port %s is not a subport on trunk %s; skip removal",
+                label,
+                port_id,
                 trunk["id"],
             )
             return trunk
         admin_context = n_context.get_admin_context()
         LOG.info(
-            "Removing gateway subport %s from trunk %s", gateway_port_id, trunk["id"]
+            "Removing Palo Alto %s subport %s from trunk %s",
+            label,
+            port_id,
+            trunk["id"],
         )
         return self._trunk_plugin.remove_subports(
             admin_context,
             trunk["id"],
-            {"sub_ports": [{"port_id": gateway_port_id}]},
+            {"sub_ports": [{"port_id": port_id}]},
         )
+
+    def _remove_gateway_subport(self, trunk: dict, gateway_port_id: str):
+        """Remove the gateway port from the trunk (idempotent)."""
+        return self._remove_router_port_subport(trunk, gateway_port_id, "gateway")
+
+    def _remove_interface_subport(self, trunk: dict, interface_port_id: str):
+        """Remove a router-interface port from the trunk (idempotent)."""
+        return self._remove_router_port_subport(trunk, interface_port_id, "interface")
 
     def _detach_and_delete_parent(self, router_id: str, parent_id: str) -> None:
         """Detach the parent VIF from the node and delete the parent port."""
@@ -536,7 +687,12 @@ class PaloAlto(base.L3ServiceProvider):
         self._trunk_plugin.delete_trunk(admin_context, trunk["id"])
         self._detach_and_delete_parent(router_id, parent_id)
 
-    def _cleanup_gateway_attachment(self, router: dict, gateway_port: dict) -> None:
+    def _cleanup_router_port_attachment(
+        self,
+        router: dict,
+        port_id: str,
+        label: str,
+    ) -> None:
         """Reverse of the add: remove subport, then tear down the parent stack.
 
         Handles a partially-built attach too: if a prior add failed after the
@@ -560,8 +716,16 @@ class PaloAlto(base.L3ServiceProvider):
                     router_id,
                 )
             return
-        self._remove_gateway_subport(trunk, gateway_port["id"])
+        self._remove_router_port_subport(trunk, port_id, label)
         self._delete_parent_stack_if_unused(router_id, trunk)
+
+    def _cleanup_gateway_attachment(self, router: dict, gateway_port: dict) -> None:
+        """Clean up a gateway port's Palo Alto trunk attachment."""
+        self._cleanup_router_port_attachment(router, gateway_port["id"], "gateway")
+
+    def _cleanup_interface_attachment(self, router: dict, interface_port: dict) -> None:
+        """Clean up a router-interface port's Palo Alto trunk attachment."""
+        self._cleanup_router_port_attachment(router, interface_port["id"], "interface")
 
     @registry.receives(resources.ROUTER, [events.BEFORE_CREATE])
     def _process_router_create(self, resource, event, trigger, payload=None):
@@ -691,4 +855,78 @@ class PaloAlto(base.L3ServiceProvider):
             "Cleaned Palo Alto router %s gateway attachment (port %s)",
             router_id,
             gateway_port["id"],
+        )
+
+    def _process_router_interface_create(self, resource, event, trigger, payload=None):
+        """ROUTER_INTERFACE / AFTER_CREATE: wire a subnet interface port."""
+        context = payload.context
+        router_id = payload.resource_id
+        router = self.l3plugin.get_router(context, router_id)
+        if not self._is_palo_alto_provider(context, router):
+            return
+
+        interface_port = payload.metadata.get("port")
+        if not interface_port:
+            raise n_exc.BadRequest(
+                resource="router",
+                msg=(
+                    f"Palo Alto router {router_id} interface was created but no "
+                    "router interface port was supplied."
+                ),
+            )
+        if interface_port.get("device_owner") not in const.ROUTER_INTERFACE_OWNERS:
+            return
+
+        parent = self._ensure_parent_port(router)
+        parent = self._ensure_parent_vif_attached(router, parent)
+        trunk = self._ensure_trunk(router, parent)
+        self._add_interface_subport(router, trunk, interface_port)
+
+        LOG.info(
+            "Attached Palo Alto router %s interface port %s via parent %s trunk %s",
+            router_id,
+            interface_port["id"],
+            parent["id"],
+            trunk["id"],
+        )
+
+    def _process_router_interface_port_delete(
+        self, resource, event, trigger, payload=None
+    ):
+        """PORT / BEFORE_DELETE: remove Palo Alto interface trunk wiring.
+
+        This runs before the trunk plugin's own port-in-use check. That allows
+        Neutron to delete a router-interface port that we previously attached as
+        a trunk subport.
+        """
+        port = payload.metadata.get("port") if payload else None
+        if not port or port.get("device_owner") not in const.ROUTER_INTERFACE_OWNERS:
+            return
+
+        context = payload.context
+        router_id = port.get("device_id")
+        if not router_id:
+            return
+
+        try:
+            router = self.l3plugin.get_router(context, router_id)
+            is_palo_alto = self._is_palo_alto_provider(context, router)
+        except Exception:
+            LOG.debug(
+                "Skipping Palo Alto interface cleanup for port %s; router %s "
+                "could not be confirmed as Palo Alto",
+                port["id"],
+                router_id,
+                exc_info=True,
+            )
+            return
+
+        if not is_palo_alto:
+            return
+
+        self._cleanup_interface_attachment(router, port)
+        LOG.info(
+            "Cleaned Palo Alto router %s interface attachment (port %s)",
+            router_id,
+            port["id"],
         )

--- a/python/neutron-understack/neutron_understack/l3_router/palo_alto.py
+++ b/python/neutron-understack/neutron_understack/l3_router/palo_alto.py
@@ -1,6 +1,9 @@
 import json
 import logging
+import weakref
+from dataclasses import dataclass
 
+from neutron.objects import router as l3_obj
 from neutron.services.l3_router.service_providers import base
 from neutron_lib import constants as const
 from neutron_lib import context as n_context
@@ -32,6 +35,16 @@ TRUNK_NAME_PREFIX = "palo-alto-router-trunk"
 # allocated model once the trunk-tag semantics are revisited.
 GATEWAY_SUBPORT_VLAN = 200
 INTERFACE_SUBPORT_VLAN_START = GATEWAY_SUBPORT_VLAN + 1
+
+
+@dataclass(frozen=True)
+class _InterfaceAttachment:
+    router_id: str
+    port_id: str
+    parent_id: str | None
+    trunk_id: str | None
+    subport_present: bool
+    parent_vif_attached: bool
 
 
 # Conflict -> HTTP 409: the request cannot be satisfied because the hardware
@@ -90,6 +103,7 @@ class PaloAlto(base.L3ServiceProvider):
     def __init__(self, l3_plugin):
         super().__init__(l3_plugin)
         self._palo_alto_provider = f"{__name__}.{self.__class__.__name__}"
+        self._interface_attachments = weakref.WeakKeyDictionary()
         # Gateway attach must run on AFTER_CREATE (the gateway port does not
         # exist earlier) and must be cancellable so a wiring failure returns a
         # real API error instead of a swallowed 200. @registry.receives cannot
@@ -112,8 +126,14 @@ class PaloAlto(base.L3ServiceProvider):
         registry.subscribe(
             self._process_router_interface_create,
             resources.ROUTER_INTERFACE,
-            events.AFTER_CREATE,
+            events.BEFORE_CREATE,
+            priority=priority_group.PRIORITY_ROUTER_DRIVER,
             cancellable=True,
+        )
+        registry.subscribe(
+            self._process_router_interface_abort,
+            resources.ROUTER_INTERFACE,
+            events.ABORT_CREATE,
         )
         # Run before neutron.services.trunk.rules.enforce_port_deletion_rules
         # (PRIORITY_DEFAULT) so a Palo Alto router-interface port can be removed
@@ -858,7 +878,7 @@ class PaloAlto(base.L3ServiceProvider):
         )
 
     def _process_router_interface_create(self, resource, event, trigger, payload=None):
-        """ROUTER_INTERFACE / AFTER_CREATE: wire a subnet interface port."""
+        """Wire the interface before Neutron commits its RouterPort association."""
         context = payload.context
         router_id = payload.resource_id
         router = self.l3plugin.get_router(context, router_id)
@@ -870,17 +890,42 @@ class PaloAlto(base.L3ServiceProvider):
             raise n_exc.BadRequest(
                 resource="router",
                 msg=(
-                    f"Palo Alto router {router_id} interface was created but no "
-                    "router interface port was supplied."
+                    f"Palo Alto router {router_id} interface attachment has no "
+                    "router interface port."
                 ),
             )
         if interface_port.get("device_owner") not in const.ROUTER_INTERFACE_OWNERS:
             return
 
-        parent = self._ensure_parent_port(router)
-        parent = self._ensure_parent_vif_attached(router, parent)
-        trunk = self._ensure_trunk(router, parent)
-        self._add_interface_subport(router, trunk, interface_port)
+        previous_parent = self._parent_port_for_router(router_id)
+        previous_trunk = self._trunk_for_router(router_id)
+        parent_vif_attached = False
+        if previous_parent is not None:
+            node = self._ironic.node_by_instance_uuid(router_id)
+            if node is not None:
+                vif_ids = self._ironic.node_vif_ids(node)
+                parent_vif_attached = previous_parent["id"] in vif_ids
+        self._interface_attachments[payload] = _InterfaceAttachment(
+            router_id=router_id,
+            port_id=interface_port["id"],
+            parent_id=previous_parent["id"] if previous_parent else None,
+            trunk_id=previous_trunk["id"] if previous_trunk else None,
+            subport_present=any(
+                sp["port_id"] == interface_port["id"]
+                for sp in (previous_trunk or {}).get("sub_ports", [])
+            ),
+            parent_vif_attached=parent_vif_attached,
+        )
+        try:
+            parent = self._ensure_parent_port(router)
+            parent = self._ensure_parent_vif_attached(router, parent)
+            trunk = self._ensure_trunk(router, parent)
+            self._add_interface_subport(router, trunk, interface_port)
+        except Exception:
+            # Attach-by-port is reverted with a port update by Neutron, so it
+            # cannot rely on PORT/BEFORE_DELETE to undo partial realization.
+            self._rollback_interface_attachment(payload)
+            raise
 
         LOG.info(
             "Attached Palo Alto router %s interface port %s via parent %s trunk %s",
@@ -889,6 +934,50 @@ class PaloAlto(base.L3ServiceProvider):
             parent["id"],
             trunk["id"],
         )
+
+    def _rollback_interface_attachment(self, payload):
+        """Undo this request's changes, including calls that failed postcommit."""
+        attachment = self._interface_attachments.get(payload)
+        if attachment is None:
+            return
+        try:
+            trunk = self._trunk_for_router(attachment.router_id)
+            if trunk is not None:
+                if not attachment.subport_present:
+                    self._remove_interface_subport(trunk, attachment.port_id)
+                admin_context = n_context.get_admin_context()
+                trunk = self._trunk_plugin.get_trunk(admin_context, trunk["id"])
+                if trunk.get("sub_ports"):
+                    # Other interfaces still need the shared parent and VIF.
+                    self._interface_attachments.pop(payload, None)
+                    return
+                if trunk["id"] != attachment.trunk_id:
+                    self._trunk_plugin.delete_trunk(admin_context, trunk["id"])
+
+            parent = self._parent_port_for_router(attachment.router_id)
+            if parent is not None:
+                if parent["id"] != attachment.parent_id:
+                    self._detach_and_delete_parent(attachment.router_id, parent["id"])
+                elif not attachment.parent_vif_attached:
+                    node = self._ironic.node_by_instance_uuid(attachment.router_id)
+                    if node is not None:
+                        self._ironic.detach_vif_from_node(node, parent["id"])
+            self._interface_attachments.pop(payload, None)
+        except Exception:
+            # Preserve the original attach error. Keep the snapshot so the
+            # subsequent ABORT_CREATE can retry compensation if it failed here.
+            LOG.exception(
+                "Failed to roll back Palo Alto router %s interface port %s; "
+                "attachment cleanup is incomplete",
+                attachment.router_id,
+                attachment.port_id,
+            )
+
+    def _process_router_interface_abort(self, resource, event, trigger, payload=None):
+        # The registry continues invoking callbacks after validation errors. An
+        # error in another subscriber must unwind even a successful attachment.
+        if payload is not None:
+            self._rollback_interface_attachment(payload)
 
     def _process_router_interface_port_delete(
         self, resource, event, trigger, payload=None
@@ -899,7 +988,9 @@ class PaloAlto(base.L3ServiceProvider):
         Neutron to delete a router-interface port that we previously attached as
         a trunk subport.
         """
-        port = payload.metadata.get("port") if payload else None
+        if payload is None or payload.metadata.get("port_check") is not False:
+            return
+        port = payload.metadata.get("port")
         if not port or port.get("device_owner") not in const.ROUTER_INTERFACE_OWNERS:
             return
 
@@ -922,6 +1013,14 @@ class PaloAlto(base.L3ServiceProvider):
             return
 
         if not is_palo_alto:
+            return
+
+        # Neutron also deletes newly-created ports when attachment aborts. That
+        # request already compensated its changes; it must not remove a shared
+        # stack which existed beforehand and has no RouterPort for this port.
+        if not l3_obj.RouterPort.objects_exist(
+            context, router_id=router_id, port_id=port["id"]
+        ):
             return
 
         self._cleanup_interface_attachment(router, port)

--- a/python/neutron-understack/neutron_understack/tests/test_palo_alto_provider.py
+++ b/python/neutron-understack/neutron_understack/tests/test_palo_alto_provider.py
@@ -1,8 +1,26 @@
+import copy
+from types import MethodType
+from types import SimpleNamespace
+
 import pytest
+from neutron.db import l3_db
+from neutron.services.trunk import rules as trunk_rules
 from neutron_lib import constants as const
 from neutron_lib import exceptions as n_exc
+from neutron_lib.callbacks import events
+from neutron_lib.callbacks import exceptions as callback_exc
+from neutron_lib.callbacks import manager
+from neutron_lib.callbacks import priority_group
+from neutron_lib.callbacks import registry
+from neutron_lib.callbacks import resources
+from neutron_lib.exceptions import l3 as l3_exc
 
 from neutron_understack.l3_router import palo_alto
+
+
+@pytest.fixture(autouse=True)
+def _isolated_callbacks(mocker):
+    mocker.patch.object(registry, "_CALLBACK_MANAGER", manager.CallbacksManager())
 
 
 class FakeFlavorPlugin:
@@ -780,6 +798,8 @@ class TestRouterInterfaceCreateHandler:
         )
         m_trunk = mocker.patch.object(provider, "_ensure_trunk", return_value=trunk)
         m_sub = mocker.patch.object(provider, "_add_interface_subport")
+        mocker.patch.object(provider, "_parent_port_for_router", return_value=None)
+        mocker.patch.object(provider, "_trunk_for_router", return_value=None)
 
         provider._process_router_interface_create("r", "e", "t", self._payload(mocker))
 
@@ -952,11 +972,32 @@ class TestGatewayDeleteHandler:
 
 class TestRouterInterfacePortDeleteHandler:
     def _payload(self, mocker, port=None):
+        mocker.patch.object(
+            palo_alto.l3_obj.RouterPort, "objects_exist", return_value=True
+        )
         payload = mocker.Mock()
         payload.context = "ctx"
         payload.resource_id = "intf-1"
-        payload.metadata = {"port": port if port is not None else dict(_INTERFACE_PORT)}
+        payload.metadata = {
+            "port": port if port is not None else dict(_INTERFACE_PORT),
+            "port_check": False,
+        }
         return payload
+
+    @pytest.mark.parametrize("port_check", [True, None, "missing"])
+    def test_skips_unless_l3_explicitly_authorized_removal(self, mocker, port_check):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        cleanup = mocker.patch.object(provider, "_cleanup_interface_attachment")
+        payload = self._payload(mocker)
+        if port_check == "missing":
+            payload.metadata.pop("port_check")
+        else:
+            payload.metadata["port_check"] = port_check
+
+        provider._process_router_interface_port_delete("r", "e", "t", payload)
+
+        cleanup.assert_not_called()
+        provider.l3plugin.get_router.assert_not_called()
 
     def test_cleans_up_before_port_delete_when_palo_alto(self, mocker):
         provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
@@ -1078,3 +1119,427 @@ class TestGatewayCleanupPartialAdd:
 
         core.delete_port.assert_not_called()
         ironic.detach_vif_from_node.assert_not_called()
+
+
+@pytest.fixture
+def interface_lifecycle(mocker):
+    """Run Neutron's L3 flow/guards with stateful core, trunk and Ironic doubles."""
+    state = SimpleNamespace(
+        ports={}, trunks={}, vifs=set(), associations=set(), fail=None
+    )
+
+    def fail_at(stage):
+        if state.fail == stage:
+            raise RuntimeError(f"{stage} failed")
+
+    core = mocker.Mock()
+    trunk_plugin = mocker.Mock()
+    ironic = mocker.Mock()
+    context = mocker.Mock()
+    context.session.is_active = True
+    context.project_id = "admin-project"
+    router = SimpleNamespace(id="r1", project_id="project-1", gw_port=None)
+    router_dict = {"id": router.id, "flavor_id": "f1"}
+    interface_port = {
+        **_INTERFACE_PORT,
+        "network_id": "tenant-net",
+        "project_id": router.project_id,
+        "fixed_ips": [{"subnet_id": "subnet-1", "ip_address": "10.0.0.1"}],
+    }
+    subnet = {"id": "subnet-1", "cidr": "10.0.0.0/24"}
+
+    def create_port(_context, body):
+        port = copy.deepcopy(body["port"])
+        is_parent = port.get("name", "").startswith("palo-alto-router-anchor-")
+        port["id"] = "parent-1" if is_parent else "intf-1"
+        state.ports[port["id"]] = port
+        if is_parent:
+            fail_at("parent_create")
+        return copy.deepcopy(port)
+
+    def update_port(_context, port_id, body):
+        state.ports[port_id].update(body["port"])
+        return copy.deepcopy(state.ports[port_id])
+
+    def delete_port(ctx, port_id, l3_port_check=True):
+        registry.publish(
+            resources.PORT,
+            events.BEFORE_DELETE,
+            core,
+            payload=events.DBEventPayload(
+                ctx,
+                resource_id=port_id,
+                metadata={
+                    "port": copy.deepcopy(state.ports[port_id]),
+                    "port_check": l3_port_check,
+                },
+            ),
+        )
+        del state.ports[port_id]
+        state.associations.discard(port_id)
+
+    core.create_port.side_effect = create_port
+    core.update_port.side_effect = update_port
+    core.delete_port.side_effect = delete_port
+    core.get_port.side_effect = lambda _ctx, port_id: copy.deepcopy(
+        state.ports[port_id]
+    )
+    core.get_ports.side_effect = lambda _ctx, filters: [
+        copy.deepcopy(port)
+        for port in state.ports.values()
+        if all(port.get(key) in values for key, values in filters.items())
+    ]
+    core.get_networks.return_value = [{"id": "anchor-net"}]
+
+    def create_trunk(_context, body):
+        trunk = {"id": "trunk-1", **copy.deepcopy(body["trunk"])}
+        state.trunks[trunk["id"]] = trunk
+        fail_at("trunk_create")
+        return copy.deepcopy(trunk)
+
+    def add_subports(_context, trunk_id, body):
+        fail_at("subport_precommit")
+        state.trunks[trunk_id]["sub_ports"].extend(copy.deepcopy(body["sub_ports"]))
+        fail_at("subport_postcommit")
+        return copy.deepcopy(state.trunks[trunk_id])
+
+    def remove_subports(_context, trunk_id, body):
+        removed = {sp["port_id"] for sp in body["sub_ports"]}
+        state.trunks[trunk_id]["sub_ports"] = [
+            sp
+            for sp in state.trunks[trunk_id]["sub_ports"]
+            if sp["port_id"] not in removed
+        ]
+        return copy.deepcopy(state.trunks[trunk_id])
+
+    trunk_plugin.create_trunk.side_effect = create_trunk
+    trunk_plugin.add_subports.side_effect = add_subports
+    trunk_plugin.remove_subports.side_effect = remove_subports
+    trunk_plugin.get_trunks.side_effect = lambda _ctx, filters: [
+        copy.deepcopy(trunk)
+        for trunk in state.trunks.values()
+        if trunk["name"] in filters["name"]
+    ]
+    trunk_plugin.get_trunk.side_effect = lambda _ctx, tid: copy.deepcopy(
+        state.trunks[tid]
+    )
+    trunk_plugin.delete_trunk.side_effect = lambda _ctx, tid: state.trunks.pop(tid)
+    mocker.patch.object(
+        palo_alto.utils, "fetch_trunk_plugin", return_value=trunk_plugin
+    )
+    mocker.patch.object(
+        palo_alto.utils,
+        "allowed_tenant_vlan_id_ranges",
+        side_effect=lambda: (
+            [(200, 200)] if state.fail == "vlan_allocation" else [(200, 210)]
+        ),
+    )
+    mocker.patch.object(
+        palo_alto.utils,
+        "clear_device_id_for_port",
+        side_effect=lambda pid: update_port(context, pid, {"port": {"device_id": ""}}),
+    )
+    mocker.patch.object(
+        palo_alto.utils,
+        "set_device_id_and_owner_for_port",
+        side_effect=lambda pid, did, owner: update_port(
+            context, pid, {"port": {"device_id": did, "device_owner": owner}}
+        ),
+    )
+
+    def attach_vif(_node, port_id):
+        fail_at("vif_attach")
+        state.vifs.add(port_id)
+        fail_at("vif_annotation")
+        state.ports[port_id].update(
+            {
+                "binding:host_id": "node-1",
+                "binding:profile": {
+                    "physical_network": "physnet-1",
+                    "local_link_information": [
+                        {"switch_info": "switch-1", "port_id": "Eth1"}
+                    ],
+                },
+            }
+        )
+
+    ironic.node_by_instance_uuid.return_value = SimpleNamespace(id="node-1")
+    ironic.node_vif_ids.side_effect = lambda _node: list(state.vifs)
+    ironic.attach_vif_to_node.side_effect = attach_vif
+    ironic.detach_vif_from_node.side_effect = lambda _node, pid: state.vifs.discard(pid)
+    provider = _make_provider(
+        mocker, FakeFlavorPlugin(_palo_alto_driver()), ironic=ironic, core_plugin=core
+    )
+    palo_alto.n_context.get_admin_context.return_value = context
+
+    # Bind the installed Neutron methods, including its real rollback context
+    # managers. Only persistence and pre-event subnet validation are doubled.
+    l3 = SimpleNamespace(
+        _core_plugin=core,
+        _get_router=mocker.Mock(return_value=router),
+        get_router=mocker.Mock(return_value=router_dict),
+        _get_device_owner=mocker.Mock(return_value=const.DEVICE_OWNER_ROUTER_INTF),
+        _validate_interface_info=mocker.Mock(
+            side_effect=lambda info: ("port_id" in info, "subnet_id" in info)
+        ),
+        _check_router_port=mocker.Mock(
+            side_effect=lambda _ctx, pid, _owner: copy.deepcopy(state.ports[pid])
+        ),
+        _validate_router_port_info=mocker.Mock(
+            side_effect=lambda _ctx, _router, pid: (
+                copy.deepcopy(state.ports[pid]),
+                [subnet],
+            )
+        ),
+        _add_interface_by_subnet=mocker.Mock(
+            side_effect=lambda _ctx, _router, _sid, _owner: (
+                create_port(context, {"port": interface_port}),
+                [subnet],
+                True,
+            )
+        ),
+        router_device_owners=l3_db.L3_NAT_dbonly_mixin.router_device_owners,
+    )
+    for method in (
+        "add_router_interface",
+        "_notify_attaching_interface",
+        "_add_interface_by_port",
+        "_add_router_port",
+        "prevent_l3_port_deletion",
+    ):
+        setattr(l3, method, MethodType(getattr(l3_db.L3_NAT_dbonly_mixin, method), l3))
+    l3._make_router_interface_info = (
+        l3_db.L3_NAT_dbonly_mixin._make_router_interface_info
+    )
+    router_port = mocker.patch.object(l3_db.l3_obj, "RouterPort")
+    router_port.return_value.create.side_effect = lambda: state.associations.add(
+        "intf-1"
+    )
+    router_port.get_objects.return_value = []
+    router_port.objects_exist.side_effect = lambda _ctx, router_id, port_id: (
+        port_id in state.associations
+    )
+    mocker.patch.object(l3_db.l3_obj.Router, "objects_exist", return_value=True)
+    provider.l3plugin = l3
+    mocker.patch.object(
+        palo_alto.directory,
+        "get_plugin",
+        side_effect=lambda plugin=None: (
+            l3 if plugin == palo_alto.plugin_constants.L3 else core
+        ),
+    )
+    registry.subscribe(
+        l3_db.L3_NAT_dbonly_mixin._prevent_l3_port_delete_callback,
+        resources.PORT,
+        events.BEFORE_DELETE,
+    )
+    registry.subscribe(
+        trunk_rules.enforce_port_deletion_rules, resources.PORT, events.BEFORE_DELETE
+    )
+    mocker.patch.object(
+        trunk_rules.trunk_objects.SubPort,
+        "get_object",
+        side_effect=lambda _ctx, port_id: next(
+            (
+                SimpleNamespace(trunk_id=trunk["id"])
+                for trunk in state.trunks.values()
+                for sp in trunk["sub_ports"]
+                if sp["port_id"] == port_id
+            ),
+            None,
+        ),
+    )
+    mocker.patch.object(
+        trunk_rules.trunk_objects.Trunk, "get_object", return_value=None
+    )
+    return SimpleNamespace(
+        state=state,
+        provider=provider,
+        core=core,
+        trunk_plugin=trunk_plugin,
+        ironic=ironic,
+        context=context,
+        l3=l3,
+        router_port=router_port,
+        interface_port=interface_port,
+        router=router_dict,
+    )
+
+
+class TestRouterInterfaceLifecycle:
+    def _add(self, env, by_port=False):
+        info = {"port_id": "intf-1"} if by_port else {"subnet_id": "subnet-1"}
+        return env.l3.add_router_interface(env.context, "r1", info)
+
+    def test_rejected_direct_delete_preserves_live_subport(self, interface_lifecycle):
+        env = interface_lifecycle
+        self._add(env)
+        before = copy.deepcopy(env.state)
+
+        with pytest.raises(callback_exc.CallbackFailure) as error:
+            env.core.delete_port(env.context, "intf-1")
+
+        assert any(
+            isinstance(exc, n_exc.ServicePortInUse)
+            for exc in error.value.inner_exceptions
+        )
+        assert env.state == before
+        env.trunk_plugin.remove_subports.assert_not_called()
+        env.ironic.detach_vif_from_node.assert_not_called()
+
+    def test_authorized_delete_unwires_before_trunk_guard(self, interface_lifecycle):
+        env = interface_lifecycle
+        self._add(env)
+
+        env.core.delete_port(env.context, "intf-1", l3_port_check=False)
+
+        assert not env.state.ports
+        assert not env.state.trunks
+        assert not env.state.vifs
+        assert not env.state.associations
+
+    @pytest.mark.parametrize("by_port", [False, True], ids=["by-subnet", "by-port"])
+    @pytest.mark.parametrize(
+        "stage",
+        [
+            "parent_create",
+            "vif_attach",
+            "vif_annotation",
+            "trunk_create",
+            "vlan_allocation",
+            "subport_precommit",
+            "subport_postcommit",
+        ],
+    )
+    def test_attach_failure_unwinds_and_allows_retry(
+        self, interface_lifecycle, by_port, stage
+    ):
+        env = interface_lifecycle
+        original = {**env.interface_port, "device_id": "", "device_owner": ""}
+        if by_port:
+            env.state.ports["intf-1"] = copy.deepcopy(original)
+        env.state.fail = stage
+
+        with pytest.raises(l3_exc.RouterInterfaceAttachmentConflict):
+            self._add(env, by_port)
+
+        env.router_port.assert_not_called()
+        assert not env.state.associations
+        assert not env.state.trunks
+        assert not env.state.vifs
+        assert env.state.ports == ({"intf-1": original} if by_port else {})
+        if by_port:
+            assert all(
+                call.args[1] != "intf-1" for call in env.core.delete_port.call_args_list
+            )
+
+        env.state.fail = None
+        self._add(env, by_port)
+        assert env.state.associations == {"intf-1"}
+        assert env.state.trunks["trunk-1"]["sub_ports"] == [
+            {"port_id": "intf-1", "segmentation_type": "vlan", "segmentation_id": 201}
+        ]
+
+    @pytest.mark.parametrize(
+        "priority",
+        [
+            priority_group.PRIORITY_DEFAULT,
+            priority_group.PRIORITY_ROUTER_DRIVER + 1,
+        ],
+        ids=["earlier-validator", "later-validator"],
+    )
+    def test_other_callback_rejection_unwinds_successful_attach(
+        self, interface_lifecycle, mocker, priority
+    ):
+        env = interface_lifecycle
+        env.state.ports["intf-1"] = {
+            **env.interface_port,
+            "device_id": "",
+            "device_owner": "",
+        }
+        reject = mocker.Mock(
+            side_effect=n_exc.BadRequest(resource="router", msg="validation failed")
+        )
+        registry.subscribe(
+            reject, resources.ROUTER_INTERFACE, events.BEFORE_CREATE, priority=priority
+        )
+
+        with pytest.raises(l3_exc.RouterInterfaceAttachmentConflict):
+            self._add(env, by_port=True)
+
+        env.router_port.assert_not_called()
+        assert not env.state.trunks
+        assert not env.state.vifs
+        assert set(env.state.ports) == {"intf-1"}
+        assert env.state.ports["intf-1"]["device_id"] == ""
+
+    @pytest.mark.parametrize("existing_trunk", [False, True])
+    @pytest.mark.parametrize("existing_vif", [False, True])
+    def test_failure_preserves_preexisting_empty_stack(
+        self, interface_lifecycle, existing_trunk, existing_vif
+    ):
+        env = interface_lifecycle
+        parent = env.provider._ensure_parent_port(env.router)
+        if existing_vif:
+            env.provider._ensure_parent_vif_attached(env.router, parent)
+        if existing_trunk:
+            env.provider._ensure_trunk(env.router, parent)
+        trunks = copy.deepcopy(env.state.trunks)
+        vifs = set(env.state.vifs)
+        env.state.fail = "subport_postcommit"
+
+        with pytest.raises(l3_exc.RouterInterfaceAttachmentConflict):
+            self._add(env)
+
+        assert env.state.trunks == trunks
+        assert env.state.vifs == vifs
+        assert set(env.state.ports) == {"parent-1"}
+        assert not env.state.associations
+
+    def test_failed_subnet_preserves_existing_gateway(self, interface_lifecycle):
+        env = interface_lifecycle
+        parent = env.provider._ensure_parent_port(env.router)
+        env.provider._ensure_parent_vif_attached(env.router, parent)
+        env.provider._ensure_trunk(env.router, parent)
+        env.state.trunks["trunk-1"]["sub_ports"] = [
+            {"port_id": "gw-1", "segmentation_type": "vlan", "segmentation_id": 200}
+        ]
+        before = copy.deepcopy(env.state)
+        env.state.fail = "subport_postcommit"
+
+        with pytest.raises(l3_exc.RouterInterfaceAttachmentConflict):
+            self._add(env)
+
+        assert env.state.ports == before.ports
+        assert env.state.trunks == before.trunks
+        assert env.state.vifs == before.vifs
+        env.ironic.detach_vif_from_node.assert_not_called()
+
+    def test_abort_retries_failed_compensation(
+        self, interface_lifecycle, mocker, caplog
+    ):
+        env = interface_lifecycle
+        env.state.fail = "subport_postcommit"
+        cleanup = env.provider._remove_interface_subport
+        attempts = []
+
+        def fail_once(*args):
+            attempts.append(args)
+            if len(attempts) == 1:
+                raise RuntimeError("transient cleanup failure")
+            return cleanup(*args)
+
+        mocker.patch.object(
+            env.provider, "_remove_interface_subport", side_effect=fail_once
+        )
+        with pytest.raises(
+            l3_exc.RouterInterfaceAttachmentConflict, match="subport_postcommit"
+        ):
+            self._add(env)
+
+        assert len(attempts) == 2
+        assert "attachment cleanup is incomplete" in caplog.text
+        assert not env.state.trunks
+        assert not env.state.vifs
+        assert not env.state.ports
+        assert not env.state.associations

--- a/python/neutron-understack/neutron_understack/tests/test_palo_alto_provider.py
+++ b/python/neutron-understack/neutron_understack/tests/test_palo_alto_provider.py
@@ -131,6 +131,9 @@ class TestExceptionHttpCodes:
     def test_flavor_misconfigured_is_bad_request(self):
         assert issubclass(palo_alto.PaloAltoFlavorMisconfigured, n_exc.BadRequest)
 
+    def test_no_subport_vlan_available_is_conflict(self):
+        assert issubclass(palo_alto.NoPaloAltoSubportVlanAvailable, n_exc.Conflict)
+
 
 class TestResourceClassLookup:
     def test_reads_resource_class_from_profile_metainfo(self, mocker):
@@ -426,6 +429,26 @@ class TestParentVifAttach:
         ironic.attach_vif_to_node.assert_called_once_with(node, "parent-1")
         assert result == _ANNOTATED_PARENT  # fresh, annotated copy returned
 
+    def test_recovers_when_attach_raises_after_vif_lands(self, mocker):
+        node = mocker.Mock(id="node-1")
+        provider, ironic = self._provider(mocker, node, vif_ids=[])
+        ironic.node_vif_ids.side_effect = [[], ["parent-1"]]
+        ironic.attach_vif_to_node.side_effect = RuntimeError("rpc timeout")
+
+        result = provider._ensure_parent_vif_attached({"id": "r1"}, {"id": "parent-1"})
+
+        ironic.attach_vif_to_node.assert_called_once_with(node, "parent-1")
+        assert result == _ANNOTATED_PARENT
+
+    def test_reraises_attach_error_when_vif_did_not_land(self, mocker):
+        node = mocker.Mock(id="node-1")
+        provider, ironic = self._provider(mocker, node, vif_ids=[])
+        ironic.node_vif_ids.side_effect = [[], []]
+        ironic.attach_vif_to_node.side_effect = RuntimeError("rpc timeout")
+
+        with pytest.raises(RuntimeError, match="rpc timeout"):
+            provider._ensure_parent_vif_attached({"id": "r1"}, {"id": "parent-1"})
+
     def test_skips_attach_when_already_attached(self, mocker):
         node = mocker.Mock(id="node-1")
         provider, ironic = self._provider(mocker, node, vif_ids=["parent-1"])
@@ -489,6 +512,12 @@ _GATEWAY_PORT = {
     "device_owner": "network:router_gateway",
 }
 
+_INTERFACE_PORT = {
+    "id": "intf-1",
+    "device_id": "r1",
+    "device_owner": "network:router_interface",
+}
+
 
 class TestGatewaySubport:
     def _provider(self, mocker):
@@ -533,6 +562,139 @@ class TestGatewaySubport:
 
         provider._add_gateway_subport({"id": "r1"}, trunk, dict(_GATEWAY_PORT))
 
+        tp.add_subports.assert_not_called()
+        self.clear.assert_not_called()
+
+
+class TestSubportVlanAllocation:
+    def _provider(self, mocker, ranges):
+        mocker.patch.object(
+            palo_alto.utils,
+            "allowed_tenant_vlan_id_ranges",
+            return_value=ranges,
+        )
+        return _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+
+    def test_starts_at_requested_vlan(self, mocker):
+        provider = self._provider(mocker, ranges=[(1, 199), (200, 202)])
+        trunk = {"id": "trunk-1", "sub_ports": []}
+
+        assert (
+            provider._next_available_subport_vlan(
+                "r1", trunk, palo_alto.INTERFACE_SUBPORT_VLAN_START
+            )
+            == 201
+        )
+
+    def test_skips_used_vlans(self, mocker):
+        provider = self._provider(mocker, ranges=[(200, 202)])
+        trunk = {
+            "id": "trunk-1",
+            "sub_ports": [
+                {
+                    "port_id": "gw-1",
+                    "segmentation_type": "vlan",
+                    "segmentation_id": 200,
+                },
+                {
+                    "port_id": "intf-1",
+                    "segmentation_type": "vlan",
+                    "segmentation_id": 201,
+                },
+            ],
+        }
+
+        assert (
+            provider._next_available_subport_vlan(
+                "r1", trunk, palo_alto.INTERFACE_SUBPORT_VLAN_START
+            )
+            == 202
+        )
+
+    def test_raises_when_no_vlan_available(self, mocker):
+        provider = self._provider(mocker, ranges=[(200, 201)])
+        trunk = {
+            "id": "trunk-1",
+            "sub_ports": [
+                {
+                    "port_id": "gw-1",
+                    "segmentation_type": "vlan",
+                    "segmentation_id": 200,
+                },
+                {
+                    "port_id": "intf-1",
+                    "segmentation_type": "vlan",
+                    "segmentation_id": 201,
+                },
+            ],
+        }
+
+        with pytest.raises(palo_alto.NoPaloAltoSubportVlanAvailable):
+            provider._next_available_subport_vlan(
+                "r1", trunk, palo_alto.INTERFACE_SUBPORT_VLAN_START
+            )
+
+
+class TestInterfaceSubport:
+    def _provider(self, mocker):
+        tp = mocker.Mock()
+        tp.add_subports.return_value = {"id": "trunk-1", "updated": True}
+        mocker.patch.object(palo_alto.utils, "fetch_trunk_plugin", return_value=tp)
+        self.clear = mocker.patch.object(palo_alto.utils, "clear_device_id_for_port")
+        self.restore = mocker.patch.object(
+            palo_alto.utils, "set_device_id_and_owner_for_port"
+        )
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        return provider, tp
+
+    def test_adds_subport_with_next_available_vlan(self, mocker):
+        provider, tp = self._provider(mocker)
+        next_vlan = mocker.patch.object(
+            provider, "_next_available_subport_vlan", return_value=201
+        )
+        trunk = {
+            "id": "trunk-1",
+            "sub_ports": [
+                {
+                    "port_id": "gw-1",
+                    "segmentation_type": "vlan",
+                    "segmentation_id": palo_alto.GATEWAY_SUBPORT_VLAN,
+                }
+            ],
+        }
+
+        provider._add_interface_subport({"id": "r1"}, trunk, dict(_INTERFACE_PORT))
+
+        next_vlan.assert_called_once_with(
+            "r1", trunk, palo_alto.INTERFACE_SUBPORT_VLAN_START
+        )
+        tp.add_subports.assert_called_once()
+        _ctx, trunk_id, body = tp.add_subports.call_args[0]
+        assert trunk_id == "trunk-1"
+        sub = body["sub_ports"][0]
+        assert sub["port_id"] == "intf-1"
+        assert sub["segmentation_type"] == "vlan"
+        assert sub["segmentation_id"] == 201
+        self.clear.assert_called_once_with("intf-1")
+        self.restore.assert_called_once_with("intf-1", "r1", "network:router_interface")
+
+    def test_add_subport_is_idempotent(self, mocker):
+        provider, tp = self._provider(mocker)
+        next_vlan = mocker.patch.object(provider, "_next_available_subport_vlan")
+        trunk = {
+            "id": "trunk-1",
+            "sub_ports": [
+                {
+                    "port_id": "intf-1",
+                    "segmentation_type": "vlan",
+                    "segmentation_id": 201,
+                }
+            ],
+        }
+
+        provider._add_interface_subport({"id": "r1"}, trunk, dict(_INTERFACE_PORT))
+
+        next_vlan.assert_not_called()
         tp.add_subports.assert_not_called()
         self.clear.assert_not_called()
 
@@ -594,6 +756,73 @@ class TestGatewayCreateHandler:
             provider._process_gateway_create("r", "e", "t", self._payload(mocker))
 
 
+class TestRouterInterfaceCreateHandler:
+    def _payload(self, mocker, router_id="r1", port=None):
+        payload = mocker.Mock()
+        payload.context = "ctx"
+        payload.resource_id = router_id
+        payload.metadata = {"port": port if port is not None else dict(_INTERFACE_PORT)}
+        return payload
+
+    def test_orchestrates_in_order(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        router = {"id": "r1", "flavor_id": "f1"}
+        provider.l3plugin.get_router.return_value = router
+        mocker.patch.object(provider, "_is_palo_alto_provider", return_value=True)
+        parent = {"id": "parent-1"}
+        bound = {"id": "parent-1", "bound": True}
+        trunk = {"id": "trunk-1"}
+        m_parent = mocker.patch.object(
+            provider, "_ensure_parent_port", return_value=parent
+        )
+        m_vif = mocker.patch.object(
+            provider, "_ensure_parent_vif_attached", return_value=bound
+        )
+        m_trunk = mocker.patch.object(provider, "_ensure_trunk", return_value=trunk)
+        m_sub = mocker.patch.object(provider, "_add_interface_subport")
+
+        provider._process_router_interface_create("r", "e", "t", self._payload(mocker))
+
+        m_parent.assert_called_once_with(router)
+        m_vif.assert_called_once_with(router, parent)
+        m_trunk.assert_called_once_with(router, bound)
+        m_sub.assert_called_once_with(router, trunk, dict(_INTERFACE_PORT))
+
+    def test_skips_non_palo_alto_router(self, mocker):
+        provider = _make_provider(
+            mocker, FakeFlavorPlugin("neutron_understack.l3_router.vrf.Vrf")
+        )
+        provider.l3plugin.get_router.return_value = {"id": "r1", "flavor_id": "f1"}
+        m_parent = mocker.patch.object(provider, "_ensure_parent_port")
+
+        provider._process_router_interface_create("r", "e", "t", self._payload(mocker))
+
+        m_parent.assert_not_called()
+
+    def test_skips_non_router_interface_port(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        provider.l3plugin.get_router.return_value = {"id": "r1", "flavor_id": "f1"}
+        mocker.patch.object(provider, "_is_palo_alto_provider", return_value=True)
+        m_parent = mocker.patch.object(provider, "_ensure_parent_port")
+        port = {**_INTERFACE_PORT, "device_owner": "network:dhcp"}
+
+        provider._process_router_interface_create(
+            "r", "e", "t", self._payload(mocker, port=port)
+        )
+
+        m_parent.assert_not_called()
+
+    def test_raises_when_interface_port_missing(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        provider.l3plugin.get_router.return_value = {"id": "r1", "flavor_id": "f1"}
+        mocker.patch.object(provider, "_is_palo_alto_provider", return_value=True)
+        payload = self._payload(mocker, port=None)
+        payload.metadata = {}
+
+        with pytest.raises(n_exc.BadRequest):
+            provider._process_router_interface_create("r", "e", "t", payload)
+
+
 class TestGatewayTeardown:
     def _provider(self, mocker, trunk_after_removal):
         tp = mocker.Mock()
@@ -628,6 +857,17 @@ class TestGatewayTeardown:
         provider._remove_gateway_subport(trunk, "gw-1")
 
         tp.remove_subports.assert_not_called()
+
+    def test_remove_interface_subport_when_present(self, mocker):
+        provider, tp, _, _ = self._provider(mocker, trunk_after_removal={})
+        trunk = {"id": "trunk-1", "sub_ports": [{"port_id": "intf-1"}]}
+
+        provider._remove_interface_subport(trunk, "intf-1")
+
+        tp.remove_subports.assert_called_once()
+        _ctx, tid, body = tp.remove_subports.call_args[0]
+        assert tid == "trunk-1"
+        assert body["sub_ports"] == [{"port_id": "intf-1"}]
 
     def test_deletes_stack_when_no_subports_left(self, mocker):
         # after removal the trunk has no subports -> delete trunk + parent
@@ -708,6 +948,96 @@ class TestGatewayDeleteHandler:
         provider._process_gateway_delete("r", "e", "t", self._payload(mocker))
 
         m_cleanup.assert_not_called()
+
+
+class TestRouterInterfacePortDeleteHandler:
+    def _payload(self, mocker, port=None):
+        payload = mocker.Mock()
+        payload.context = "ctx"
+        payload.resource_id = "intf-1"
+        payload.metadata = {"port": port if port is not None else dict(_INTERFACE_PORT)}
+        return payload
+
+    def test_cleans_up_before_port_delete_when_palo_alto(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        router = {"id": "r1", "flavor_id": "f1"}
+        provider.l3plugin.get_router.return_value = router
+        mocker.patch.object(provider, "_is_palo_alto_provider", return_value=True)
+        m_cleanup = mocker.patch.object(provider, "_cleanup_interface_attachment")
+
+        provider._process_router_interface_port_delete(
+            "r", "e", "t", self._payload(mocker)
+        )
+
+        m_cleanup.assert_called_once_with(router, dict(_INTERFACE_PORT))
+
+    def test_skips_non_router_interface_port(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        m_cleanup = mocker.patch.object(provider, "_cleanup_interface_attachment")
+        port = {**_INTERFACE_PORT, "device_owner": "network:dhcp"}
+
+        provider._process_router_interface_port_delete(
+            "r", "e", "t", self._payload(mocker, port=port)
+        )
+
+        m_cleanup.assert_not_called()
+        provider.l3plugin.get_router.assert_not_called()
+
+    def test_skips_non_palo_alto_router(self, mocker):
+        provider = _make_provider(
+            mocker, FakeFlavorPlugin("neutron_understack.l3_router.vrf.Vrf")
+        )
+        provider.l3plugin.get_router.return_value = {"id": "r1", "flavor_id": "f1"}
+        m_cleanup = mocker.patch.object(provider, "_cleanup_interface_attachment")
+
+        provider._process_router_interface_port_delete(
+            "r", "e", "t", self._payload(mocker)
+        )
+
+        m_cleanup.assert_not_called()
+
+    def test_skips_when_router_lookup_fails(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        provider.l3plugin.get_router.side_effect = RuntimeError("db hiccup")
+        m_cleanup = mocker.patch.object(provider, "_cleanup_interface_attachment")
+
+        provider._process_router_interface_port_delete(
+            "r", "e", "t", self._payload(mocker)
+        )
+
+        m_cleanup.assert_not_called()
+
+    def test_skips_when_palo_alto_check_fails(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        provider.l3plugin.get_router.return_value = {"id": "r1", "flavor_id": "f1"}
+        mocker.patch.object(
+            provider,
+            "_is_palo_alto_provider",
+            side_effect=RuntimeError("flavor lookup failed"),
+        )
+        m_cleanup = mocker.patch.object(provider, "_cleanup_interface_attachment")
+
+        provider._process_router_interface_port_delete(
+            "r", "e", "t", self._payload(mocker)
+        )
+
+        m_cleanup.assert_not_called()
+
+    def test_cleanup_error_still_raises_for_confirmed_palo_alto(self, mocker):
+        provider = _make_provider(mocker, FakeFlavorPlugin(_palo_alto_driver()))
+        router = {"id": "r1", "flavor_id": "f1"}
+        provider.l3plugin.get_router.return_value = router
+        mocker.patch.object(provider, "_is_palo_alto_provider", return_value=True)
+        mocker.patch.object(
+            provider,
+            "_cleanup_interface_attachment",
+            side_effect=RuntimeError("cleanup failed"),
+        )
+
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            provider._process_router_interface_port_delete(
+                "r", "e", "t", self._payload(mocker)
+            )
 
 
 class TestGatewayCleanupPartialAdd:


### PR DESCRIPTION
https://gist.github.com/nidzrai/955ce3c975c5806ccbebb7d6af79510a 

Test scenerios after review : 

1. Rejected direct port deletion preserves wiring.
2. Failed subnet attachment cleans up newly created  resources.
3. Failed attach-by-port preserves the original port.
4. Retrying that port succeeds.
5. Gateway and subnet reuse the same parent/trunk.
6. Removing either preserves the other’s connection.
7. Removing the last attachment cleans up the unused stack.

```shell
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack baremetal node list
+--------------------------------------+-------------------+--------------------------------------+-------------+-----------------+-------------+
| uuid                                 | name              | instance_uuid                        | power_state | provision_state | maintenance |
+--------------------------------------+-------------------+--------------------------------------+-------------+-----------------+-------------+

| 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb | pa1410-dev-fw5    | 725e25a1-0b02-4435-90f0-d8bb9f5606a3 | None        | active          | False       |
+--------------------------------------+-------------------+--------------------------------------+-------------+-----------------+-------------+
(openstack)
```

```shell 
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack baremetal node show 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
+------------------------+-------------------------------------------------------------------------------------------------------------------+
| Field                  | Value                                                                                                             |
+------------------------+-------------------------------------------------------------------------------------------------------------------+
| uuid                   | 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb                                                                              |
| created_at             | 2026-08-27T16:28:49+00:00                                                                                         |
| updated_at             | 2026-09-10T11:15:25+00:00                                                                                         |
| automated_clean        | False                                                                                                             |
| bios_interface         | no-bios                                                                                                           |
| boot_interface         | ipxe                                                                                                              |
| boot_mode              | None                                                                                                              |
| clean_step             | {}                                                                                                                |
| conductor_group        |                                                                                                                   |
| console_enabled        | False                                                                                                             |
| console_interface      | no-console                                                                                                        |
| disable_power_off      | False                                                                                                             |
| deploy_interface       | noop                                                                                                              |
| deploy_step            | {}                                                                                                                |
| description            | None                                                                                                              |
| driver                 | netdev                                                                                                            |
| driver_info            | {'management_ip': '10.46.96.178', 'management_switch': 'f20-3-1d.iad3', 'management_switch_port': 'Ethernet1/25'} |
| driver_internal_info   | {'deploy_steps': None}                                                                                            |
| extra                  | {'external_cmdb_id': '1354803', 'rack': 'F20-3', 'position': 46}                                                  |
| fault                  | None                                                                                                              |
| firmware_interface     | no-firmware                                                                                                       |
| health                 | None                                                                                                              |
| inspection_finished_at | None                                                                                                              |
| inspection_started_at  | None                                                                                                              |
| inspect_interface      | no-inspect                                                                                                        |
| instance_info          | {}                                                                                                                |
| instance_name          | nidhi-pa-callback-router                                                                                          |
| instance_uuid          | 725e25a1-0b02-4435-90f0-d8bb9f5606a3                                                                              |
| last_error             | None                                                                                                              |
| lessee                 | 32e02632f4f04415bab5895d1e7247b7                                                                                  |
| maintenance            | False                                                                                                             |
| maintenance_reason     | None                                                                                                              |
| management_interface   | noop                                                                                                              |
| name                   | pa1410-dev-fw5                                                                                                    |
| network_data           | {}                                                                                                                |
| network_interface      | neutron                                                                                                           |
| owner                  | 32e02632f4f04415bab5895d1e7247b7                                                                                  |
| parent_node            | None                                                                                                              |
| power_interface        | fake                                                                                                              |
| power_state            | None                                                                                                              |
| properties             | {}                                                                                                                |
| protected              | False                                                                                                             |
| protected_reason       | None                                                                                                              |
| provision_state        | active                                                                                                            |
| provision_updated_at   | 2026-09-10T11:15:25+00:00                                                                                         |
| raid_config            | {}                                                                                                                |
| raid_interface         | no-raid                                                                                                           |
| rescue_interface       | no-rescue                                                                                                         |
| reservation            | None                                                                                                              |
| resource_class         | pa1410                                                                                                            |
| retired                | False                                                                                                             |
| retired_reason         | None                                                                                                              |
| secure_boot            | None                                                                                                              |
| service_step           | {}                                                                                                                |
| shard                  | None                                                                                                              |
| storage_interface      | noop                                                                                                              |
| target_power_state     | None                                                                                                              |
| target_provision_state | None                                                                                                              |
| target_raid_config     | {}                                                                                                                |
| traits                 | []                                                                                                                |
| vendor_interface       | no-vendor                                                                                                         |
| conductor              | 1327175-hp3                                                                                                       |
| allocation_uuid        | None                                                                                                              |
| chassis_uuid           | None                                                                                                              |
+------------------------+-------------------------------------------------------------------------------------------------------------------+
(openstack)
```
```shell
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 2s
❯ openstack network create nidhi-pa-callback-net
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2026-09-10T11:24:00Z                 |
| description               |                                      |
| dns_domain                | None                                 |
| id                        | 1ef1ceac-ced6-4919-87b8-7d3dd9bd1867 |
| ipv4_address_scope        | None                                 |
| ipv6_address_scope        | None                                 |
| is_default                | False                                |
| is_vlan_qinq              | None                                 |
| is_vlan_transparent       | False                                |
| l2_adjacency              | True                                 |
| mtu                       | 9000                                 |
| name                      | nidhi-pa-callback-net                |
| port_security_enabled     | True                                 |
| project_id                | 32e02632f4f04415bab5895d1e7247b7     |
| provider:network_type     | vxlan                                |
| provider:physical_network | None                                 |
| provider:segmentation_id  | 1810                                 |
| pvlan                     | None                                 |
| qinq                      | False                                |
| qos_policy_id             | None                                 |
| revision_number           | 1                                    |
| router:external           | Internal                             |
| segments                  | None                                 |
| shared                    | False                                |
| status                    | ACTIVE                               |
| subnets                   |                                      |
| tags                      |                                      |
| updated_at                | 2026-09-10T11:24:01Z                 |
+---------------------------+--------------------------------------+
```

```shell
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ openstack subnet create nidhi-pa-callback-sub \
  --network nidhi-pa-callback-net \
  --subnet-range 10.203.0.0/24 \
  --gateway 10.203.0.1
+----------------------+--------------------------------------+
| Field                | Value                                |
+----------------------+--------------------------------------+
| allocation_pools     | 10.203.0.2-10.203.0.254              |
| cidr                 | 10.203.0.0/24                        |
| created_at           | 2026-09-10T11:24:17Z                 |
| description          |                                      |
| dns_nameservers      |                                      |
| dns_publish_fixed_ip | None                                 |
| enable_dhcp          | True                                 |
| gateway_ip           | 10.203.0.1                           |
| host_routes          |                                      |
| id                   | a598c096-cdb2-4bb5-82a4-1de3e53da6db |
| ip_version           | 4                                    |
| ipv6_address_mode    | None                                 |
| ipv6_ra_mode         | None                                 |
| name                 | nidhi-pa-callback-sub                |
| network_id           | 1ef1ceac-ced6-4919-87b8-7d3dd9bd1867 |
| project_id           | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number      | 0                                    |
| router:external      | False                                |
| segment_id           | None                                 |
| service_types        |                                      |
| subnetpool_id        | None                                 |
| tags                 |                                      |
| updated_at           | 2026-09-10T11:24:17Z                 |
+----------------------+--------------------------------------+
```
```shell
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ openstack router show 725e25a1-0b02-4435-90f0-d8bb9f5606a3
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2026-09-10T11:15:26Z                 |
| description               |                                      |
| enable_default_route_bfd  | False                                |
| enable_default_route_ecmp | False                                |
| enable_ndp_proxy          | None                                 |
| enable_snat               | True                                 |
| evpn_vni                  | None                                 |
| external_gateway_info     | null                                 |
| external_gateways         | []                                   |
| flavor_id                 | a9db3546-6d64-4d62-84f3-3baf90f11bdf |
| ha                        | False                                |
| id                        | 725e25a1-0b02-4435-90f0-d8bb9f5606a3 |
| interfaces_info           | []                                   |
| name                      | nidhi-pa-callback-router             |
| project_id                | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number           | 1                                    |
| routes                    |                                      |
| status                    | ACTIVE                               |
| tags                      |                                      |
| updated_at                | 2026-09-10T11:15:26Z                 |
+---------------------------+--------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 8s
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 50s
❯ openstack router show 725e25a1-0b02-4435-90f0-d8bb9f5606a3
+---------------------------+---------------------------------------------------------------------------------------------------------------------+
| Field                     | Value                                                                                                               |
+---------------------------+---------------------------------------------------------------------------------------------------------------------+
| admin_state_up            | UP                                                                                                                  |
| availability_zone_hints   |                                                                                                                     |
| availability_zones        |                                                                                                                     |
| created_at                | 2026-09-10T11:15:26Z                                                                                                |
| description               |                                                                                                                     |
| enable_default_route_bfd  | False                                                                                                               |
| enable_default_route_ecmp | False                                                                                                               |
| enable_ndp_proxy          | None                                                                                                                |
| enable_snat               | True                                                                                                                |
| evpn_vni                  | None                                                                                                                |
| external_gateway_info     | null                                                                                                                |
| external_gateways         | []                                                                                                                  |
| flavor_id                 | a9db3546-6d64-4d62-84f3-3baf90f11bdf                                                                                |
| ha                        | False                                                                                                               |
| id                        | 725e25a1-0b02-4435-90f0-d8bb9f5606a3                                                                                |
| interfaces_info           | [{"port_id": "7b89688a-d6a8-4283-af13-9942378313d1", "ip_address": "10.203.0.1", "subnet_id":                       |
|                           | "a598c096-cdb2-4bb5-82a4-1de3e53da6db"}]                                                                            |
| name                      | nidhi-pa-callback-router                                                                                            |
| project_id                | 32e02632f4f04415bab5895d1e7247b7                                                                                    |
| revision_number           | 2                                                                                                                   |
| routes                    |                                                                                                                     |
| status                    | ACTIVE                                                                                                              |
| tags                      |                                                                                                                     |
| updated_at                | 2026-09-10T11:26:21Z                                                                                                |
+---------------------------+---------------------------------------------------------------------------------------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack network trunk show "palo-alto-router-trunk-$RID"
+-------------------+-------------------------------------------------------------------------------------------------+
| Field             | Value                                                                                           |
+-------------------+-------------------------------------------------------------------------------------------------+
| created_at        | 2026-09-10T11:26:08Z                                                                            |
| description       |                                                                                                 |
| id                | 71576d0f-8cf1-4469-a5a0-53e67607a4dc                                                            |
| is_admin_state_up | True                                                                                            |
| name              | palo-alto-router-trunk-725e25a1-0b02-4435-90f0-d8bb9f5606a3                                     |
| port_id           | c659020e-94cc-4d14-ab3c-fb5b82bd79c9                                                            |
| project_id        |                                                                                                 |
| revision_number   | 3                                                                                               |
| status            | ACTIVE                                                                                          |
| sub_ports         | port_id='7b89688a-d6a8-4283-af13-9942378313d1', segmentation_id='201', segmentation_type='vlan' |
| tags              | []                                                                                              |
| updated_at        | 2026-09-10T11:26:10Z                                                                            |
+-------------------+-------------------------------------------------------------------------------------------------+
```
```shell
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack router add subnet "$RID" nidhi-pa-callback-sub
BadRequestException: 400: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/routers/725e25a1-0b02-4435-90f0-d8bb9f5606a3/add_router_interface, Bad router request: Cidr 10.203.0.0/24 of subnet a598c096-cdb2-4bb5-82a4-1de3e53da6db overlaps with cidr 10.203.0.0/24 of subnet a598c096-cdb2-4bb5-82a4-1de3e53da6db.
```
```shell
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ openstack port show 7b89688a-d6a8-4283-af13-9942378313d1
+-------------------------+---------------------------------------------------------------------------+
| Field                   | Value                                                                     |
+-------------------------+---------------------------------------------------------------------------+
| admin_state_up          | UP                                                                        |
| allowed_address_pairs   |                                                                           |
| binding_host_id         |                                                                           |
| binding_profile         | parent_name='c659020e-94cc-4d14-ab3c-fb5b82bd79c9', tag='201'             |
| binding_vif_details     | bound_drivers.0='understack'                                              |
| binding_vif_type        | ovs                                                                       |
| binding_vnic_type       | normal                                                                    |
| created_at              | 2026-09-10T11:25:44Z                                                      |
| data_plane_status       | None                                                                      |
| description             |                                                                           |
| device_id               | 725e25a1-0b02-4435-90f0-d8bb9f5606a3                                      |
| device_owner            | network:router_interface                                                  |
| device_profile          | None                                                                      |
| dns_assignment          |                                                                           |
| dns_domain              | None                                                                      |
| dns_name                | None                                                                      |
| extra_dhcp_opts         |                                                                           |
| fixed_ips               | ip_address='10.203.0.1', subnet_id='a598c096-cdb2-4bb5-82a4-1de3e53da6db' |
| hardware_offload_type   | None                                                                      |
| hints                   |                                                                           |
| id                      | 7b89688a-d6a8-4283-af13-9942378313d1                                      |
| ip_allocation           | immediate                                                                 |
| mac_address             | fa:16:3e:c6:23:f2                                                         |
| name                    |                                                                           |
| network_id              | 1ef1ceac-ced6-4919-87b8-7d3dd9bd1867                                      |
| numa_affinity_policy    | None                                                                      |
| port_security_enabled   | False                                                                     |
| project_id              | 32e02632f4f04415bab5895d1e7247b7                                          |
| propagate_uplink_status | None                                                                      |
| pvlan_type              | None                                                                      |
| pvlan_community         | None                                                                      |
| resource_request        | None                                                                      |
| revision_number         | 3                                                                         |
| qos_network_policy_id   | None                                                                      |
| qos_policy_id           | None                                                                      |
| security_group_ids      |                                                                           |
| status                  | ACTIVE                                                                    |
| tags                    |                                                                           |
| trunk_details           | None                                                                      |
| trusted                 | None                                                                      |
| updated_at              | 2026-09-10T11:26:21Z                                                      |
+-------------------------+---------------------------------------------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack port show c659020e-94cc-4d14-ab3c-fb5b82bd79c9
+-------------------------+-----------------------------------------------------------------------------------------------------------------------+
| Field                   | Value                                                                                                                 |
+-------------------------+-----------------------------------------------------------------------------------------------------------------------+
| admin_state_up          | UP                                                                                                                    |
| allowed_address_pairs   |                                                                                                                       |
| binding_host_id         | 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb                                                                                  |
| binding_profile         | local_link_information='[{'switch_id': '00:00:00:00:00:00', 'switch_info': 'f20-3-1.iad3', 'port_id':                 |
|                         | 'Ethernet1/43'}]', physical_network='f20-3-network'                                                                   |
| binding_vif_details     | bound_drivers.0='understack', bound_drivers.1='undersync'                                                             |
| binding_vif_type        | other                                                                                                                 |
| binding_vnic_type       | baremetal                                                                                                             |
| created_at              | 2026-09-10T11:25:46Z                                                                                                  |
| data_plane_status       | None                                                                                                                  |
| description             | None                                                                                                                  |
| device_id               | 725e25a1-0b02-4435-90f0-d8bb9f5606a3                                                                                  |
| device_owner            |                                                                                                                       |
| device_profile          | None                                                                                                                  |
| dns_assignment          |                                                                                                                       |
| dns_domain              | None                                                                                                                  |
| dns_name                | None                                                                                                                  |
| extra_dhcp_opts         |                                                                                                                       |
| fixed_ips               |                                                                                                                       |
| hardware_offload_type   | None                                                                                                                  |
| hints                   |                                                                                                                       |
| id                      | c659020e-94cc-4d14-ab3c-fb5b82bd79c9                                                                                  |
| ip_allocation           | none                                                                                                                  |
| mac_address             | 00:00:00:00:00:43                                                                                                     |
| name                    | palo-alto-router-anchor-725e25a1-0b02-4435-90f0-d8bb9f5606a3                                                          |
| network_id              | 23ffa9dd-4aea-4178-94da-a667957a9039                                                                                  |
| numa_affinity_policy    | None                                                                                                                  |
| port_security_enabled   | True                                                                                                                  |
| project_id              |                                                                                                                       |
| propagate_uplink_status | None                                                                                                                  |
| pvlan_type              | None                                                                                                                  |
| pvlan_community         | None                                                                                                                  |
| resource_request        | None                                                                                                                  |
| revision_number         | 5                                                                                                                     |
| qos_network_policy_id   | None                                                                                                                  |
| qos_policy_id           | None                                                                                                                  |
| security_group_ids      | 4e72ab8e-8a34-4c4f-849e-f3d6706d8cbb                                                                                  |
| status                  | ACTIVE                                                                                                                |
| tags                    |                                                                                                                       |
| trunk_details           | {'trunk_id': '71576d0f-8cf1-4469-a5a0-53e67607a4dc', 'sub_ports': [{'segmentation_id': 201, 'segmentation_type':      |
|                         | 'vlan', 'port_id': '7b89688a-d6a8-4283-af13-9942378313d1', 'mac_address': 'fa:16:3e:c6:23:f2'}]}                      |
| trusted                 | None                                                                                                                  |
| updated_at              | 2026-09-10T11:25:57Z                                                                                                  |
+-------------------------+-----------------------------------------------------------------------------------------------------------------------+
(openstack)
```
 subnet first attachment worked 

```shell
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ export INTF_PORT=7b89688a-d6a8-4283-af13-9942378313d1
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal)
❯ openstack port delete "$INTF_PORT"
Failed to delete port with name or ID '7b89688a-d6a8-4283-af13-9942378313d1': ConflictException: 409: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/ports/7b89688a-d6a8-4283-af13-9942378313d1, Port 7b89688a-d6a8-4283-af13-9942378313d1 cannot be deleted directly via the port API: Callback neutron.db.l3_db.L3_NAT_dbonly_mixin._prevent_l3_port_delete_callback-8137171769294 failed with "Port 7b89688a-d6a8-4283-af13-9942378313d1 cannot be deleted directly via the port API: has device owner network:router_interface.",Callback neutron.services.trunk.rules.enforce_port_deletion_rules-8137171486954 failed with "Port 7b89688a-d6a8-4283-af13-9942378313d1 is currently a subport for trunk 71576d0f-8cf1-4469-a5a0-53e67607a4dc.".
1 of 1 ports failed to delete.
```
```shell
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack port show "$INTF_PORT" \
  -c device_id -c device_owner -c fixed_ips -f yaml
device_id: 725e25a1-0b02-4435-90f0-d8bb9f5606a3
device_owner: network:router_interface
fixed_ips:
- ip_address: 10.203.0.1
  subnet_id: a598c096-cdb2-4bb5-82a4-1de3e53da6db
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack network trunk show "palo-alto-router-trunk-$RID" \
  -c port_id -c sub_ports -f yaml
port_id: c659020e-94cc-4d14-ab3c-fb5b82bd79c9
sub_ports:
- port_id: 7b89688a-d6a8-4283-af13-9942378313d1
  segmentation_id: 201
  segmentation_type: vlan
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack router show "$RID" -c interfaces_info -f yaml
interfaces_info:
- ip_address: 10.203.0.1
  port_id: 7b89688a-d6a8-4283-af13-9942378313d1
  subnet_id: a598c096-cdb2-4bb5-82a4-1de3e53da6db

understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack router remove subnet "$RID" nidhi-pa-callback-sub
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 34s

```
```shell
Log:
2026-09-10 11:35:54.826 8 INFO neutron_understack.l3_router.palo_alto [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Removing Palo Alto interface subport 7b89688a-d6a8-4283-af13-9942378313d1 from trunk 71576d0f-8cf1-4469-a5a0-53e67607a4dc
2026-09-10 11:35:54.826 8 INFO neutron_understack.l3_router.palo_alto [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Removing Palo Alto interface subport 7b89688a-d6a8-4283-af13-9942378313d1 from trunk 71576d0f-8cf1-4469-a5a0-53e67607a4dc
2026-09-10 11:36:05.135 8 INFO neutron_understack.l3_router.palo_alto [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Deleting Palo Alto trunk 71576d0f-8cf1-4469-a5a0-53e67607a4dc (no subports left) for router 725e25a1-0b02-4435-90f0-d8bb9f5606a3
2026-09-10 11:36:05.135 8 INFO neutron_understack.l3_router.palo_alto [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Deleting Palo Alto trunk 71576d0f-8cf1-4469-a5a0-53e67607a4dc (no subports left) for router 725e25a1-0b02-4435-90f0-d8bb9f5606a3
2026-09-10 11:36:05.269 8 WARNING openstack [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Disabling service 'compute': Encountered an exception attempting to process config for project 'nova' (service type 'compute'): no such option valid_interfaces in group [nova]: oslo_config.cfg.NoSuchOptError: no such option valid_interfaces in group [nova]
2026-09-10 11:36:05.280 8 WARNING openstack [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Disabling service 'placement': Encountered an exception attempting to process config for project 'placement' (service type 'placement'): no such option valid_interfaces in group [placement]: oslo_config.cfg.NoSuchOptError: no such option valid_interfaces in group [placement]
2026-09-10 11:36:05.981 8 INFO neutron_understack.ironic [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Detaching VIF c659020e-94cc-4d14-ab3c-fb5b82bd79c9 from Ironic node 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
2026-09-10 11:36:05.981 8 INFO neutron_understack.ironic [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Detaching VIF c659020e-94cc-4d14-ab3c-fb5b82bd79c9 from Ironic node 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
2026-09-10 11:36:06.788 7 INFO neutron.pecan_wsgi.hooks.translation [req-2e1af8af-76d0-40e4-8bb3-c8ba98cf8917 req-23fb283b-5fc1-48d6-b0ed-27b70bc9a8e4 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:36:06.788 7 INFO neutron.pecan_wsgi.hooks.translation [req-2e1af8af-76d0-40e4-8bb3-c8ba98cf8917 req-23fb283b-5fc1-48d6-b0ed-27b70bc9a8e4 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:36:07.484 8 INFO neutron.pecan_wsgi.hooks.translation [req-2e1af8af-76d0-40e4-8bb3-c8ba98cf8917 req-3bdca4de-010b-4bf1-8fd6-54086c7dc60e 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:36:07.484 8 INFO neutron.pecan_wsgi.hooks.translation [req-2e1af8af-76d0-40e4-8bb3-c8ba98cf8917 req-3bdca4de-010b-4bf1-8fd6-54086c7dc60e 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:36:21.585 8 INFO neutron_understack.l3_router.palo_alto [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Deleting Palo Alto anchor parent port c659020e-94cc-4d14-ab3c-fb5b82bd79c9
2026-09-10 11:36:21.585 8 INFO neutron_understack.l3_router.palo_alto [None req-0ab65ab4-363b-4495-ba3a-6f8e5fd2691e 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] Deleting Palo Alto anchor parent port c659020e-94cc-4d14-ab3c-fb5b82bd79c9
2026-09-10 11:36:21.945 8 INFO neutron_understack.l3_router.palo_alto [None req-be68fba5-3e56-4398-b178-df106186238a - - - - - -] Cleaned Palo Alto router 725e25a1-0b02-4435-90f0-d8bb9f5606a3 interface attachment (port 7b89688a-d6a8-4283-af13-9942378313d1)
2026-09-10 11:36:21.945 8 INFO neutron_understack.l3_router.palo_alto [None req-be68fba5-3e56-4398-b178-df106186238a - - - - - -] Cleaned Palo Alto router 725e25a1-0b02-4435-90f0-d8bb9f5606a3 interface attachment (port 7b89688a-d6a8-4283-af13-9942378313d1)
2026-09-10 11:36:07.484 8 INFO neutron.pecan_wsgi.hooks.translation [req-2e1af8af-76d0-40e4-8bb3-c8ba98cf8917 req-3bdca4de-010b-4bf1-8fd6-54086c7dc60e 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
```

```shell
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack router remove subnet "$RID" nidhi-pa-callback-sub
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 34s
❯ openstack router show "$RID" -c interfaces_info -f yaml
interfaces_info: []
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ openstack port show "$INTF_PORT"
openstack network trunk show "palo-alto-router-trunk-$RID"
openstack port show c659020e-94cc-4d14-ab3c-fb5b82bd79c9
No Port found for 7b89688a-d6a8-4283-af13-9942378313d1
No Trunk found for palo-alto-router-trunk-725e25a1-0b02-4435-90f0-d8bb9f5606a3
No Port found for c659020e-94cc-4d14-ab3c-fb5b82bd79c9
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 13s
❯ openstack baremetal node vif list 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb

(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ openstack router show "$RID"
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2026-09-10T11:15:26Z                 |
| description               |                                      |
| enable_default_route_bfd  | False                                |
| enable_default_route_ecmp | False                                |
| enable_ndp_proxy          | None                                 |
| enable_snat               | True                                 |
| evpn_vni                  | None                                 |
| external_gateway_info     | null                                 |
| external_gateways         | []                                   |
| flavor_id                 | a9db3546-6d64-4d62-84f3-3baf90f11bdf |
| ha                        | False                                |
| id                        | 725e25a1-0b02-4435-90f0-d8bb9f5606a3 |
| interfaces_info           | []                                   |
| name                      | nidhi-pa-callback-router             |
| project_id                | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number           | 3                                    |
| routes                    |                                      |
| status                    | ACTIVE                               |
| tags                      |                                      |
| updated_at                | 2026-09-10T11:36:22Z                 |
+---------------------------+--------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
```

remove subport → delete empty trunk → detach VIF → delete parent → report cleanup complete 


```shell
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 21s
❯ openstack router add subnet "$RID" nidhi-pa-callback-sub
ConflictException: 409: Client Error for url: https://neutron.iad3-dev.undercloud.rackspace.net/v2.0/routers/725e25a1-0b02-4435-90f0-d8bb9f5606a3/add_router_interface, Error cannot perform router interface attachment due to Callback neutron_understack.l3_router.palo_alto.PaloAlto._process_router_interface_create-371371 failed with "Injected subnet attachment failure" while attempting the operation.
(openstack)
```
```shell
2026-09-10 11:56:23.344 9 INFO neutron_understack.ironic [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Attaching VIF 05a8d358-e7fb-4b35-b823-3a4c9052323b to Ironic node 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
2026-09-10 11:56:23.344 9 INFO neutron_understack.ironic [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Attaching VIF 05a8d358-e7fb-4b35-b823-3a4c9052323b to Ironic node 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
2026-09-10 11:56:24.587 7 INFO neutron.pecan_wsgi.hooks.translation [req-78342210-2c9d-4429-a403-905e82c07925 req-8726aa8d-96da-46a4-9f37-9340db87bf53 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:56:24.587 7 INFO neutron.pecan_wsgi.hooks.translation [req-78342210-2c9d-4429-a403-905e82c07925 req-8726aa8d-96da-46a4-9f37-9340db87bf53 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:56:25.378 8 WARNING neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.ovn_client [None req-a00b25df-7c61-4903-aa64-80e99445ea91 - - - - - -] No hosting information found for port 05a8d358-e7fb-4b35-b823-3a4c9052323b: RuntimeError: No hosting information found for port 05a8d358-e7fb-4b35-b823-3a4c9052323b
2026-09-10 11:56:25.378 8 WARNING neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.ovn_client [None req-a00b25df-7c61-4903-aa64-80e99445ea91 - - - - - -] No hosting information found for port 05a8d358-e7fb-4b35-b823-3a4c9052323b: RuntimeError: No hosting information found for port 05a8d358-e7fb-4b35-b823-3a4c9052323b
2026-09-10 11:56:25.767 11 INFO neutron.pecan_wsgi.hooks.translation [req-78342210-2c9d-4429-a403-905e82c07925 req-9a8aff04-261f-4813-954d-e650c8003933 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:56:25.767 11 INFO neutron.pecan_wsgi.hooks.translation [req-78342210-2c9d-4429-a403-905e82c07925 req-9a8aff04-261f-4813-954d-e650c8003933 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:56:31.580 10 INFO neutron_understack.neutron_understack_mech [req-78342210-2c9d-4429-a403-905e82c07925 req-067941da-8a5a-41d1-8678-6061493528bc 22fda78801004c82aeab2317931052b8 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] vlan segment: {'id': 'af5e802e-1b4a-446d-bae5-da25e1b3e345', 'network_type': 'vlan', 'physical_network': 'f20-3-network', 'segmentation_id': 1801, 'network_id': '23ffa9dd-4aea-4178-94da-a667957a9039'} already preset for physnet: f20-3-network
2026-09-10 11:56:31.580 10 INFO neutron_understack.neutron_understack_mech [req-78342210-2c9d-4429-a403-905e82c07925 req-067941da-8a5a-41d1-8678-6061493528bc 22fda78801004c82aeab2317931052b8 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] vlan segment: {'id': 'af5e802e-1b4a-446d-bae5-da25e1b3e345', 'network_type': 'vlan', 'physical_network': 'f20-3-network', 'segmentation_id': 1801, 'network_id': '23ffa9dd-4aea-4178-94da-a667957a9039'} already preset for physnet: f20-3-network
2026-09-10 11:56:43.551 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Creating Palo Alto trunk palo-alto-router-trunk-725e25a1-0b02-4435-90f0-d8bb9f5606a3 on parent port 05a8d358-e7fb-4b35-b823-3a4c9052323b for router 725e25a1-0b02-4435-90f0-d8bb9f5606a3
2026-09-10 11:56:43.551 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Creating Palo Alto trunk palo-alto-router-trunk-725e25a1-0b02-4435-90f0-d8bb9f5606a3 on parent port 05a8d358-e7fb-4b35-b823-3a4c9052323b for router 725e25a1-0b02-4435-90f0-d8bb9f5606a3
2026-09-10 11:56:43.785 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Adding Palo Alto interface port 53b86f5c-62ed-4940-a827-22cd86d60601 to trunk 8cefb364-73a7-4d89-8e4d-a4710377adfa as VLAN 201 subport for router 725e25a1-0b02-4435-90f0-d8bb9f5606a3
2026-09-10 11:56:43.785 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Adding Palo Alto interface port 53b86f5c-62ed-4940-a827-22cd86d60601 to trunk 8cefb364-73a7-4d89-8e4d-a4710377adfa as VLAN 201 subport for router 725e25a1-0b02-4435-90f0-d8bb9f5606a3
2026-09-10 11:56:44.025 9 WARNING openstack [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Disabling service 'compute': Encountered an exception attempting to process config for project 'nova' (service type 'compute'): no such option valid_interfaces in group [nova]: oslo_config.cfg.NoSuchOptError: no such option valid_interfaces in group [nova]
2026-09-10 11:56:44.030 9 WARNING openstack [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Disabling service 'placement': Encountered an exception attempting to process config for project 'placement' (service type 'placement'): no such option valid_interfaces in group [placement]: oslo_config.cfg.NoSuchOptError: no such option valid_interfaces in group [placement]
2026-09-10 11:56:44.819 9 INFO neutron_understack.utils [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Found network node trunk: 2e558202-0bd0-4971-a9f8-61d1adea0427 (parent_port: b20be064-000d-47c2-9d4b-f11b3efe4027, host: 1327172-hp1)
2026-09-10 11:56:44.819 9 INFO neutron_understack.utils [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Found network node trunk: 2e558202-0bd0-4971-a9f8-61d1adea0427 (parent_port: b20be064-000d-47c2-9d4b-f11b3efe4027, host: 1327172-hp1)
2026-09-10 11:56:44.820 9 INFO neutron_understack.utils [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Discovered and cached network node trunk ID: 2e558202-0bd0-4971-a9f8-61d1adea0427 (gateway_host: 1327172-hp1, gateway_uuid: 7ca98881-bca5-4c82-9369-66eb36292a95)
2026-09-10 11:56:44.820 9 INFO neutron_understack.utils [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Discovered and cached network node trunk ID: 2e558202-0bd0-4971-a9f8-61d1adea0427 (gateway_host: 1327172-hp1, gateway_uuid: 7ca98881-bca5-4c82-9369-66eb36292a95)
2026-09-10 11:56:45.034 9 INFO neutron.db.segments_db [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Added segment f2d2cb75-e5f9-43a6-bfa7-d63f6dbcfdc0 of type vlan for network 1ef1ceac-ced6-4919-87b8-7d3dd9bd1867
2026-09-10 11:56:45.034 9 INFO neutron.db.segments_db [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Added segment f2d2cb75-e5f9-43a6-bfa7-d63f6dbcfdc0 of type vlan for network 1ef1ceac-ced6-4919-87b8-7d3dd9bd1867
2026-09-10 11:56:56.337 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Removing Palo Alto interface subport 53b86f5c-62ed-4940-a827-22cd86d60601 from trunk 8cefb364-73a7-4d89-8e4d-a4710377adfa
2026-09-10 11:56:56.337 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Removing Palo Alto interface subport 53b86f5c-62ed-4940-a827-22cd86d60601 from trunk 8cefb364-73a7-4d89-8e4d-a4710377adfa
2026-09-10 11:57:08.849 9 INFO neutron_understack.ironic [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Detaching VIF 05a8d358-e7fb-4b35-b823-3a4c9052323b from Ironic node 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
2026-09-10 11:57:08.849 9 INFO neutron_understack.ironic [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Detaching VIF 05a8d358-e7fb-4b35-b823-3a4c9052323b from Ironic node 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
2026-09-10 11:57:09.571 7 INFO neutron.pecan_wsgi.hooks.translation [req-81e836aa-3719-47e3-825f-b0bdf77d7969 req-094b2856-054c-4108-bd8e-08c6bc42d563 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:57:09.571 7 INFO neutron.pecan_wsgi.hooks.translation [req-81e836aa-3719-47e3-825f-b0bdf77d7969 req-094b2856-054c-4108-bd8e-08c6bc42d563 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:57:10.770 8 INFO neutron.pecan_wsgi.hooks.translation [req-81e836aa-3719-47e3-825f-b0bdf77d7969 req-17948078-f538-4129-8533-58677e14c9e7 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:57:10.770 8 INFO neutron.pecan_wsgi.hooks.translation [req-81e836aa-3719-47e3-825f-b0bdf77d7969 req-17948078-f538-4129-8533-58677e14c9e7 0eb5724d7c074f63bdb565e2398062cf 5cd5ec5f3c2f4b278920416234573570 - - a6f7dcd63c9b4940915062f57a48df77 a6f7dcd63c9b4940915062f57a48df77] GET failed (client error): The resource could not be found.
2026-09-10 11:57:24.924 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Deleting Palo Alto anchor parent port 05a8d358-e7fb-4b35-b823-3a4c9052323b
2026-09-10 11:57:24.924 9 INFO neutron_understack.l3_router.palo_alto [None req-47331b86-f006-4927-b430-3c9492601709 - - - - - -] Deleting Palo Alto anchor parent port 05a8d358-e7fb-4b35-b823-3a4c9052323b
2026-09-10 11:57:25.922 9 INFO neutron.api.v2.resource [None req-04f5579f-dddb-499c-9861-c7bfcde0a7d8 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] add_router_interface failed (client error): There was a conflict when trying to complete your request.
2026-09-10 11:57:25.922 9 INFO neutron.api.v2.resource [None req-04f5579f-dddb-499c-9861-c7bfcde0a7d8 684d9ee39a5f3fac9239338ed3026116d96dd6267e9aeb631fb2c4eb9c160f2b 32e02632f4f04415bab5895d1e7247b7 - - 1f75c3b20fcb41ec924a71be83a5ee94 7f46f53fcb3c4625a343eaa35b5e0d04] add_router_interface failed (client error): There was a conflict when trying to complete your request.
```
❯
gateway attachment reuses this existing subnet trunk

```shell
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 14s
❯ openstack router set --external-gateway PUBLICNET "$RID"
openstack network trunk show "palo-alto-router-trunk-$RID" \
  -c port_id -c sub_ports -f yaml
port_id: 810fc5d8-024b-4aca-9122-52c8df7c13d7
sub_ports:
- port_id: 0eb78930-c8ec-4527-8b11-fe73e7a5cb6b
  segmentation_id: 200
  segmentation_type: vlan
- port_id: bd51d4a0-127e-42d5-91a4-0a2b1c54a99d
  segmentation_id: 201
  segmentation_type: vlan
(openstack)

```

removing the subnet preserves the gateway’s shared wiring

```shell
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 28s
❯ openstack router remove port "$RID" "$TEST_PORT"
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 18s
❯ openstack network trunk show "palo-alto-router-trunk-$RID" \
  -c port_id -c sub_ports -f yaml
port_id: 810fc5d8-024b-4aca-9122-52c8df7c13d7
sub_ports:
- port_id: 0eb78930-c8ec-4527-8b11-fe73e7a5cb6b
  segmentation_id: 200
  segmentation_type: vlan
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯ openstack baremetal node vif list 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
+--------------------------------------+
| id                                   |
+--------------------------------------+
| 810fc5d8-024b-4aca-9122-52c8df7c13d7 |
+--------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 6s
❯ openstack router show "$RID" \
  -c interfaces_info -c external_gateway_info -f yaml
external_gateway_info:
  enable_snat: true
  external_fixed_ips:
  - ip_address: 204.232.163.34
    subnet_id: 36ecd265-c0cc-4079-ad73-1101164b4a5f
  network_id: 356bb8c1-1470-452f-99e2-6252585c847a
interfaces_info: []
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯  openstack router show "$RID"
+---------------------------+-------------------------------------------------------------------------------------------------------------------------------+
| Field                     | Value                                                                                                                         |
+---------------------------+-------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up            | UP                                                                                                                            |
| availability_zone_hints   |                                                                                                                               |
| availability_zones        |                                                                                                                               |
| created_at                | 2026-09-10T11:15:26Z                                                                                                          |
| description               |                                                                                                                               |
| enable_default_route_bfd  | False                                                                                                                         |
| enable_default_route_ecmp | False                                                                                                                         |
| enable_ndp_proxy          | None                                                                                                                          |
| enable_snat               | True                                                                                                                          |
| evpn_vni                  | None                                                                                                                          |
| external_gateway_info     | {"network_id": "356bb8c1-1470-452f-99e2-6252585c847a", "external_fixed_ips": [{"subnet_id":                                   |
|                           | "36ecd265-c0cc-4079-ad73-1101164b4a5f", "ip_address": "204.232.163.34"}], "enable_snat": true}                                |
| external_gateways         | [{'network_id': '356bb8c1-1470-452f-99e2-6252585c847a', 'external_fixed_ips': [{'ip_address': '204.232.163.34', 'subnet_id':  |
|                           | '36ecd265-c0cc-4079-ad73-1101164b4a5f'}]}]                                                                                    |
| flavor_id                 | a9db3546-6d64-4d62-84f3-3baf90f11bdf                                                                                          |
| ha                        | False                                                                                                                         |
| id                        | 725e25a1-0b02-4435-90f0-d8bb9f5606a3                                                                                          |
| interfaces_info           | []                                                                                                                            |
| name                      | nidhi-pa-callback-router                                                                                                      |
| project_id                | 32e02632f4f04415bab5895d1e7247b7                                                                                              |
| revision_number           | 6                                                                                                                             |
| routes                    |                                                                                                                               |
| status                    | ACTIVE                                                                                                                        |
| tags                      |                                                                                                                               |
| updated_at                | 2026-09-10T12:24:34Z                                                                                                          |
+---------------------------+-------------------------------------------------------------------------------------------------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯
❯understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack router add subnet "$RID" nidhi-pa-callback-sub
openstack network trunk show "palo-alto-router-trunk-$RID" \
  -c port_id -c sub_ports -f yaml
port_id: 810fc5d8-024b-4aca-9122-52c8df7c13d7
sub_ports:
- port_id: 0eb78930-c8ec-4527-8b11-fe73e7a5cb6b
  segmentation_id: 200
  segmentation_type: vlan
- port_id: 331c78d8-2bf4-4836-84d6-9a8f1432d37a
  segmentation_id: 201
  segmentation_type: vlan
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 43s
❯ openstack network trunk show "palo-alto-router-trunk-$RID"
+-------------------+-------------------------------------------------------------------------------------------------+
| Field             | Value                                                                                           |
+-------------------+-------------------------------------------------------------------------------------------------+
| created_at        | 2026-09-10T12:21:36Z                                                                            |
| description       |                                                                                                 |
| id                | 7b6dcec6-8881-45e4-9694-139df7cae1df                                                            |
| is_admin_state_up | True                                                                                            |
| name              | palo-alto-router-trunk-725e25a1-0b02-4435-90f0-d8bb9f5606a3                                     |
| port_id           | 810fc5d8-024b-4aca-9122-52c8df7c13d7                                                            |
| project_id        |                                                                                                 |
| revision_number   | 9                                                                                               |
| status            | ACTIVE                                                                                          |
| sub_ports         | port_id='0eb78930-c8ec-4527-8b11-fe73e7a5cb6b', segmentation_id='200', segmentation_type='vlan' |
|                   | port_id='331c78d8-2bf4-4836-84d6-9a8f1432d37a', segmentation_id='201', segmentation_type='vlan' |
| tags              | []                                                                                              |
| updated_at        | 2026-09-10T12:27:59Z                                                                            |
+-------------------+-------------------------------------------------------------------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack router show "$RID"
+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
| Field                     | Value                                                                                                                                         |
+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
| admin_state_up            | UP                                                                                                                                            |
| availability_zone_hints   |                                                                                                                                               |
| availability_zones        |                                                                                                                                               |
| created_at                | 2026-09-10T11:15:26Z                                                                                                                          |
| description               |                                                                                                                                               |
| enable_default_route_bfd  | False                                                                                                                                         |
| enable_default_route_ecmp | False                                                                                                                                         |
| enable_ndp_proxy          | None                                                                                                                                          |
| enable_snat               | True                                                                                                                                          |
| evpn_vni                  | None                                                                                                                                          |
| external_gateway_info     | {"network_id": "356bb8c1-1470-452f-99e2-6252585c847a", "external_fixed_ips": [{"subnet_id": "36ecd265-c0cc-4079-ad73-1101164b4a5f",           |
|                           | "ip_address": "204.232.163.34"}], "enable_snat": true}                                                                                        |
| external_gateways         | [{'network_id': '356bb8c1-1470-452f-99e2-6252585c847a', 'external_fixed_ips': [{'ip_address': '204.232.163.34', 'subnet_id':                  |
|                           | '36ecd265-c0cc-4079-ad73-1101164b4a5f'}]}]                                                                                                    |
| flavor_id                 | a9db3546-6d64-4d62-84f3-3baf90f11bdf                                                                                                          |
| ha                        | False                                                                                                                                         |
| id                        | 725e25a1-0b02-4435-90f0-d8bb9f5606a3                                                                                                          |
| interfaces_info           | [{"port_id": "331c78d8-2bf4-4836-84d6-9a8f1432d37a", "ip_address": "10.203.0.1", "subnet_id": "a598c096-cdb2-4bb5-82a4-1de3e53da6db"}]        |
| name                      | nidhi-pa-callback-router                                                                                                                      |
| project_id                | 32e02632f4f04415bab5895d1e7247b7                                                                                                              |
| revision_number           | 7                                                                                                                                             |
| routes                    |                                                                                                                                               |
| status                    | ACTIVE                                                                                                                                        |
| tags                      |                                                                                                                                               |
| updated_at                | 2026-09-10T12:28:09Z                                                                                                                          |
+---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack router unset --external-gateway "$RID"
openstack router show "$RID" \
  -c external_gateway_info -c interfaces_info -f yaml
openstack network trunk show "palo-alto-router-trunk-$RID" \
  -c port_id -c sub_ports -f yaml
openstack baremetal node vif list 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
external_gateway_info: null
interfaces_info:
- ip_address: 10.203.0.1
  port_id: 331c78d8-2bf4-4836-84d6-9a8f1432d37a
  subnet_id: a598c096-cdb2-4bb5-82a4-1de3e53da6db
port_id: 810fc5d8-024b-4aca-9122-52c8df7c13d7
sub_ports:
- port_id: 331c78d8-2bf4-4836-84d6-9a8f1432d37a
  segmentation_id: 201
  segmentation_type: vlan
+--------------------------------------+
| id                                   |
+--------------------------------------+
| 810fc5d8-024b-4aca-9122-52c8df7c13d7 |
+--------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 1m24s
❯ openstack port show 0eb78930-c8ec-4527-8b11-fe73e7a5cb6b \
  -c device_id -c device_owner -c fixed_ips -f yaml
No Port found for 0eb78930-c8ec-4527-8b11-fe73e7a5cb6b
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 5s
❯


understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal)
❯ openstack router remove subnet "$RID" nidhi-pa-callback-sub
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 32s
❯ openstack router show "$RID"
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2026-09-10T11:15:26Z                 |
| description               |                                      |
| enable_default_route_bfd  | False                                |
| enable_default_route_ecmp | False                                |
| enable_ndp_proxy          | None                                 |
| enable_snat               | True                                 |
| evpn_vni                  | None                                 |
| external_gateway_info     | null                                 |
| external_gateways         | []                                   |
| flavor_id                 | a9db3546-6d64-4d62-84f3-3baf90f11bdf |
| ha                        | False                                |
| id                        | 725e25a1-0b02-4435-90f0-d8bb9f5606a3 |
| interfaces_info           | []                                   |
| name                      | nidhi-pa-callback-router             |
| project_id                | 32e02632f4f04415bab5895d1e7247b7     |
| revision_number           | 10                                   |
| routes                    |                                      |
| status                    | ACTIVE                               |
| tags                      |                                      |
| updated_at                | 2026-09-10T12:33:19Z                 |
+---------------------------+--------------------------------------+
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack network trunk show "palo-alto-router-trunk-$RID"
No Trunk found for palo-alto-router-trunk-725e25a1-0b02-4435-90f0-d8bb9f5606a3
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack port show 810fc5d8-024b-4aca-9122-52c8df7c13d7
No Port found for 810fc5d8-024b-4aca-9122-52c8df7c13d7
(openstack)
understack on  vif_subnet [$?] 🐍 openstack on ☁️  uc-dev-infra(baremetal) took 4s
❯ openstack baremetal node vif list 31fc6193-e3fa-43ff-a27d-fe45e5fd90fb
```