### PR TITLE
feat: Enable NTP on iDRAC, and stop using Ironic's verify_bmc_clock

### DIFF
--- a/components/ironic/values.yaml
+++ b/components/ironic/values.yaml
@@ -109,10 +109,6 @@ conf:
     redfish:
       # Redfish inspection hooks run after inspecting out-of-band using the BMC:
       inspection_hooks: "validate-interfaces,ports,port-bios-name,architecture,pci-devices,resource-class,chassis_model"
-      # To avoid SSL issues due to the system clock differing, have the conductor
-      # set the system clock to its time whenever we go to boot the machine into
-      # IPA
-      enable_verify_bmc_clock: true
     # enable sensors and metrics for redfish metrics - https://docs.openstack.org/ironic/latest/admin/drivers/redfish/metrics.html
     sensor_data:
       send_sensor_data: true

--- a/python/understack-workflows/understack_workflows/bmc_settings.py
+++ b/python/understack-workflows/understack_workflows/bmc_settings.py
@@ -11,10 +11,12 @@ REQUIRED_VALUES = {
     "SNMP.1.AgentCommunity": "public",
     "SNMP.1.AlertPort": 161,
     "SwitchConnectionView.1.Enable": "Enabled",
-    "NTPConfigGroup.1.NTPEnable": "Disabled",
+    "NTPConfigGroup.1.NTPEnable": "Enabled",
     "Time.1.Timezone": "UTC",
     "IPv4.1.DNS1": os.getenv("DNS_SERVER_IPV4_ADDR_1"),
     "IPv4.1.DNS2": os.getenv("DNS_SERVER_IPV4_ADDR_2"),
+    "NTPConfigGroup.1.NTP1": os.getenv("NTP_SERVER_IPV4_ADDR_1"),
+    "NTPConfigGroup.1.NTP2": os.getenv("NTP_SERVER_IPV4_ADDR_2"),
 }
 
 # When we GET Enum-type keys we can expect a string like "Enabled".


### PR DESCRIPTION
We need proper time syncronisation on the iDRAC for:

(1) SSL connections made by the iDRAC to download firmware updates (2) When using SSO/DEX authentication

Here we choose NTP as the way to sync the time.

The IPA image has a clock-step functionality but it does not always work, and when it fails it causes IPA to fail altogether.

When NTP is enabled, the time-of-day redfish route becomes read-only and IPA will fail 100% of the time - these two methods are mutually exclusive, so we disable the IPA's clock-setting mechanism.

We might want to proactively update the drac configurations.  This could be done quite cheaply with some kind of one-liner like:

```sh
export NTP_SERVER_IPV4_ADDR_1=10.4.91.240 # note: varies per data center
export NTP_SERVER_IPV4_ADDR_2=10.4.91.241 # note: varies per data center

uv run python -c "from understack_workflows import bmc, bmc_settings; print(bmc_settings.update_dell_drac_settings(bmc.bmc_for_ip_address('$drac_ip')))"
```