### PR TITLE
feat: upgrade Envoy Gateway to 1.8.4

### DIFF
--- a/changelog.d/20260908_155524_doug.goldstein.md
+++ b/changelog.d/20260908_155524_doug.goldstein.md
@@ -1,0 +1,9 @@
+### Notes
+
+Envoy Gateway's `targetRevision` moves from 1.7.2 to 1.8.4. No values changes
+are required and no operator action is needed beyond a normal resync;
+existing `extensionApis` settings still apply.
+
+Per upstream's upgrade documentation, Envoy Gateway upgrades must be taken one
+minor version at a time. A future upgrade to 1.9 has to land on top of this
+1.8 change rather than jumping directly from 1.7.

--- a/charts/argocd-understack/templates/application-envoy-gateway.yaml
+++ b/charts/argocd-understack/templates/application-envoy-gateway.yaml
@@ -23,7 +23,7 @@ spec:
       - $understack/components/envoy-gateway/values.yaml
       - $deploy/{{ include "understack.deploy_path" $ }}/envoy-gateway/values.yaml
     repoURL: docker.io/envoyproxy
-    targetRevision: 1.7.2
+    targetRevision: 1.8.4
   - path: components/envoy-gateway
     ref: understack
     repoURL: {{ include "understack.understack_url" $ }}


### PR DESCRIPTION
Bump the gateway-helm chart targetRevision from 1.7.2 to 1.8.4, which
pulls the matching docker.io/envoyproxy/gateway:v1.8.4 image. No
values changes are required; existing extensionApis settings still
apply. No operator action is needed beyond a normal resync.
