### PR TITLE
docs: add migration note for v0.5.5

### DIFF
--- a/docs/release-notes/v0.5.md
+++ b/docs/release-notes/v0.5.md
@@ -30,6 +30,8 @@ off for it rather than for the prose above:
 
 ### Action required
 
+#### Ironic runbooks
+
 Ironic runbooks are now reconciled by the `ironicRunbooks` hook in
 `openstack-sync-operator`, and the `IronicRunbook` CRD moved to a new API group.
 Existing runbook CRs are not migrated for you: they are deleted, and you
@@ -121,6 +123,74 @@ guarantee between the two. If the old CRD is pruned while that pod is still
 running, its delete hook fires for each cascade-deleted CR and removes those
 runbooks from Ironic. Scale `shell-operator-ironic` to zero before syncing if
 you need to avoid that window.
+
+#### RabbitMQ queues
+
+The `neutron` chart bump to `2026.1.41+7c81bea7c` in this
+release pulled in upstream's RabbitMQ 4.x migration (openstack-helm commit
+`644e7d76ab`). It changed the chart's default `oslo_messaging_rabbit`
+settings: `amqp_durable_queues` and `rabbit_transient_quorum_queue` are now
+`true`, and `rabbit_ha_queues` is now `false`. This makes neutron declare its
+`*_fanout` exchanges durable.
+
+RabbitMQ clusters that predate this change still have those exchanges (and
+possibly some queues) declared non-durable/classic from before, and RabbitMQ
+refuses to change an existing exchange's or queue's durability or type in
+place. You'll see this in `neutron-server` logs:
+
+```text
+amqp.exceptions.PreconditionFailed: Exchange.declare: (406) PRECONDITION_FAILED
+  - inequivalent arg 'durable' for exchange '<name>_fanout' in vhost 'neutron':
+  received 'true' but current is 'false'
+```
+
+oslo.messaging catches this and falls back to a non-durable redeclare (logged
+as `Force creating a non durable exchange`), so RPC keeps working, but the
+intended durability never applies and the warning repeats on every
+reconnect.
+
+Separately, the chart's new default sets `rabbit_quorum_queues` (plural),
+which does not match oslo.messaging's real option, `rabbit_quorum_queue`
+(singular) -- it's a silent no-op today. If upstream fixes that typo, any
+environment relying on the chart default rather than an explicit override
+will suddenly start requesting real quorum queues for its RPC/notification
+queues, hitting this same class of `PRECONDITION_FAILED` again, this time on
+the `x-queue-type` argument, against any classic queue already sitting in
+the vhost.
+
+For each affected vhost:
+
+1. Check for non-durable exchanges and classic queues that predate this
+   change:
+
+    ```bash
+    kubectl -n openstack exec rabbitmq-server-0 -- \
+      rabbitmqctl list_exchanges -p <vhost> name durable type
+    kubectl -n openstack exec rabbitmq-server-0 -- \
+      rabbitmqctl list_queues -p <vhost> name durable type
+    ```
+
+2. Pin the settings explicitly in your deploy repo's
+   `<site>/neutron/values.yaml` rather than relying on chart defaults,
+   matching what several sites already carry:
+
+    ```yaml
+    conf:
+      neutron:
+        oslo_messaging_rabbit:
+          rabbit_ha_queues: false
+          rabbit_quorum_queue: true
+          rabbit_transient_quorum_queue: true
+          rabbit_qos_prefetch_count: 1
+          use_queue_manager: true
+          rabbit_stream_fanout: true
+    ```
+
+3. Delete any exchange or queue reported as non-durable/classic so it gets
+   recreated matching the new declare. Fanout exchanges and their consumer
+   queues are transient and re-declared automatically by the owning
+   service, so deleting them costs a brief broadcast gap, not data loss. A
+   classic queue with real content needs more care before deleting.
 
 ### Deploy repo changes
 


### PR DESCRIPTION
There was a RabbitMQ change which required some care when interacting
with so document it.
