### PR TITLE
feat: patch CR status via the Kubernetes client, not kubectl

### DIFF
--- a/python/openstack-sync/openstack_sync/hooks/common.py
+++ b/python/openstack-sync/openstack_sync/hooks/common.py
@@ -1,6 +1,6 @@
 """Generic shell-operator hook utilities shared across all hooks.
 
-Provides binding context I/O and status patching via kubectl.
+Provides binding context I/O and CR status patching.
 """
 
 from __future__ import annotations
@@ -9,9 +9,13 @@ import datetime as dt
 import json
 import logging
 import os
-import subprocess
 import sys
 from typing import Any
+
+from kubernetes import client as k8s_client
+from kubernetes.client.exceptions import ApiException
+
+from openstack_sync.utils import load_kubernetes_config
 
 LOG = logging.getLogger(__name__)
 
@@ -181,6 +185,49 @@ def _status_is_current(
     return True
 
 
+#: Memoised CustomObjectsApi, so one config load serves every patch in a run.
+_custom_objects_api: Any = None
+
+
+def _customobjects_api() -> Any:
+    """Return the shared ``CustomObjectsApi``, configuring the client once."""
+    global _custom_objects_api
+    if _custom_objects_api is None:
+        load_kubernetes_config()
+        _custom_objects_api = k8s_client.CustomObjectsApi()
+    return _custom_objects_api
+
+
+def crd_request_target(crd_api_version: str, crd_resource: str) -> tuple[str, str, str]:
+    """Return ``(group, version, plural)`` for addressing a CR.
+
+    Derived from the two environment values the chart already injects, rather
+    than from new ones: ``<prefix>_CRD_API_VERSION`` is ``<group>/<version>``
+    and ``<prefix>_CRD_RESOURCE`` is ``<plural>.<group>``, which between them
+    carry everything the API needs.
+
+    Raises:
+        ValueError: When either value is not in the expected shape.
+    """
+    group, _, version = crd_api_version.partition("/")
+    plural = crd_resource.partition(".")[0]
+    if not group or not version or not plural:
+        raise ValueError(
+            f"cannot derive a CRD request target from "
+            f"api_version={crd_api_version!r} and resource={crd_resource!r}"
+        )
+    return group, version, plural
+
+
+def _api_error_detail(exc: ApiException, max_body: int = 512) -> str:
+    """Return a one-line description of *exc* for a log message."""
+    body = str(exc.body or "").strip().replace("\n", " ")
+    detail = f"HTTP {exc.status} {exc.reason or ''}".strip()
+    if not body:
+        return detail
+    return f"{detail}: {truncate_message(body, max_body)}"
+
+
 def patch_resource_status(
     *,
     name: str,
@@ -188,20 +235,24 @@ def patch_resource_status(
     generation: int | None,
     sync_status: str,
     message: str,
+    crd_api_version: str,
     crd_resource: str,
     crd_kind: str,
     status_enabled: bool,
     current_status: dict[str, Any] | None = None,
 ) -> None:
-    """Patch the status subresource of a CR via kubectl.
+    """Patch the status subresource of a CR.
 
     Args:
         name: CR metadata.name.
-        namespace: CR metadata.namespace (optional).
+        namespace: CR metadata.namespace. Required to address the object; the
+            patch is skipped with a warning when it is absent.
         generation: CR metadata.generation for observedGeneration (optional).
         sync_status: One of ``"Synced"`` or ``"Failed"``.
         message: Human-readable detail for the status message.
-        crd_resource: Fully-qualified CRD resource name for kubectl (e.g.
+        crd_api_version: CRD API version as ``<group>/<version>`` (e.g.
+            ``neutron.understack.rackspace.net/v1alpha1``).
+        crd_resource: Fully-qualified CRD resource name (e.g.
             ``neutronrouterflavors.neutron.understack.rackspace.net``).
         crd_kind: CRD kind used in log messages (e.g. ``NeutronRouterFlavor``).
         status_enabled: When False the function returns immediately.
@@ -231,32 +282,46 @@ def patch_resource_status(
     if generation is not None:
         status["observedGeneration"] = generation
 
-    command = [
-        "kubectl",
-        "patch",
-        crd_resource,
-        name,
-        "--type",
-        "merge",
-        "--subresource",
-        "status",
-        "-p",
-        json.dumps({"status": status}, sort_keys=True),
-    ]
-    if namespace:
-        command.extend(["-n", namespace])
-
-    try:
-        result = subprocess.run(  # noqa: S603,S607
-            command,
-            capture_output=True,
-            check=False,
-            text=True,
+    if not namespace:
+        LOG.warning(
+            "unable to patch %s status for %s; no namespace to address it in",
+            crd_kind,
+            name,
         )
-    except FileNotFoundError:
-        LOG.warning("kubectl not found; unable to patch %s status", crd_kind)
         return
 
-    if result.returncode != 0:
-        error = (result.stderr or result.stdout or "unknown error").strip()
-        LOG.warning("failed to patch %s status for %s: %s", crd_kind, name, error)
+    try:
+        group, version, plural = crd_request_target(crd_api_version, crd_resource)
+    except ValueError as exc:
+        LOG.warning("unable to patch %s status for %s: %s", crd_kind, name, exc)
+        return
+
+    # The client's default content type here is merge-patch+json, which is what
+    # `kubectl patch --type merge --subresource status` sent before this moved
+    # off kubectl, so the request on the wire is unchanged.
+    try:
+        _customobjects_api().patch_namespaced_custom_object_status(
+            group=group,
+            version=version,
+            namespace=namespace,
+            plural=plural,
+            name=name,
+            body={"status": status},
+        )
+    except ApiException as exc:
+        LOG.warning(
+            "failed to patch %s status for %s: %s",
+            crd_kind,
+            name,
+            _api_error_detail(exc),
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Config load and transport failures reach here. A status patch is
+        # reporting, never the work itself, so it must not fail the reconcile.
+        LOG.warning(
+            "failed to patch %s status for %s: %s: %s",
+            crd_kind,
+            name,
+            type(exc).__name__,
+            exc,
+        )

--- a/python/openstack-sync/openstack_sync/hooks/framework.py
+++ b/python/openstack-sync/openstack_sync/hooks/framework.py
@@ -502,6 +502,7 @@ def _patch_status(
         generation=resource.generation,
         sync_status=sync_status,
         message=message,
+        crd_api_version=config.crd_api_version,
         crd_resource=config.crd_resource,
         crd_kind=config.crd_kind,
         status_enabled=config.status_enabled,

--- a/python/openstack-sync/openstack_sync/utils.py
+++ b/python/openstack-sync/openstack_sync/utils.py
@@ -17,12 +17,20 @@ from kubernetes import config as k8s_config
 from openstack.config import loader as os_config_loader
 
 
-def read_secret_key(secret_name: str, secret_key: str, namespace: str) -> str:
-    """Read a single key from a Kubernetes Secret and return its decoded value.
+def load_kubernetes_config() -> None:
+    """Configure the Kubernetes client for wherever this is running.
 
-    Configures the client automatically:
     - Inside a cluster: uses the pod's service-account token.
     - Outside a cluster: falls back to the local kubeconfig (development).
+    """
+    try:
+        k8s_config.load_incluster_config()
+    except k8s_config.ConfigException:
+        k8s_config.load_kube_config()
+
+
+def read_secret_key(secret_name: str, secret_key: str, namespace: str) -> str:
+    """Read a single key from a Kubernetes Secret and return its decoded value.
 
     Args:
         secret_name: Name of the Kubernetes Secret to read.
@@ -35,10 +43,7 @@ def read_secret_key(secret_name: str, secret_key: str, namespace: str) -> str:
     Raises:
         KeyError: When ``secret_key`` is not present in the Secret's data.
     """
-    try:
-        k8s_config.load_incluster_config()
-    except k8s_config.ConfigException:
-        k8s_config.load_kube_config()
+    load_kubernetes_config()
 
     v1 = client.CoreV1Api()
     secret = v1.read_namespaced_secret(name=secret_name, namespace=namespace)
@@ -89,7 +94,7 @@ def get_openstack_connection(secret_name: str, cloud_name: str) -> Any:
     # openstack.connect(cloud=name) resolves the named cloud from files on
     # disk, which fails inside a container with no clouds.yaml present.
     # Instead, parse the YAML from the Secret and inject it directly into
-    # the SDK config loader — no filesystem writes required.
+    # the SDK config loader -- no filesystem writes required.
     loader = os_config_loader.OpenStackConfig(
         config_files=[],
         vendor_files=[],

--- a/python/openstack-sync/tests/test_framework.py
+++ b/python/openstack-sync/tests/test_framework.py
@@ -767,8 +767,8 @@ def test_run_sync_connects_with_each_resources_own_credentials():
 def test_run_sync_forwards_crd_identity_and_current_status_to_the_patch():
     """Forward everything patch_resource_status needs.
 
-    The CRD identity targets kubectl, and the current status decides whether the
-    patch can be skipped.
+    The CRD identity addresses the object on the API, and the current status
+    decides whether the patch can be skipped.
     """
     config = make_hook_config(status_enabled=True)
     plugin = StubPlugin(config)

--- a/python/openstack-sync/tests/test_hook_common.py
+++ b/python/openstack-sync/tests/test_hook_common.py
@@ -1,4 +1,4 @@
-"""Tests for openstack_sync.hooks.common — generic shell-operator utilities."""
+"""Tests for openstack_sync.hooks.common -- generic shell-operator utilities."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import logging
 from unittest import mock
 
 import pytest
+from kubernetes.client.exceptions import ApiException
 
 from openstack_sync.hooks import common as hc
 
@@ -242,100 +243,83 @@ def test_status_is_current_detects_real_status_differences(
 # ---------------------------------------------------------------------------
 
 
+API_VERSION = "neutron.understack.rackspace.net/v1alpha1"
+RESOURCE = "neutronrouterflavors.neutron.understack.rackspace.net"
+
+
+def _patch(**overrides):
+    """Call patch_resource_status against a mocked API, returning the mock."""
+    kwargs = {
+        "name": "test-flavor",
+        "namespace": "openstack",
+        "generation": 2,
+        "sync_status": "Synced",
+        "message": "all good",
+        "crd_api_version": API_VERSION,
+        "crd_resource": RESOURCE,
+        "crd_kind": "NeutronRouterFlavor",
+        "status_enabled": True,
+    }
+    kwargs.update(overrides)
+    api = mock.MagicMock()
+    with mock.patch.object(hc, "_customobjects_api", return_value=api):
+        hc.patch_resource_status(**kwargs)
+    return api.patch_namespaced_custom_object_status
+
+
 def test_patch_resource_status_skips_when_disabled():
-    with mock.patch("subprocess.run") as mock_run:
-        hc.patch_resource_status(
-            name="test-flavor",
-            namespace="openstack",
-            generation=1,
-            sync_status="Synced",
-            message="ok",
-            crd_resource="neutronrouterflavors.neutron.understack.rackspace.net",
-            crd_kind="NeutronRouterFlavor",
-            status_enabled=False,
-        )
-
-    mock_run.assert_not_called()
+    assert not _patch(status_enabled=False).called
 
 
-def test_patch_resource_status_calls_kubectl():
-    with mock.patch("subprocess.run") as mock_run:
-        mock_run.return_value = mock.MagicMock(returncode=0)
-        hc.patch_resource_status(
-            name="test-flavor",
-            namespace="openstack",
-            generation=2,
-            sync_status="Synced",
-            message="all good",
-            crd_resource="neutronrouterflavors.neutron.understack.rackspace.net",
-            crd_kind="NeutronRouterFlavor",
-            status_enabled=True,
-        )
+def test_patch_resource_status_calls_the_api():
+    call = _patch()
 
-    mock_run.assert_called_once()
-    cmd = mock_run.call_args[0][0]
-    assert "kubectl" in cmd
-    assert "test-flavor" in cmd
-    assert "-n" in cmd
-    assert "openstack" in cmd
+    call.assert_called_once()
+    kwargs = call.call_args.kwargs
+    assert kwargs["group"] == "neutron.understack.rackspace.net"
+    assert kwargs["version"] == "v1alpha1"
+    assert kwargs["plural"] == "neutronrouterflavors"
+    assert kwargs["namespace"] == "openstack"
+    assert kwargs["name"] == "test-flavor"
+
+    status = kwargs["body"]["status"]
+    assert status["syncStatus"] == "Synced"
+    assert status["observedGeneration"] == 2
+    assert [c["type"] for c in status["conditions"]] == ["Synced"]
+
+
+def test_patch_resource_status_omits_generation_when_absent():
+    status = _patch(generation=None).call_args.kwargs["body"]["status"]
+    assert "observedGeneration" not in status
 
 
 def test_patch_resource_status_skips_when_current_status_matches():
-    with mock.patch("subprocess.run") as mock_run:
-        hc.patch_resource_status(
-            name="test-flavor",
-            namespace="openstack",
-            generation=1,
-            sync_status="Synced",
-            message="ok",
-            crd_resource="neutronrouterflavors.neutron.understack.rackspace.net",
-            crd_kind="NeutronRouterFlavor",
-            status_enabled=True,
-            current_status=_matching_status(),
-        )
-
-    mock_run.assert_not_called()
+    call = _patch(generation=1, message="ok", current_status=_matching_status())
+    assert not call.called
 
 
-def test_patch_resource_status_no_namespace():
-    with mock.patch("subprocess.run") as mock_run:
-        mock_run.return_value = mock.MagicMock(returncode=0)
-        hc.patch_resource_status(
-            name="test-flavor",
-            namespace=None,
-            generation=None,
-            sync_status="Failed",
-            message="error",
-            crd_resource="neutronrouterflavors.neutron.understack.rackspace.net",
-            crd_kind="NeutronRouterFlavor",
-            status_enabled=True,
-        )
+def test_patch_resource_status_skips_without_a_namespace(caplog):
+    with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
+        call = _patch(namespace=None)
 
-    cmd = mock_run.call_args[0][0]
-    assert "-n" not in cmd
+    assert not call.called
+    assert "no namespace to address it in" in caplog.text
 
 
-def test_patch_resource_status_logs_on_kubectl_not_found(caplog):
-    with mock.patch("subprocess.run", side_effect=FileNotFoundError):
-        with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
-            hc.patch_resource_status(
-                name="test-flavor",
-                namespace=None,
-                generation=None,
-                sync_status="Synced",
-                message="ok",
-                crd_resource="neutronrouterflavors.neutron.understack.rackspace.net",
-                crd_kind="NeutronRouterFlavor",
-                status_enabled=True,
-            )
-    assert "kubectl not found" in caplog.text
+def test_patch_resource_status_skips_on_unusable_crd_identity(caplog):
+    with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
+        call = _patch(crd_api_version="no-version-here")
+
+    assert not call.called
+    assert "cannot derive a CRD request target" in caplog.text
 
 
-def test_patch_resource_status_logs_on_kubectl_failure(caplog):
-    with mock.patch("subprocess.run") as mock_run:
-        mock_run.return_value = mock.MagicMock(
-            returncode=1, stderr="not found", stdout=""
-        )
+def test_patch_resource_status_logs_api_errors(caplog):
+    api = mock.MagicMock()
+    api.patch_namespaced_custom_object_status.side_effect = ApiException(
+        status=403, reason="Forbidden"
+    )
+    with mock.patch.object(hc, "_customobjects_api", return_value=api):
         with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
             hc.patch_resource_status(
                 name="test-flavor",
@@ -343,8 +327,85 @@ def test_patch_resource_status_logs_on_kubectl_failure(caplog):
                 generation=None,
                 sync_status="Synced",
                 message="ok",
-                crd_resource="neutronrouterflavors.neutron.understack.rackspace.net",
+                crd_api_version=API_VERSION,
+                crd_resource=RESOURCE,
                 crd_kind="NeutronRouterFlavor",
                 status_enabled=True,
             )
+
     assert "failed to patch" in caplog.text
+    # The point of moving off kubectl: the HTTP status survives into the log.
+    assert "403" in caplog.text
+    assert "Forbidden" in caplog.text
+
+
+def test_patch_resource_status_logs_unexpected_errors(caplog):
+    with mock.patch.object(
+        hc, "_customobjects_api", side_effect=RuntimeError("no kubeconfig")
+    ):
+        with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
+            hc.patch_resource_status(
+                name="test-flavor",
+                namespace="openstack",
+                generation=None,
+                sync_status="Synced",
+                message="ok",
+                crd_api_version=API_VERSION,
+                crd_resource=RESOURCE,
+                crd_kind="NeutronRouterFlavor",
+                status_enabled=True,
+            )
+
+    assert "failed to patch" in caplog.text
+    assert "RuntimeError" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# crd_request_target
+# ---------------------------------------------------------------------------
+
+
+def test_crd_request_target_splits_the_chart_supplied_values():
+    assert hc.crd_request_target(API_VERSION, RESOURCE) == (
+        "neutron.understack.rackspace.net",
+        "v1alpha1",
+        "neutronrouterflavors",
+    )
+
+
+@pytest.mark.parametrize(
+    ("api_version", "resource"),
+    [
+        ("", RESOURCE),
+        ("neutron.understack.rackspace.net", RESOURCE),  # no version
+        ("/v1alpha1", RESOURCE),  # no group
+        (API_VERSION, ""),  # no plural
+    ],
+)
+def test_crd_request_target_rejects_unusable_values(api_version, resource):
+    with pytest.raises(ValueError, match="cannot derive a CRD request target"):
+        hc.crd_request_target(api_version, resource)
+
+
+# ---------------------------------------------------------------------------
+# _api_error_detail
+# ---------------------------------------------------------------------------
+
+
+def test_api_error_detail_without_a_body():
+    exc = ApiException(status=404, reason="Not Found")
+    assert hc._api_error_detail(exc) == "HTTP 404 Not Found"
+
+
+def test_api_error_detail_flattens_and_truncates_the_body():
+    exc = ApiException(status=422, reason="Unprocessable Entity")
+    exc.body = "line one\n" + "x" * 4000
+
+    detail = hc._api_error_detail(exc)
+
+    assert detail.startswith("HTTP 422 Unprocessable Entity: line one ")
+    assert "\n" not in detail
+    # The prefix plus a 512-character body at most, so one apiserver Status
+    # object cannot flood the log.
+    assert len(detail) <= len("HTTP 422 Unprocessable Entity: ") + 512
+    assert detail.endswith("...")

--- a/python/openstack-sync/tests/test_ironic_runbooks_hook.py
+++ b/python/openstack-sync/tests/test_ironic_runbooks_hook.py
@@ -325,7 +325,7 @@ def test_main_creates_then_prunes_against_a_fake_ironic(
 
     Binding context -> framework -> reconcile -> runbook client -> Ironic routes,
     then the same for prune once the CR is gone. Only the connection, the
-    microversion discovery and kubectl are stood in for.
+    microversion discovery and the status patch are stood in for.
     """
     fake = FakeBaremetal()
     conn = types.SimpleNamespace(baremetal=fake)


### PR DESCRIPTION
A hook process handles every CR in one binding context, and each status
write forked kubectl: process spawn, kubeconfig load and API discovery per
resource. With a few dozen CRs that is tens of seconds of pure overhead per
reconcile. One CustomObjectsApi, configured once, replaces it.

It also makes failures diagnosable. The chart derives the <plural>/status
RBAC rule from the CRD, so a template miss surfaces as a 403 -- previously
an opaque stderr string, now an HTTP status in the log. The error body is
truncated so one apiserver Status object cannot flood a log line.

The request on the wire is unchanged: the client's default content type for
this method is application/merge-patch+json, the same as
`kubectl patch --type merge --subresource status`.

group, version and plural are derived from the two environment values the
chart already injects, so no new configuration. kubernetes>=32.0.0 was
already a dependency and utils.py already loaded client config; that load
is extracted as load_kubernetes_config and shared.

A namespace is now required to address the object rather than falling back
to kubectl's context namespace. All three plugin CRDs are Namespaced and the
namespace comes from the CR or POD_NAMESPACE, so this is unreachable in
practice; it is a warning-and-skip rather than a silent misdirected patch.

<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
