### PR TITLE
fix(openstack-neutron-plugin): re-check the driver while matching profile

### DIFF
--- a/python/openstack-sync/openstack_sync/plugins/neutron/router_flavors/reconcile.py
+++ b/python/openstack-sync/openstack_sync/plugins/neutron/router_flavors/reconcile.py
@@ -80,16 +80,23 @@ def profiles_for_driver(conn: Any, driver: str, cache: ProfileCache) -> list[Any
     return cache[driver]
 
 
-def find_matching_profile(profiles: list[Any], meta_info: Any) -> Any | None:
-    """Return a service profile matching *meta_info*, preferring owned profiles.
+def find_matching_profile(
+    profiles: list[Any], driver: str, meta_info: Any
+) -> Any | None:
+    """Return a profile matching *driver* and *meta_info*, preferring owned ones.
 
     A NeutronRouterFlavor CR is an ownership claim for the flavor and the service
     profiles described under it. If a matching profile already exists without
     the marker, ``ensure_profile`` adopts it before binding or pruning depends on
     that marker.
+
+    The driver is re-checked rather than trusting the candidate list, so a stale
+    or wider cache cannot bind a profile for the wrong service provider.
     """
     unowned_match: Any | None = None
     for profile in profiles:
+        if get_value(profile, "driver") != driver:
+            continue
         if not meta_info_matches(service_profile_meta_info(profile), meta_info):
             continue
         if is_managed_service_profile(profile):
@@ -131,9 +138,8 @@ def _profile_drift(
 ) -> list[ProfileDrift]:
     """Return the spec fields a reused *profile* disagrees with.
 
-    ``meta_info`` is excluded by construction -- the profile was selected by
-    matching it -- and ``driver`` is excluded because profiles are queried per
-    driver. That leaves ``is_enabled`` and ``description``.
+    ``meta_info`` and ``driver`` are excluded by construction -- the profile was
+    selected by matching them. That leaves ``is_enabled`` and ``description``.
 
     ``is_enabled`` is the consequential one: Neutron's
     ``get_flavor_next_provider`` raises ``ServiceProfileDisabled`` (HTTP 503)
@@ -193,7 +199,7 @@ def ensure_profile(
     meta_info = spec.get("meta_info", {})
 
     profiles = profiles_for_driver(conn, driver, cache)
-    profile = find_matching_profile(profiles, meta_info)
+    profile = find_matching_profile(profiles, driver, meta_info)
     if profile:
         profile_id = resource_id(profile)
         if not is_managed_service_profile(profile):

--- a/python/openstack-sync/tests/test_reconcile.py
+++ b/python/openstack-sync/tests/test_reconcile.py
@@ -277,7 +277,7 @@ def test_find_matching_profile_returns_unowned_match():
     meta_info = {"vni_alloc": "auto"}
     unowned = _make_profile("adhoc-profile", meta_info=meta_info, managed=False)
 
-    assert reconcile.find_matching_profile([unowned], meta_info) is unowned
+    assert reconcile.find_matching_profile([unowned], _DRIVER, meta_info) is unowned
 
 
 def test_find_matching_profile_prefers_owned_over_unowned():
@@ -285,7 +285,37 @@ def test_find_matching_profile_prefers_owned_over_unowned():
     unowned = _make_profile("adhoc-profile", meta_info=meta_info, managed=False)
     owned = _make_profile("owned-profile", meta_info=meta_info)
 
-    assert reconcile.find_matching_profile([unowned, owned], meta_info) is owned
+    assert (
+        reconcile.find_matching_profile([unowned, owned], _DRIVER, meta_info) is owned
+    )
+
+
+def test_find_matching_profile_ignores_a_profile_with_another_driver():
+    """The candidate list is Neutron's driver filter; the match must not trust it."""
+    meta_info = {"vni_alloc": "auto"}
+    other_driver = _make_profile(
+        "other-driver-profile", driver="some.other.Driver", meta_info=meta_info
+    )
+
+    assert reconcile.find_matching_profile([other_driver], _DRIVER, meta_info) is None
+
+
+def test_ensure_profile_creates_rather_than_adopting_another_driver():
+    """A wrong-driver profile in the candidate list must not be bound to a flavor."""
+    meta_info = {"vni_alloc": "auto"}
+    other_driver = _make_profile(
+        "other-driver-profile", driver="some.other.Driver", meta_info=meta_info
+    )
+    created = _make_profile("new-profile", meta_info=meta_info)
+    conn = _create_conn(created, existing=[other_driver])
+
+    result = reconcile.ensure_profile(
+        conn, _NAME, _profile_spec(meta_info=meta_info), {}, []
+    )
+
+    assert result is created
+    conn.network.update_service_profile.assert_not_called()
+    assert conn.network.create_service_profile.call_args.kwargs["driver"] == _DRIVER
 
 
 def test_ensure_profile_adopts_unowned_match():


### PR DESCRIPTION

<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
