### PR TITLE
feat(openstack-sync): report CR status on the status subresource

### DIFF
--- a/components/openstack-sync-operator/Chart.yaml
+++ b/components/openstack-sync-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: openstack-sync-operator
 description: OpenStack configuration sync shell-operator hooks
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 1.0.0

--- a/components/openstack-sync-operator/DESIGN-NOTES.md
+++ b/components/openstack-sync-operator/DESIGN-NOTES.md
@@ -79,8 +79,10 @@ and are otherwise left alone.
 
 The CRDs have a status subresource with `syncStatus` (Synced/Failed/Unknown),
 `lastSyncTime`, `observedGeneration`, `message`, and a standard `conditions[]`
-list. Status is written by running `kubectl patch --subresource status` in a
-subprocess (`hooks/common.py`).
+list. The hook writes status through the Kubernetes Python client's status
+subresource API (`hooks/common.py`). Each CR reports one `Ready` condition so
+`kubectl wait --for=condition=Ready` and kubernetes-entrypoint dependencies can
+observe readiness directly.
 
 ### Safety details worth noting
 
@@ -92,6 +94,9 @@ The framework handles a few tricky cases carefully:
   endless loop.
 - **Skips no-op status writes**: it doesn't rewrite status when the important
   fields already match, which avoids extra Modified events.
+- **Preserves transition time**: a status write keeps the existing
+  `lastTransitionTime` while the `Ready` condition's `status` is unchanged, so
+  message-only updates don't look like readiness transitions.
 - **Guards prune**: if any CR failed to reconcile or couldn't be read, prune is
   skipped completely, since it can't know the full desired set and might delete
   something it shouldn't.

--- a/components/openstack-sync-operator/crds/ironic.understack.rackspace.net_ironicrunbooks.yaml
+++ b/components/openstack-sync-operator/crds/ironic.understack.rackspace.net_ironicrunbooks.yaml
@@ -205,14 +205,25 @@ spec:
               conditions:
                 description: Conditions describe current observed state.
                 type: array
+                x-kubernetes-list-type: map
+                x-kubernetes-list-map-keys:
+                - type
                 items:
                   type: object
                   required:
                   - type
                   - status
+                  - reason
+                  - message
+                  - lastTransitionTime
                   properties:
                     type:
+                      description: >-
+                        Condition type in CamelCase. A CR reports one
+                        condition, Ready.
                       type: string
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                     status:
                       type: string
                       enum:
@@ -220,10 +231,24 @@ spec:
                       - "False"
                       - Unknown
                     reason:
+                      description: >-
+                        CamelCase programmatic identifier for the reason of the
+                        last transition.
                       type: string
+                      minLength: 1
+                      maxLength: 1024
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                     message:
                       type: string
                       maxLength: 2048
+                    observedGeneration:
+                      description: >-
+                        The metadata.generation this condition was computed
+                        from. A value behind the current generation means the
+                        condition is out of date.
+                      type: integer
+                      format: int64
+                      minimum: 0
                     lastTransitionTime:
                       type: string
                       format: date-time

--- a/components/openstack-sync-operator/crds/neutron.understack.rackspace.net_neutronrouterflavors.yaml
+++ b/components/openstack-sync-operator/crds/neutron.understack.rackspace.net_neutronrouterflavors.yaml
@@ -185,14 +185,25 @@ spec:
               conditions:
                 description: Conditions describe current observed state.
                 type: array
+                x-kubernetes-list-type: map
+                x-kubernetes-list-map-keys:
+                - type
                 items:
                   type: object
                   required:
                   - type
                   - status
+                  - reason
+                  - message
+                  - lastTransitionTime
                   properties:
                     type:
+                      description: >-
+                        Condition type in CamelCase. A CR reports one
+                        condition, Ready.
                       type: string
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                     status:
                       type: string
                       enum:
@@ -200,10 +211,24 @@ spec:
                       - "False"
                       - Unknown
                     reason:
+                      description: >-
+                        CamelCase programmatic identifier for the reason of the
+                        last transition.
                       type: string
+                      minLength: 1
+                      maxLength: 1024
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                     message:
                       type: string
                       maxLength: 2048
+                    observedGeneration:
+                      description: >-
+                        The metadata.generation this condition was computed
+                        from. A value behind the current generation means the
+                        condition is out of date.
+                      type: integer
+                      format: int64
+                      minimum: 0
                     lastTransitionTime:
                       type: string
                       format: date-time

--- a/components/openstack-sync-operator/crds/openstack.understack.rackspace.net_openstackplaceholders.yaml
+++ b/components/openstack-sync-operator/crds/openstack.understack.rackspace.net_openstackplaceholders.yaml
@@ -56,7 +56,7 @@ spec:
                 description: >-
                   cloudCredentialsRef points to a Kubernetes Secret containing
                   an OpenStack clouds.yaml file.  The operator reads this secret
-                  directly at reconcile time — no volume mount is required.
+                  directly at reconcile time -- no volume mount is required.
                 type: object
                 required:
                 - secretName
@@ -107,14 +107,25 @@ spec:
               conditions:
                 description: Conditions describe the current observed state.
                 type: array
+                x-kubernetes-list-type: map
+                x-kubernetes-list-map-keys:
+                - type
                 items:
                   type: object
                   required:
                   - type
                   - status
+                  - reason
+                  - message
+                  - lastTransitionTime
                   properties:
                     type:
+                      description: >-
+                        Condition type in CamelCase. A CR reports one
+                        condition, Ready.
                       type: string
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                     status:
                       type: string
                       enum:
@@ -122,10 +133,24 @@ spec:
                       - "False"
                       - Unknown
                     reason:
+                      description: >-
+                        CamelCase programmatic identifier for the reason of the
+                        last transition.
                       type: string
+                      minLength: 1
+                      maxLength: 1024
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                     message:
                       type: string
                       maxLength: 2048
+                    observedGeneration:
+                      description: >-
+                        The metadata.generation this condition was computed
+                        from. A value behind the current generation means the
+                        condition is out of date.
+                      type: integer
+                      format: int64
+                      minimum: 0
                     lastTransitionTime:
                       type: string
                       format: date-time

--- a/docs/deploy-guide/components/openstack-sync-operator.md
+++ b/docs/deploy-guide/components/openstack-sync-operator.md
@@ -199,6 +199,39 @@ Each plugin CRD defines:
 - Required `spec.cloudCredentialsRef.secretName`
 - Required `spec.cloudCredentialsRef.cloudName`
 
+### Status and readiness
+
+Every plugin CR reports the same status:
+
+- `conditions` -- one `Ready` condition, reason `Reconciled` or
+  `ReconcileError`.
+- `syncStatus` -- `Synced` or `Failed`. This is the field the `SyncStatus`
+  printer column shows.
+- `message` -- detail from the last reconcile.
+- `lastSyncTime` -- when the status last changed. A reconcile that finds
+  nothing to change writes nothing, so this is not a heartbeat.
+- `observedGeneration` -- the `metadata.generation` this status was computed
+  from. A value behind `metadata.generation` means the latest spec has not been
+  applied yet.
+
+So a CR is waitable:
+
+```bash
+kubectl -n openstack wait --for=condition=Ready ironicrunbook/<name> --timeout=60s
+```
+
+`lastTransitionTime` marks the last time the condition's `status` changed rather
+than the last reconcile, so a message-only change leaves it alone.
+
+A CR that converged but needs manual attention is still `Ready`, with the detail
+appended to the message after `needs manual action:`. That is deliberate -- the
+resource really is converged, and reporting a bare success while state diverges
+from the spec is how a broken resource stays invisible until it is used.
+
+A failed status write never fails the reconcile, because status is reporting and
+not the work itself. It is logged at error level even so: anything waiting on
+`Ready` stays stuck until someone reads that log.
+
 The chart reads this CRD through
 `components/openstack-sync-operator/templates/_crd.tpl` so
 RBAC and hook environment variables are derived from the same schema Kubernetes

--- a/python/openstack-sync/openstack_sync/hooks/common.py
+++ b/python/openstack-sync/openstack_sync/hooks/common.py
@@ -127,31 +127,54 @@ def truncate_message(message: Any, max_length: int = 2048) -> str:
     return f"{text[: max_length - 3]}..."
 
 
-def _condition_status(sync_status: str) -> str:
-    return "True" if sync_status == "Synced" else "False"
+def _desired_condition(
+    sync_status: str, message: str, generation: int | None = None
+) -> dict[str, Any]:
+    """Return the Ready condition to write, without its timestamp.
 
-
-def _condition_reason(sync_status: str) -> str:
-    return "ReconcileSucceeded" if sync_status == "Synced" else "ReconcileFailed"
-
-
-def _desired_condition(sync_status: str, message: str) -> dict[str, str]:
-    return {
-        "type": "Synced",
-        "status": _condition_status(sync_status),
-        "reason": _condition_reason(sync_status),
+    A CR has one notion of success, so it reports one condition. ``Ready`` is
+    the name Kubernetes tooling expects: ``kubectl wait --for=condition=Ready``
+    and kubernetes-entrypoint's ``custom_resources`` dependency both work off it.
+    """
+    synced = sync_status == "Synced"
+    condition: dict[str, Any] = {
+        "type": "Ready",
+        "status": "True" if synced else "False",
+        "reason": "Reconciled" if synced else "ReconcileError",
         "message": truncate_message(message),
     }
+    if generation is not None:
+        condition["observedGeneration"] = generation
+    return condition
 
 
-def _synced_condition(current: dict[str, Any]) -> dict[str, Any] | None:
-    conditions = current.get("conditions")
+def _ready_condition(status: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the Ready condition in *status*, or None when it has none."""
+    conditions = status.get("conditions")
     if not isinstance(conditions, list):
         return None
     for condition in conditions:
-        if isinstance(condition, dict) and condition.get("type") == "Synced":
+        if isinstance(condition, dict) and condition.get("type") == "Ready":
             return condition
     return None
+
+
+def _transition_time(
+    current: dict[str, Any] | None, condition_status: str, now: str
+) -> str:
+    """Return the ``lastTransitionTime`` to write.
+
+    Kept from the existing condition while its ``status`` is unchanged, so the
+    timestamp marks the last True/False flip rather than the last write. A
+    message-only change leaves it alone.
+    """
+    if not current:
+        return now
+    existing = _ready_condition(current)
+    if existing is None or existing.get("status") != condition_status:
+        return now
+    existing_time = existing.get("lastTransitionTime")
+    return existing_time if isinstance(existing_time, str) and existing_time else now
 
 
 def _status_is_current(
@@ -176,13 +199,11 @@ def _status_is_current(
     if generation is not None and current.get("observedGeneration") != generation:
         return False
 
-    current_condition = _synced_condition(current)
-    if current_condition is None:
+    existing = _ready_condition(current)
+    if existing is None:
         return False
-    for key, value in _desired_condition(sync_status, truncated_message).items():
-        if current_condition.get(key) != value:
-            return False
-    return True
+    desired = _desired_condition(sync_status, truncated_message, generation)
+    return all(existing.get(key) == value for key, value in desired.items())
 
 
 #: Memoised CustomObjectsApi, so one config load serves every patch in a run.
@@ -201,10 +222,9 @@ def _customobjects_api() -> Any:
 def crd_request_target(crd_api_version: str, crd_resource: str) -> tuple[str, str, str]:
     """Return ``(group, version, plural)`` for addressing a CR.
 
-    Derived from the two environment values the chart already injects, rather
-    than from new ones: ``<prefix>_CRD_API_VERSION`` is ``<group>/<version>``
-    and ``<prefix>_CRD_RESOURCE`` is ``<plural>.<group>``, which between them
-    carry everything the API needs.
+    Both arguments come from the hook's environment: ``<prefix>_CRD_API_VERSION``
+    is ``<group>/<version>`` and ``<prefix>_CRD_RESOURCE`` is
+    ``<plural>.<group>``.
 
     Raises:
         ValueError: When either value is not in the expected shape.
@@ -220,8 +240,16 @@ def crd_request_target(crd_api_version: str, crd_resource: str) -> tuple[str, st
 
 
 def _api_error_detail(exc: ApiException, max_body: int = 512) -> str:
-    """Return a one-line description of *exc* for a log message."""
-    body = str(exc.body or "").strip().replace("\n", " ")
+    """Return a one-line description of *exc* for a log message.
+
+    The client hands over the apiserver's body as bytes, which is decoded first:
+    formatting bytes directly logs a repr, where a newline is two characters and
+    survives the flattening.
+    """
+    body = exc.body or ""
+    if isinstance(body, bytes):
+        body = body.decode("utf-8", "replace")
+    body = str(body).strip().replace("\n", " ")
     detail = f"HTTP {exc.status} {exc.reason or ''}".strip()
     if not body:
         return detail
@@ -243,10 +271,14 @@ def patch_resource_status(
 ) -> None:
     """Patch the status subresource of a CR.
 
+    A failed write is logged and swallowed: status is reporting, not the work
+    itself. It logs at error level even so, because a CR that cannot report
+    leaves anything waiting on its ``Ready`` condition stuck.
+
     Args:
         name: CR metadata.name.
         namespace: CR metadata.namespace. Required to address the object; the
-            patch is skipped with a warning when it is absent.
+            patch is skipped when it is absent.
         generation: CR metadata.generation for observedGeneration (optional).
         sync_status: One of ``"Synced"`` or ``"Failed"``.
         message: Human-readable detail for the status message.
@@ -270,20 +302,8 @@ def patch_resource_status(
         )
         return
 
-    timestamp = utc_timestamp()
-    condition = _desired_condition(sync_status, message)
-    condition["lastTransitionTime"] = timestamp
-    status: dict[str, Any] = {
-        "syncStatus": sync_status,
-        "lastSyncTime": timestamp,
-        "message": truncate_message(message),
-        "conditions": [condition],
-    }
-    if generation is not None:
-        status["observedGeneration"] = generation
-
     if not namespace:
-        LOG.warning(
+        LOG.error(
             "unable to patch %s status for %s; no namespace to address it in",
             crd_kind,
             name,
@@ -293,12 +313,23 @@ def patch_resource_status(
     try:
         group, version, plural = crd_request_target(crd_api_version, crd_resource)
     except ValueError as exc:
-        LOG.warning("unable to patch %s status for %s: %s", crd_kind, name, exc)
+        LOG.error("unable to patch %s status for %s: %s", crd_kind, name, exc)
         return
 
-    # The client's default content type here is merge-patch+json, which is what
-    # `kubectl patch --type merge --subresource status` sent before this moved
-    # off kubectl, so the request on the wire is unchanged.
+    timestamp = utc_timestamp()
+    condition = _desired_condition(sync_status, message, generation)
+    condition["lastTransitionTime"] = _transition_time(
+        current_status, str(condition["status"]), timestamp
+    )
+    status: dict[str, Any] = {
+        "syncStatus": sync_status,
+        "lastSyncTime": timestamp,
+        "message": truncate_message(message),
+        "conditions": [condition],
+    }
+    if generation is not None:
+        status["observedGeneration"] = generation
+
     try:
         _customobjects_api().patch_namespaced_custom_object_status(
             group=group,
@@ -307,21 +338,26 @@ def patch_resource_status(
             plural=plural,
             name=name,
             body={"status": status},
+            # Replaces the stored status field by field, and conditions
+            # wholesale, so the CR keeps exactly one condition. Named here so
+            # the request does not depend on the client's own default.
+            _content_type="application/merge-patch+json",
         )
     except ApiException as exc:
-        LOG.warning(
+        LOG.error(
             "failed to patch %s status for %s: %s",
             crd_kind,
             name,
             _api_error_detail(exc),
         )
     except Exception as exc:  # noqa: BLE001
-        # Config load and transport failures reach here. A status patch is
-        # reporting, never the work itself, so it must not fail the reconcile.
-        LOG.warning(
+        # Config load and transport failures land here, and so would a bad call
+        # into the client -- hence the traceback.
+        LOG.error(
             "failed to patch %s status for %s: %s: %s",
             crd_kind,
             name,
             type(exc).__name__,
             exc,
+            exc_info=True,
         )

--- a/python/openstack-sync/openstack_sync/hooks/framework.py
+++ b/python/openstack-sync/openstack_sync/hooks/framework.py
@@ -491,7 +491,7 @@ def _patch_status(
 ) -> None:
     config = plugin.config
     if not resource.name:
-        LOG.warning(
+        LOG.error(
             "Unable to patch %s status; Kubernetes metadata.name is missing",
             config.crd_kind,
         )

--- a/python/openstack-sync/tests/test_hook_common.py
+++ b/python/openstack-sync/tests/test_hook_common.py
@@ -7,6 +7,7 @@ import logging
 from unittest import mock
 
 import pytest
+from kubernetes import client as k8s_client
 from kubernetes.client.exceptions import ApiException
 
 from openstack_sync.hooks import common as hc
@@ -183,21 +184,21 @@ def _matching_status(
     message: str = "ok",
     generation: int | None = 1,
 ) -> dict:
-    condition_status = "True" if sync_status == "Synced" else "False"
-    reason = "ReconcileSucceeded" if sync_status == "Synced" else "ReconcileFailed"
+    condition = {
+        "type": "Ready",
+        "status": "True" if sync_status == "Synced" else "False",
+        "reason": "Reconciled" if sync_status == "Synced" else "ReconcileError",
+        "message": message,
+        "lastTransitionTime": "2026-08-19T06:20:21Z",
+    }
+    if generation is not None:
+        condition["observedGeneration"] = generation
+
     status = {
         "syncStatus": sync_status,
         "lastSyncTime": "2026-08-19T06:20:21Z",
         "message": message,
-        "conditions": [
-            {
-                "type": "Synced",
-                "status": condition_status,
-                "reason": reason,
-                "message": message,
-                "lastTransitionTime": "2026-08-19T06:20:21Z",
-            }
-        ],
+        "conditions": [condition],
     }
     if generation is not None:
         status["observedGeneration"] = generation
@@ -227,6 +228,15 @@ def test_status_is_current_ignores_timestamps():
         (_matching_status(message="old"), "Synced", "new", 1),
         (_matching_status(generation=1), "Synced", "ok", 2),
         ({**_matching_status(), "conditions": []}, "Synced", "ok", 1),
+        (
+            {
+                **_matching_status(),
+                "conditions": [{"type": "Reachable", "status": "True"}],
+            },
+            "Synced",
+            "ok",
+            1,
+        ),
     ],
 )
 def test_status_is_current_detects_real_status_differences(
@@ -238,6 +248,13 @@ def test_status_is_current_detects_real_status_differences(
     assert not hc._status_is_current(current, sync_status, message, generation)
 
 
+def test_status_is_current_rejects_a_stale_condition_generation():
+    current = _matching_status(generation=2)
+    current["conditions"][0]["observedGeneration"] = 1
+
+    assert not hc._status_is_current(current, "Synced", "ok", 2)
+
+
 # ---------------------------------------------------------------------------
 # patch_resource_status
 # ---------------------------------------------------------------------------
@@ -245,6 +262,16 @@ def test_status_is_current_detects_real_status_differences(
 
 API_VERSION = "neutron.understack.rackspace.net/v1alpha1"
 RESOURCE = "neutronrouterflavors.neutron.understack.rackspace.net"
+
+
+def _fake_api():
+    """Return a CustomObjectsApi mock that only accepts real client calls.
+
+    Specced against the real class, because an unspecced mock accepts any method
+    name and any signature: a call the client does not have would pass here and
+    surface in production only as a logged error.
+    """
+    return mock.create_autospec(k8s_client.CustomObjectsApi, instance=True)
 
 
 def _patch(**overrides):
@@ -261,10 +288,16 @@ def _patch(**overrides):
         "status_enabled": True,
     }
     kwargs.update(overrides)
-    api = mock.MagicMock()
+    api = _fake_api()
     with mock.patch.object(hc, "_customobjects_api", return_value=api):
         hc.patch_resource_status(**kwargs)
     return api.patch_namespaced_custom_object_status
+
+
+def _written_condition(**overrides) -> dict:
+    """Return the one condition the patch wrote."""
+    (condition,) = _patch(**overrides).call_args.kwargs["body"]["status"]["conditions"]
+    return condition
 
 
 def test_patch_resource_status_skips_when_disabled():
@@ -281,16 +314,72 @@ def test_patch_resource_status_calls_the_api():
     assert kwargs["plural"] == "neutronrouterflavors"
     assert kwargs["namespace"] == "openstack"
     assert kwargs["name"] == "test-flavor"
+    assert kwargs["_content_type"] == "application/merge-patch+json"
 
     status = kwargs["body"]["status"]
     assert status["syncStatus"] == "Synced"
     assert status["observedGeneration"] == 2
-    assert [c["type"] for c in status["conditions"]] == ["Synced"]
+    assert [c["type"] for c in status["conditions"]] == ["Ready"]
+
+
+def test_patch_resource_status_writes_the_ready_condition():
+    condition = _written_condition()
+
+    assert condition["type"] == "Ready"
+    assert condition["status"] == "True"
+    assert condition["reason"] == "Reconciled"
+    assert condition["message"] == "all good"
+    assert condition["observedGeneration"] == 2
+    assert condition["lastTransitionTime"].endswith("Z")
+
+
+def test_patch_resource_status_condition_goes_false_on_failure():
+    condition = _written_condition(sync_status="Failed", message="boom")
+
+    assert condition["status"] == "False"
+    assert condition["reason"] == "ReconcileError"
+
+
+def test_patch_resource_status_omits_condition_generation_when_absent():
+    assert "observedGeneration" not in _written_condition(generation=None)
 
 
 def test_patch_resource_status_omits_generation_when_absent():
     status = _patch(generation=None).call_args.kwargs["body"]["status"]
     assert "observedGeneration" not in status
+
+
+def test_patch_resource_status_keeps_transition_time_when_status_is_unchanged():
+    """A message-only change must not restamp lastTransitionTime."""
+    condition = _written_condition(
+        generation=1,
+        message="ok, with more detail",
+        current_status=_matching_status(message="ok"),
+    )
+
+    assert condition["lastTransitionTime"] == "2026-08-19T06:20:21Z"
+
+
+def test_patch_resource_status_restamps_transition_time_when_status_flips():
+    condition = _written_condition(
+        generation=1,
+        sync_status="Failed",
+        message="boom",
+        current_status=_matching_status(message="ok"),
+    )
+
+    assert condition["lastTransitionTime"] != "2026-08-19T06:20:21Z"
+
+
+def test_patch_resource_status_restamps_a_condition_missing_a_transition_time():
+    current = _matching_status(message="ok")
+    del current["conditions"][0]["lastTransitionTime"]
+
+    condition = _written_condition(
+        generation=1, message="changed", current_status=current
+    )
+
+    assert condition["lastTransitionTime"].endswith("Z")
 
 
 def test_patch_resource_status_skips_when_current_status_matches():
@@ -299,7 +388,7 @@ def test_patch_resource_status_skips_when_current_status_matches():
 
 
 def test_patch_resource_status_skips_without_a_namespace(caplog):
-    with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
+    with caplog.at_level(logging.ERROR, logger="openstack_sync.hooks.common"):
         call = _patch(namespace=None)
 
     assert not call.called
@@ -307,7 +396,7 @@ def test_patch_resource_status_skips_without_a_namespace(caplog):
 
 
 def test_patch_resource_status_skips_on_unusable_crd_identity(caplog):
-    with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
+    with caplog.at_level(logging.ERROR, logger="openstack_sync.hooks.common"):
         call = _patch(crd_api_version="no-version-here")
 
     assert not call.called
@@ -315,12 +404,12 @@ def test_patch_resource_status_skips_on_unusable_crd_identity(caplog):
 
 
 def test_patch_resource_status_logs_api_errors(caplog):
-    api = mock.MagicMock()
+    api = _fake_api()
     api.patch_namespaced_custom_object_status.side_effect = ApiException(
         status=403, reason="Forbidden"
     )
     with mock.patch.object(hc, "_customobjects_api", return_value=api):
-        with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
+        with caplog.at_level(logging.ERROR, logger="openstack_sync.hooks.common"):
             hc.patch_resource_status(
                 name="test-flavor",
                 namespace="openstack",
@@ -343,7 +432,7 @@ def test_patch_resource_status_logs_unexpected_errors(caplog):
     with mock.patch.object(
         hc, "_customobjects_api", side_effect=RuntimeError("no kubeconfig")
     ):
-        with caplog.at_level(logging.WARNING, logger="openstack_sync.hooks.common"):
+        with caplog.at_level(logging.ERROR, logger="openstack_sync.hooks.common"):
             hc.patch_resource_status(
                 name="test-flavor",
                 namespace="openstack",
@@ -395,6 +484,17 @@ def test_crd_request_target_rejects_unusable_values(api_version, resource):
 def test_api_error_detail_without_a_body():
     exc = ApiException(status=404, reason="Not Found")
     assert hc._api_error_detail(exc) == "HTTP 404 Not Found"
+
+
+def test_api_error_detail_decodes_the_bytes_body_the_client_supplies():
+    exc = ApiException(status=422, reason="Unprocessable Entity")
+    exc.body = b'{"kind":"Status",\n "message":"conditions in body is required"}'
+
+    detail = hc._api_error_detail(exc)
+
+    assert "conditions in body is required" in detail
+    assert "\\n" not in detail
+    assert not detail.startswith("HTTP 422 Unprocessable Entity: b'")
 
 
 def test_api_error_detail_flattens_and_truncates_the_body():


### PR DESCRIPTION
Each plugin CR reports the outcome of its last reconcile, so an operator at a terminal and a controller waiting on the resource can both read it without going to the hook logs.

status carries a Ready condition (reason Reconciled or ReconcileError), syncStatus (Synced or Failed, which the SyncStatus printer column shows), message, lastSyncTime and observedGeneration. Ready is the name Kubernetes
tooling expects: `kubectl wait --for=condition=Ready` and kubernetes-entrypoint's custom_resources dependency both work off it.


<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
