### PR TITLE
chore: remove ignoring file that has been deleted from yamllint

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,7 +7,6 @@ ignore:
   - charts/nautobot-job-queues/templates/
   - charts/site-workflows/templates/
   - charts/undersync/templates/
-  - components/neutron/configmap-neutron-bin.yaml
 
 rules:
   comments:


### PR DESCRIPTION
We removed this file but I forgot to remove this when removing the file.
