### PR TITLE
prune against every credential group's desired resources

### DIFF
--- a/python/openstack-sync/openstack_sync/hooks/framework.py
+++ b/python/openstack-sync/openstack_sync/hooks/framework.py
@@ -427,6 +427,18 @@ class SyncPlugin(ABC):
     ) -> None:
         """Delete resources whose CR was removed.
 
+        *desired_specs* is every credential group's desired specs, not just
+        those of the credentials *conn* authenticates as. A plugin prunes by its
+        own ownership marker, which records no credential, and what a connection
+        lists depends on its token, so a resource one group manages is reachable
+        from another group's connection. The union is what keeps each group's
+        prune to the resources no group asked for.
+
+        One consequence: two credentials managing the same resource name keep
+        each other's resource off the prune list. If they are separate clouds
+        the resource leaks instead. That is the safer direction, since the
+        alternative is deleting a resource whose CR still exists.
+
         Optional: the default does nothing, which is correct for a plugin whose
         resources outlive their CR or that has nothing safe to delete.
         """
@@ -586,6 +598,16 @@ def _run_prune(
     noun = plugin.noun
     prune_failed = False
 
+    # Every group's desired resources, because a resource is not private to the
+    # credentials that manage it. A plugin prunes by its own ownership marker,
+    # which records no credential, and what a connection lists depends on its
+    # token: a system-scoped credential sees what a project-scoped one manages,
+    # and every credential sees what is public. The union is what keeps each
+    # group's prune to the resources no group asked for.
+    all_desired_specs = [
+        resource.spec for resource in inputs.desired_resources_for_prune
+    ]
+
     for credentials in sorted(inputs.prune_credentials):
         secret_name, cloud_name = credentials
         desired = grouped_desired.get(credentials, [])
@@ -624,7 +646,7 @@ def _run_prune(
         try:
             plugin.prune(
                 conn,
-                [resource.spec for resource in desired],
+                all_desired_specs,
                 authoritative_empty=authoritative_empty,
             )
         except Exception as exc:  # noqa: BLE001

--- a/python/openstack-sync/tests/test_framework.py
+++ b/python/openstack-sync/tests/test_framework.py
@@ -886,6 +886,51 @@ def test_run_sync_prune_is_authoritative_for_deleted_credentials():
     assert plugin.pruned == [([], True)]
 
 
+def test_run_sync_prunes_against_every_credentials_desired_resources():
+    """Prune is scoped by ownership marker, not by credentials, so the set is the union.
+
+    Here the credential whose only CR was deleted has an authoritative empty
+    desired set of its own, and can still list what the other credential manages.
+    It is handed every group's desired names, which is what keeps the resource
+    the other group still wants from being a prune candidate.
+    """
+    plugin = StubPlugin(make_hook_config(prune=True))
+    keeper = _resource("keeper", secret="infrasetup", cloud="understack")
+    gone = _resource("gone", secret="infrasetup-system", cloud="understack")
+    inputs = _inputs([keeper], desired=[keeper], deleted=[gone])
+
+    code, _, _ = _drive(plugin, inputs)
+
+    assert code == 0
+    # Sorted by credentials: infrasetup, then infrasetup-system. The second
+    # group's desired set is empty and authoritative, and it still sees keeper.
+    assert plugin.pruned == [(["keeper"], False), (["keeper"], True)]
+
+
+def test_run_sync_keeps_a_resource_another_credential_wants_off_the_prune_list():
+    """The bug the union closes, stated on its own.
+
+    Both credentials still want a resource, and each prunes with a connection
+    that can list what the other manages -- a system-scoped token sees another
+    project's runbooks, and every token sees what is public. Prune filters by an
+    ownership marker that records no credential, so a per-credential desired set
+    would offer the other group's resource up for deletion.
+    """
+    plugin = StubPlugin(make_hook_config(prune=True))
+    mine = _resource("mine", secret="infrasetup", cloud="understack")
+    theirs = _resource("theirs", secret="infrasetup-system", cloud="understack")
+    inputs = _inputs([mine, theirs])
+
+    code, _, _ = _drive(plugin, inputs)
+
+    assert code == 0
+    # Neither call may omit a name the other credential still wants.
+    assert [sorted(names) for names, _ in plugin.pruned] == [
+        ["mine", "theirs"],
+        ["mine", "theirs"],
+    ]
+
+
 def test_run_sync_skips_prune_for_credentials_with_no_desired_resources():
     """An empty desired set with no deletion may be an unreadable snapshot."""
     plugin = StubPlugin(make_hook_config(prune=True))


### PR DESCRIPTION
A plugin prunes by its own ownership marker, which records no credential, and what a connection lists depends on its token: a system-scoped credential sees what a project-scoped one manages, and every credential sees what is public. Handing each group only its own desired specs therefore offered the other group's resources up for deletion, so whichever credential pruned first could delete a resource whose CR still existed.

Prune now receives the union. The tradeoff is that two credentials managing the same resource name keep each other's resource off the prune list, which leaks it if they are separate clouds; that is the safer direction, and the plugin contract now says so.

<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
