### PR TITLE
fix(kubectl-us-net): Fixes 'uv sync' build of kubectl-us-net

### DIFF
--- a/python/kubectl-us-net/pyproject.toml
+++ b/python/kubectl-us-net/pyproject.toml
@@ -44,6 +44,8 @@ source = "vcs"
 [tool.hatch.version.raw-options]
 root = "../../"
 tag_regex = "^kubectl-us-net/v(?P<version>.*)$"
+git_describe_command = "git describe --dirty --tags --long --match kubectl-us-net/v*"
+fallback_version = "0.0.1"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
Hit an error attempting to install with uv sync. This update fixes it.

``` text
 uv sync
Using CPython 3.14.2
Creating virtual environment at: .venv
Resolved 43 packages in 1ms
  × Failed to build `kubectl-us-net @ file:///understack/python/kubectl-us-net`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      /lib/python3.14/site-packages/vcs_versioning/_scm_version.py:357: UserWarning: tag 'v0.5.5' no version found
        return tag_to_version(tag, config)
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename = backend.build_editable("/.cache/uv/builds-v0/.tmpXdAVwh", {}, None)
        File "/lib/python3.14/site-packages/hatchling/build.py", line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=["editable"])))
                                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/lib/python3.14/site-packages/hatchling/builders/plugin/interface.py", line 92, in build
          self.metadata.validate_fields()
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
        File "/lib/python3.14/site-packages/hatchling/metadata/core.py", line 266, in validate_fields
          _ = self.version
              ^^^^^^^^^^^^
        File "/lib/python3.14/site-packages/hatchling/metadata/core.py", line 150, in version
          self._version = self._get_version()
                          ~~~~~~~~~~~~~~~~~^^
        File "/lib/python3.14/site-packages/hatchling/metadata/core.py", line 249, in _get_version
          version = self.hatch.version.cached
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/lib/python3.14/site-packages/hatchling/metadata/core.py", line 1534, in cached
          raise type(e)(message) from None
      ValueError: Error getting the version from source `vcs`: Can't parse version from tag 'v0.5.5' (tag_regex='^kubectl-us-net/v(?P<version>.*)$', tag_prefix='')

      hint: This usually indicates a problem with the package or the build environment.
```
