### PR TITLE
fix(openstack-neutron-plugin): common case when orphaned profiles are never cleaned up when prune is disabled

### DIFF
--- a/python/openstack-sync/openstack_sync/hooks/framework.py
+++ b/python/openstack-sync/openstack_sync/hooks/framework.py
@@ -480,6 +480,15 @@ class SyncPlugin(ABC):
         """
         LOG.debug("%s defines no prune step", type(self).__name__)
 
+    def needs_prune_connection(self) -> bool:
+        """Return whether prune can do useful work and needs a connection.
+
+        Most plugins only prune when their chart prune flag is enabled. Plugins
+        with narrower cleanup that is safe without destructive pruning can
+        override this so deletion-only runs still get a connection.
+        """
+        return self.config.prune
+
 
 # ---------------------------------------------------------------------------
 # Status
@@ -663,7 +672,7 @@ def _run_prune(
 
         conn = connections.get(credentials)
         if conn is None:
-            if not plugin.config.prune:
+            if not plugin.needs_prune_connection():
                 continue
             try:
                 conn = get_openstack_connection(secret_name, cloud_name)

--- a/python/openstack-sync/openstack_sync/hooks/router_flavors.py
+++ b/python/openstack-sync/openstack_sync/hooks/router_flavors.py
@@ -51,10 +51,14 @@ class RouterFlavorPlugin(SyncPlugin):
         authoritative_empty: bool,
     ) -> None:
         if not self.config.prune:
+            prune_module.prune_orphaned_profiles(conn)
             return
         prune_module.prune_removed_flavors(
             conn, desired_specs, authoritative_empty=authoritative_empty
         )
+
+    def needs_prune_connection(self) -> bool:
+        return True
 
 
 def main() -> int:

--- a/python/openstack-sync/openstack_sync/plugins/neutron/router_flavors/prune.py
+++ b/python/openstack-sync/openstack_sync/plugins/neutron/router_flavors/prune.py
@@ -129,8 +129,17 @@ def _prune_orphaned_profiles(
     """
     LOG.info("Scanning for orphaned operator-owned service profiles")
     for profile in list(conn.network.service_profiles()):
-        if is_managed_service_profile(profile):
-            maybe_delete_profile(conn, resource_id(profile), cache, counts)
+        if not is_managed_service_profile(profile):
+            continue
+        profile_id = resource_id(profile)
+        cache.setdefault(profile_id, profile)
+        maybe_delete_profile(conn, profile_id, cache, counts)
+
+
+def prune_orphaned_profiles(conn: Any) -> None:
+    """Delete owned, unattached service profiles without deleting any flavor."""
+    current = list(conn.network.flavors(service_type=SERVICE_TYPE))
+    _prune_orphaned_profiles(conn, {}, _attachment_counts(current))
 
 
 def prune_removed_flavors(

--- a/python/openstack-sync/tests/test_prune.py
+++ b/python/openstack-sync/tests/test_prune.py
@@ -29,6 +29,7 @@ class FakeNetwork:
         self.deleted_flavors: list[str] = []
         self.deleted_profiles: list[str] = []
         self.flavor_list_calls = 0
+        self.profile_get_calls = 0
 
     def flavors(self, service_type: str | None = None) -> list[dict[str, Any]]:
         self.flavor_list_calls += 1
@@ -45,6 +46,7 @@ class FakeNetwork:
         return [p for p in self._profiles.values() if p is not None]
 
     def get_service_profile(self, profile_id: str) -> Any:
+        self.profile_get_calls += 1
         profile = self._profiles.get(profile_id)
         if profile is None:
             raise openstack_exceptions.NotFoundException(f"no profile {profile_id}")
@@ -226,3 +228,66 @@ def test_prune_skips_flavor_still_used_by_routers():
     prune.prune_removed_flavors(conn, [{"name": "kept-flavor"}])
 
     assert conn.network.deleted_flavors == []
+
+
+# ---------------------------------------------------------------------------
+# The orphaned profile sweep on its own, with PRUNE off
+# ---------------------------------------------------------------------------
+
+
+def test_prune_orphaned_profiles_deletes_an_owned_unattached_profile():
+    orphan = _owned_profile("orphan-profile-id")
+    conn = _conn([], {orphan.id: orphan})
+
+    prune.prune_orphaned_profiles(conn)
+
+    assert conn.network.deleted_profiles == ["orphan-profile-id"]
+
+
+def test_prune_orphaned_profiles_keeps_an_unowned_profile():
+    unowned = SimpleNamespace(
+        id="unmanaged-profile-id",
+        driver=_DRIVER,
+        meta_info={"vni_alloc": "auto"},  # no ownership marker
+    )
+    conn = _conn([], {unowned.id: unowned})
+
+    prune.prune_orphaned_profiles(conn)
+
+    assert conn.network.deleted_profiles == []
+
+
+def test_prune_orphaned_profiles_keeps_an_attached_profile():
+    """The sweep needs its own attachment counts, or it deletes a bound profile."""
+    attached = _owned_profile("attached-profile-id")
+    kept = _owned_flavor("kept-flavor-id", "kept-flavor", [attached.id])
+    conn = _conn([kept], {attached.id: attached})
+
+    prune.prune_orphaned_profiles(conn)
+
+    assert conn.network.deleted_profiles == []
+
+
+def test_prune_orphaned_profiles_reuses_the_listing_instead_of_refetching():
+    """The sweep already holds the profile, so it must not GET it again."""
+    orphan = _owned_profile("orphan-profile-id")
+    conn = _conn([], {orphan.id: orphan})
+
+    prune.prune_orphaned_profiles(conn)
+
+    assert conn.network.profile_get_calls == 0
+    assert conn.network.deleted_profiles == ["orphan-profile-id"]
+
+
+def test_prune_orphaned_profiles_deletes_no_flavor():
+    """The sweep must not delete a flavor; that still needs PRUNE."""
+    orphan = _owned_profile("orphan-profile-id")
+    conn = _conn(
+        [_owned_flavor("removed-flavor-id", "removed-flavor")],
+        {orphan.id: orphan},
+    )
+
+    prune.prune_orphaned_profiles(conn)
+
+    assert conn.network.deleted_flavors == []
+    assert conn.network.deleted_profiles == ["orphan-profile-id"]

--- a/python/openstack-sync/tests/test_router_flavors_hook.py
+++ b/python/openstack-sync/tests/test_router_flavors_hook.py
@@ -17,6 +17,8 @@ import pytest
 
 import openstack_sync.utils as utils
 from openstack_sync.hooks import router_flavors as hook
+from openstack_sync.hooks.framework import HookInputs
+from openstack_sync.hooks.framework import SyncResource
 from openstack_sync.plugins.neutron.router_flavors import markers
 from openstack_sync.plugins.neutron.router_flavors.config import BINDING_NAME
 from openstack_sync.plugins.neutron.router_flavors.config import ENV_PREFIX
@@ -156,13 +158,29 @@ def test_plugin_wait_for_api_uses_configured_retry_budget():
     wait.assert_called_once_with(conn, retries=5, delay=0.25)
 
 
-def test_plugin_prune_is_a_noop_when_disabled():
+def test_plugin_prune_deletes_no_flavor_when_disabled():
     plugin = hook.RouterFlavorPlugin(make_hook_config(prune=False))
+    conn = mock.MagicMock()
 
-    with mock.patch.object(hook.prune_module, "prune_removed_flavors") as prune:
-        plugin.prune(mock.MagicMock(), [{"name": "a"}], authoritative_empty=False)
+    with (
+        mock.patch.object(hook.prune_module, "prune_removed_flavors") as prune,
+        mock.patch.object(hook.prune_module, "prune_orphaned_profiles") as sweep,
+    ):
+        plugin.prune(conn, [{"name": "a"}], authoritative_empty=False)
 
     prune.assert_not_called()
+    sweep.assert_called_once_with(conn)
+
+
+def test_plugin_prune_sweeps_orphaned_profiles_when_disabled():
+    """PRUNE gates flavor deletion; an unattached owned profile is collected anyway."""
+    plugin = hook.RouterFlavorPlugin(make_hook_config(prune=False))
+    conn = mock.MagicMock()
+
+    with mock.patch.object(hook.prune_module, "prune_orphaned_profiles") as sweep:
+        plugin.prune(conn, [{"name": "a"}], authoritative_empty=False)
+
+    sweep.assert_called_once_with(conn)
 
 
 def test_plugin_prune_forwards_authoritative_empty_when_enabled():
@@ -181,6 +199,61 @@ def test_plugin_cache_is_per_credential_group():
 
     assert plugin.new_cache() == {}
     assert plugin.new_cache() is not plugin.new_cache()
+
+
+# ---------------------------------------------------------------------------
+# Integration through run_sync()
+# ---------------------------------------------------------------------------
+
+
+def test_run_sync_sweeps_orphaned_profile_on_deletion_when_prune_disabled():
+    """Deletion-only input must still open a connection for safe orphan cleanup."""
+    plugin = hook.RouterFlavorPlugin(make_hook_config(prune=False))
+    deleted = SyncResource(
+        spec={"name": "pa1410"},
+        name="pa1410",
+        namespace="openstack",
+        generation=3,
+        secret_name="infrasetup",
+        cloud_name="understack",
+    )
+    conn = _neutron_conn()
+    orphan = types.SimpleNamespace(
+        id="orphan-profile-id",
+        driver="neutron_understack.l3_router.vrf.Vrf",
+        is_enabled=True,
+        description="pa1410 profile",
+        meta_info=markers.managed_meta_info({"vni_alloc": "auto"}),
+    )
+    conn.network.service_profiles.return_value = [
+        conn.network.service_profiles.return_value[0],
+        orphan,
+    ]
+    inputs = HookInputs(
+        resources_to_reconcile=[],
+        desired_resources_for_prune=[],
+        deleted_resources=[deleted],
+        prune_credentials=frozenset({deleted.credentials}),
+        unreadable_resources=frozenset(),
+    )
+
+    with (
+        mock.patch(
+            "openstack_sync.hooks.framework.get_openstack_connection",
+            return_value=conn,
+        ) as connect,
+        mock.patch("openstack_sync.hooks.framework.patch_resource_status"),
+        mock.patch.object(hook, "wait_for_openstack_network") as wait,
+    ):
+        code = hook.run_sync(plugin, inputs)
+
+    assert code == 0
+    connect.assert_called_once_with("infrasetup", "understack")
+    wait.assert_called_once_with(conn, retries=30, delay=10.0)
+    conn.network.delete_flavor.assert_not_called()
+    assert [
+        call.args[0] for call in conn.network.delete_service_profile.call_args_list
+    ] == [orphan]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This fixes orphan cleanup when a changed/deleted CR gives the framework credentials, including the important deletion-only event path. It does not solve the zero-CR steady state: after all CRs are gone, future scheduled/sync runs have no prune_credentials, so there is no credential source to retry an orphan sweep if the last deletion-event sweep was interrupted.

Fully solving that would require a framework-level credential source outside the CR set, such as persisted last-seen credentials or configured prune credentials which we are not addressing in this PR
<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
