### PR TITLE
feat(kubectl-us-net): audit and repair OVN router state

### DIFF
--- a/docs/operator-guide/kubectl-us-net.md
+++ b/docs/operator-guide/kubectl-us-net.md
@@ -187,6 +187,124 @@ Here the router port shows a **pinned chassis** (expected for a centralized
 router), while the baremetal server's external port shows its own
 **`HA_Chassis_Group`** -- exactly the split described in the note above.
 
+### router audit
+
+```bash
+kubectl us-net router audit <router-name-or-id>
+```
+
+Compares Neutron's native OVN router and port state with its realized state.
+The command exits nonzero when any check fails, so it can also be used as a
+pre/post-upgrade check. Flavored routers are skipped because their realization
+is outside this command's scope.
+
+For a native OVN router, the audit verifies:
+
+- the `Logical_Router` exists;
+- every Neutron gateway and interface port has an attached
+  `Logical_Router_Port` and a peer `Logical_Switch_Port` on the expected
+  switch. Gateway ports must use `neutron-<network-id>`. Router interfaces
+  currently use the same base-network switch because ML2/OVN does not
+  host-bind them. The audit defensively accepts a future segment-stamped
+  interface on its `neutron-<segment-id>` switch;
+- every LRP attached to the logical router, and its peer LSP when present,
+  corresponds to a current Neutron router port;
+- each router network has exactly one shared Neutron `uplink-*` port, with a
+  matching `localnet` LSP attached to `neutron-<network-id>` and
+  `addresses=unknown`, and exactly one VLAN tag;
+- the peer LSP has `type=router`, `addresses=router`, and the matching
+  `options:router-port`;
+- gateway LSPs additionally have `options:nat-addresses=router` and
+  `options:exclude-lb-vips-from-garp=true`; and
+- Neutron's `binding:host_id` is present in the comma-separated
+  `options:requested-chassis` value. An absent value on both sides is healthy;
+  it should not be added to an unbound port; and
+- each router-owned per-network `HA_Chassis_Group` has at least one
+  `HA_Chassis` member whose chassis is live in the Southbound database. This
+  reports empty and stale-only groups as requiring per-network HA chassis
+  group repopulation; and
+- when repopulation is required, a live `options:chassis` value or an
+  unambiguous router-level HA chassis group is available as its source.
+
+Example of the corruption detected in issue 2330:
+
+```console
+Router tenant-router (7a4b...)
+Backend: native OVN
+  PASS  logical router: neutron-7a4b...
+  FAIL  gateway 6718...: LSP type: expected router, found (empty)
+  FAIL  gateway 6718...: LSP addresses: expected ['router'], found []
+  FAIL  gateway 6718...: router-port option: expected lrp-6718..., found (missing)
+  FAIL  gateway 6718...: nat-addresses option: expected router, found (missing)
+```
+
+### router repair
+
+```bash
+# Plan only; this never writes to OVN.
+kubectl us-net router repair <router-name-or-id>
+
+# Apply the displayed plan and verify the result.
+kubectl us-net router repair <router-name-or-id> --apply
+```
+
+`router repair` is deliberately narrower than Neutron's fleet-wide OVN DB
+sync repair mode. It repairs only the selected native-OVN router. Existing
+gateway/interface peer LSP rows must already be attached to both the expected
+logical router port and logical switch. Its LSP writes are:
+
+- `type=router`;
+- `addresses=router`;
+- `options:router-port=lrp-<port-id>`; and, for gateway ports only,
+- `options:nat-addresses=router` and
+  `options:exclude-lb-vips-from-garp=true`.
+
+The command updates option keys individually, preserving unrelated options
+such as `requested-chassis`.
+
+Repair also repopulates router-owned per-network HA chassis groups that have
+no live members. It selects the target chassis from the logical router's live
+`options:chassis` value. When that option is absent, it uses the router's own
+HA chassis group only when that group resolves to exactly one live chassis.
+For each affected per-network group, repair removes its non-live member
+references, creates a replacement `HA_Chassis` at priority `32767`, and adds
+the replacement to the group.
+
+This per-router repair overlaps the stale-member cleanup and per-network group
+repopulation performed fleet-wide by
+`scripts/cleanup_dead_ovn_ha_chassis.py`.
+The script also has a separate, opt-in orphan-network teardown mode that this
+command does not provide. The command is preferable when diagnosing and
+repairing one known router; use the script when intentionally auditing the
+fleet-wide HA chassis state.
+
+Shared `uplink-*` localnet LSPs are audit-only. `router repair` does not
+recreate them because doing so also requires coordinating Neutron port and
+trunk state.
+
+With `--apply`, all planned LSP and HA chassis group updates are sent in one
+`ovn-nbctl` transaction and the affected state is read back for verification.
+HA chassis group verification checks the exact plan: the selected chassis is
+present at priority `32767` and the stale member references are absent.
+
+Repair refuses a router with a flavor entirely. For native OVN routers, it
+refuses the affected repair domain when:
+
+- a logical router, router port, or switch port is missing; or
+- an existing port is attached to the wrong logical router or switch; or
+- an LRP is attached to the logical router without a corresponding Neutron
+  router port; or
+- an affected per-network HA chassis group has no unambiguous live target
+  chassis.
+
+Those conditions require investigation rather than field-level repair. Run
+`router audit` after resolving them.
+
+LSP repair and HA chassis group repair are independent safety domains. A
+refusal in one domain does not block safe work in the other. When `--apply`
+performs only the safe portion, the command verifies that work and exits `2`
+to report that part of the router remains unresolved.
+
 ## Development
 
 Each command is a self-contained module under `us_net/commands/` that

--- a/python/kubectl-us-net/README.md
+++ b/python/kubectl-us-net/README.md
@@ -87,6 +87,62 @@ Resolves the router in OpenStack, maps it to its OVN `Logical_Router`
   from the router-port-level HCG shown above).
 - Optionally, southbound logical flows (`ovn-sbctl lflow-list`).
 
+### `router audit`
+
+```
+kubectl us-net router audit <router-name-or-id>
+```
+
+Checks native OVN routers for their logical router, LRP/LSP attachments,
+router peer LSP type, addresses, required options, and `requested-chassis`
+membership with `binding:host_id`. Gateway LSPs must use the network logical
+switch. Router interfaces use it today; a segment-stamped interface is also
+accepted on its segment switch as a defensive forward-compatibility path.
+Attached LRPs and peer LSPs without a Neutron router port are reported as
+orphans.
+For each router network, the audit also verifies that its single shared
+Neutron `uplink-*` port has a matching `localnet` LSP on the network logical
+switch with `addresses=unknown` and exactly one VLAN tag.
+Router-owned per-network `HA_Chassis_Group` rows are also checked for at least
+one member backed by a live Southbound chassis. An empty or stale-only group is
+reported as requiring per-network HA chassis group repopulation, along with
+whether the router has an unambiguous live chassis from which to repair it.
+Flavored routers are skipped because their realization is outside this
+command's scope. Any failed check produces a nonzero exit status.
+
+### `router repair`
+
+```
+kubectl us-net router repair <router-name-or-id>          # dry-run plan
+kubectl us-net router repair <router-name-or-id> --apply  # write and verify
+```
+
+Narrowly repairs the `type`, `addresses`, `router-port`, and gateway-only
+`nat-addresses`/`exclude-lb-vips-from-garp` fields of existing, correctly
+attached native-OVN peer LSPs. Map keys are updated individually, so unrelated
+options such as `requested-chassis` are preserved.
+Shared `uplink-*` localnet LSPs are audit-only and are not recreated by this
+command.
+
+The same transaction repopulates a router-owned per-network HA chassis group
+when it has no live members. The target must be unambiguous: a live
+`Logical_Router.options:chassis`, or, for a distributed router, exactly one
+live chassis resolved through the router's own HA chassis group. Stale member
+references are removed from the affected per-network group, a replacement is
+created at priority `32767`, and the result is read back for verification.
+Verification checks that the selected chassis was added at that priority and
+that every stale member reference in the plan was removed.
+
+Repair refuses flavored routers, missing objects, wrong attachments, attached
+LRPs without Neutron router ports, and HA chassis placement that is unavailable
+or ambiguous. LSP and HA chassis group repairs are independent: a refusal in
+one does not block safe changes in the other, but a partial repair exits `2`.
+For fleet-wide stale-member cleanup and group repopulation, see
+[`cleanup_dead_ovn_ha_chassis.py`](../../scripts/cleanup_dead_ovn_ha_chassis.py).
+See the
+[operator guide](../../docs/operator-guide/kubectl-us-net.md#router-repair) for
+the complete safety contract.
+
 ## Global options
 
 - `--context` -- kubectl context (default: current context)

--- a/python/kubectl-us-net/tests/test_ovn.py
+++ b/python/kubectl-us-net/tests/test_ovn.py
@@ -1,4 +1,5 @@
 from us_net.ovn import as_list
+from us_net.ovn import nbctl_list_records
 from us_net.ovn import parse_ovn_json
 
 
@@ -26,3 +27,22 @@ def test_as_list_normalizes_single_value_and_empty():
     assert as_list("") == []
     assert as_list("solo") == ["solo"]
     assert as_list(["a", "b"]) == ["a", "b"]
+
+
+def test_nbctl_list_records_uses_if_exists(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "us_net.ovn.nbctl_raw",
+        lambda ctx, args: calls.append(args) or '{"headings": [], "data": []}',
+    )
+
+    assert nbctl_list_records(None, "Logical_Router_Port", ["uuid-1"]) == []
+    assert calls == [
+        [
+            "--format=json",
+            "--if-exists",
+            "list",
+            "Logical_Router_Port",
+            "uuid-1",
+        ]
+    ]

--- a/python/kubectl-us-net/tests/test_router.py
+++ b/python/kubectl-us-net/tests/test_router.py
@@ -1,10 +1,12 @@
 import types
 
+import pytest
 import typer
 from openstack import exceptions as os_exc
 from typer.testing import CliRunner
 
 from us_net.commands import router
+from us_net.commands import router_common
 from us_net.connection import ConnectionContext
 
 runner = CliRunner()
@@ -365,6 +367,33 @@ def test_router_show_reports_gateway_and_internal_ports(monkeypatch):
     assert "-> port vm-port-1" in result.output
     assert "snat" in result.output
     assert "logical=192.168.0.0/24" in result.output
+
+
+@pytest.mark.parametrize(
+    "device_owner",
+    sorted(
+        router_common.ROUTER_INTERFACE_DEVICE_OWNERS
+        - {router_common.INTERFACE_DEVICE_OWNER}
+    ),
+)
+def test_router_show_recognizes_migrated_interface_owners(monkeypatch, device_owner):
+    patch_common(monkeypatch)
+    ports = make_ports()
+    ports[1].device_owner = device_owner
+    monkeypatch.setattr(
+        router.osclient,
+        "get_connection",
+        lambda os_cloud: FakeConnection(
+            ports,
+            all_ports=[*ports, make_bound_port()],
+            servers={"server-1": types.SimpleNamespace(name="my-server")},
+        ),
+    )
+
+    result = runner.invoke(make_app(), ["router", "show", "test-router"])
+
+    assert result.exit_code == 0
+    assert "lrp-int-1 [internal]" in result.output
     assert "FLOW_TABLE_OUTPUT" not in result.output  # --flows not passed
 
 
@@ -658,7 +687,7 @@ def test_rows_by_uuid_filters_to_matching_rows_only():
         {"_uuid": "b", "name": "drop-b"},
         {"_uuid": "c", "name": "keep-c"},
     ]
-    result = router._rows_by_uuid(rows, {"a", "c"})
+    result = router_common.rows_by_uuid(rows, {"a", "c"})
     assert result == [
         {"_uuid": "a", "name": "keep-a"},
         {"_uuid": "c", "name": "keep-c"},
@@ -667,12 +696,12 @@ def test_rows_by_uuid_filters_to_matching_rows_only():
 
 def test_rows_by_uuid_ignores_rows_missing_uuid_key():
     rows = [{"name": "no-uuid-field"}, {"_uuid": "a", "name": "keep-a"}]
-    assert router._rows_by_uuid(rows, {"a"}) == [{"_uuid": "a", "name": "keep-a"}]
+    assert router_common.rows_by_uuid(rows, {"a"}) == [{"_uuid": "a", "name": "keep-a"}]
 
 
 def test_rows_by_uuid_returns_empty_for_no_matches():
     rows = [{"_uuid": "a"}, {"_uuid": "b"}]
-    assert router._rows_by_uuid(rows, {"z"}) == []
+    assert router_common.rows_by_uuid(rows, {"z"}) == []
 
 
 def test_router_show_flags_dangling_hcg_reference(monkeypatch):

--- a/python/kubectl-us-net/tests/test_router_health.py
+++ b/python/kubectl-us-net/tests/test_router_health.py
@@ -1,0 +1,935 @@
+import types
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from us_net.commands import router
+from us_net.commands import router_health
+from us_net.connection import ConnectionContext
+
+runner = CliRunner()
+
+
+def make_app():
+    app = typer.Typer()
+
+    @app.callback()
+    def main(ctx: typer.Context) -> None:
+        ctx.obj = ConnectionContext(
+            kube_context=None,
+            namespace="openstack",
+            nb_pod="ovn-ovsdb-nb-0",
+            sb_pod="ovn-ovsdb-sb-0",
+            os_cloud="dev-cloud",
+        )
+
+    app.add_typer(router.app, name="router")
+    return app
+
+
+class FakeNetwork:
+    def __init__(self, test_router, ports):
+        self.router = test_router
+        self._ports = ports
+
+    def find_router(self, name_or_id):
+        return self.router if name_or_id in {self.router.id, self.router.name} else None
+
+    def ports(self, device_id=None, name=None, network_id=None):
+        ports = self._ports
+        if name is not None:
+            ports = [port for port in ports if getattr(port, "name", None) == name]
+        if device_id is not None:
+            ports = [
+                port for port in ports if getattr(port, "device_id", None) == device_id
+            ]
+        if network_id is not None:
+            ports = [
+                port
+                for port in ports
+                if getattr(port, "network_id", None) == network_id
+            ]
+        return ports
+
+
+class FakeConnection:
+    def __init__(self, network):
+        self.network = network
+        self.config = types.SimpleNamespace(config={})
+
+
+def native_state(*, healthy=False, requested_chassis=""):
+    test_router = types.SimpleNamespace(
+        id="router-1", name="native-router", flavor_id=None
+    )
+    port = types.SimpleNamespace(
+        id="gw-1",
+        name="",
+        network_id="net-1",
+        device_id="router-1",
+        device_owner="network:router_gateway",
+        binding_host_id=requested_chassis,
+    )
+    uplink_port = types.SimpleNamespace(
+        id="uplink-port-1",
+        name="uplink-segment-1",
+        network_id="net-1",
+        device_id="",
+        device_owner="",
+    )
+    options = (
+        {
+            "router-port": "lrp-gw-1",
+            "nat-addresses": "router",
+            "exclude-lb-vips-from-garp": "true",
+            **({"requested-chassis": requested_chassis} if requested_chassis else {}),
+        }
+        if healthy
+        else ({"requested-chassis": requested_chassis} if requested_chassis else {})
+    )
+    tables = {
+        "Logical_Router": [
+            {
+                "_uuid": "lr-uuid",
+                "name": "neutron-router-1",
+                "ports": ["lrp-uuid"],
+            }
+        ],
+        "Logical_Router_Port": [{"_uuid": "lrp-uuid", "name": "lrp-gw-1"}],
+        "Logical_Switch_Port": [
+            {
+                "_uuid": "lsp-uuid",
+                "name": "gw-1",
+                "type": "router" if healthy else "",
+                "addresses": ["router"] if healthy else [],
+                "options": options,
+            },
+            {
+                "_uuid": "uplink-lsp-uuid",
+                "name": "uplink-segment-1",
+                "type": "localnet",
+                "addresses": ["unknown"],
+                "tag": 1800,
+                "options": {},
+            },
+        ],
+        "Logical_Switch": [
+            {
+                "_uuid": "ls-uuid",
+                "name": "neutron-net-1",
+                "ports": ["lsp-uuid", "uplink-lsp-uuid"],
+            }
+        ],
+        "HA_Chassis_Group": [],
+        "HA_Chassis": [],
+        "SB_Chassis": [],
+    }
+    return FakeConnection(FakeNetwork(test_router, [port, uplink_port])), tables
+
+
+def patch_environment(
+    monkeypatch,
+    conn,
+    tables,
+    *,
+    list_calls=None,
+    find_calls=None,
+    record_calls=None,
+    sb_list_calls=None,
+):
+    monkeypatch.setattr(router_health.osclient, "get_connection", lambda cloud: conn)
+
+    def list_rows(ctx, table):
+        if list_calls is not None:
+            list_calls.append(table)
+        return tables[table]
+
+    def find_rows(ctx, table, condition):
+        if find_calls is not None:
+            find_calls.append((table, condition))
+        column, value = condition.split("=", 1)
+        if ":" in column:
+            map_column, key = column.split(":", 1)
+            key = key.replace(r"\:", ":")
+            return [
+                row
+                for row in tables[table]
+                if (row.get(map_column) or {}).get(key) == value
+            ]
+        return [row for row in tables[table] if row.get(column) == value]
+
+    def list_records(ctx, table, records):
+        if record_calls is not None:
+            record_calls.append((table, records))
+        record_set = set(records)
+        return [
+            row
+            for row in tables[table]
+            if row.get("_uuid") in record_set or row.get("name") in record_set
+        ]
+
+    def sb_list_rows(ctx, table):
+        if sb_list_calls is not None:
+            sb_list_calls.append(table)
+        return tables[f"SB_{table}"]
+
+    monkeypatch.setattr(
+        router_health.ovn,
+        "nbctl_list",
+        list_rows,
+    )
+    monkeypatch.setattr(router_health.ovn, "nbctl_find", find_rows)
+    monkeypatch.setattr(router_health.ovn, "nbctl_list_records", list_records)
+    monkeypatch.setattr(router_health.ovn, "sbctl_list", sb_list_rows)
+
+
+def test_audit_reports_corrupt_native_gateway_lsp(monkeypatch):
+    conn, tables = native_state()
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 1
+    assert "Backend: native OVN" in result.output
+    assert "FAIL  gateway gw-1: LSP type" in result.output
+    assert "FAIL  gateway gw-1: LSP addresses" in result.output
+    assert "FAIL  gateway gw-1: router-port option" in result.output
+    assert "FAIL  gateway gw-1: nat-addresses option" in result.output
+    assert "FAIL  gateway gw-1: exclude-lb-vips-from-garp option" in result.output
+
+
+def test_audit_reports_missing_peer_lsp_without_crashing(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Switch_Port"] = []
+    tables["Logical_Switch"][0]["ports"] = []
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 1
+    assert "PASS  logical router: neutron-router-1" in result.output
+    assert "FAIL  gateway gw-1: LSP attachment" in result.output
+    assert "found no attachment" in result.output
+    assert "list index out of range" not in result.output
+
+
+def test_audit_reports_missing_uplink_localnet_lsp(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Switch_Port"] = [
+        row
+        for row in tables["Logical_Switch_Port"]
+        if row["name"] != "uplink-segment-1"
+    ]
+    tables["Logical_Switch"][0]["ports"].remove("uplink-lsp-uuid")
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 1
+    assert (
+        "PASS  gateway network net-1: uplink port intent: uplink-segment-1"
+        in result.output
+    )
+    assert "FAIL  gateway uplink uplink-segment-1: LSP attachment" in result.output
+    assert "found no attachment" in result.output
+
+
+def test_audit_groups_gateway_and_internal_network_checks(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    conn.network._ports.extend(
+        [
+            types.SimpleNamespace(
+                id="int-1",
+                name="",
+                network_id="net-2",
+                device_id="router-1",
+                device_owner="network:router_interface",
+                binding_host_id="",
+            ),
+            types.SimpleNamespace(
+                id="uplink-port-2",
+                name="uplink-segment-2",
+                network_id="net-2",
+                device_id="",
+                device_owner="",
+            ),
+        ]
+    )
+    tables["Logical_Router"][0]["ports"].append("int-lrp-uuid")
+    tables["Logical_Router_Port"].append({"_uuid": "int-lrp-uuid", "name": "lrp-int-1"})
+    tables["Logical_Switch_Port"].extend(
+        [
+            {
+                "_uuid": "int-lsp-uuid",
+                "name": "int-1",
+                "type": "router",
+                "addresses": ["router"],
+                "options": {"router-port": "lrp-int-1"},
+            },
+            {
+                "_uuid": "uplink-lsp-uuid-2",
+                "name": "uplink-segment-2",
+                "type": "localnet",
+                "addresses": ["unknown"],
+                "tag": 1801,
+                "options": {},
+            },
+        ]
+    )
+    tables["Logical_Switch"].append(
+        {
+            "_uuid": "ls-uuid-2",
+            "name": "neutron-net-2",
+            "ports": ["int-lsp-uuid", "uplink-lsp-uuid-2"],
+        }
+    )
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 0
+    gateway_port = result.output.index("PASS  gateway gw-1: LRP attachment")
+    gateway_uplink = result.output.index("PASS  gateway network net-1")
+    internal_port = result.output.index("PASS  internal int-1: LRP attachment")
+    internal_uplink = result.output.index("PASS  internal network net-2")
+    assert gateway_port < gateway_uplink < internal_port < internal_uplink
+    assert "PASS  gateway uplink uplink-segment-1: VLAN tag: 1800" in result.output
+    assert "PASS  internal uplink uplink-segment-2: VLAN tag: 1801" in result.output
+
+
+def test_audit_reports_missing_uplink_vlan_tag(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Switch_Port"][1]["tag"] = []
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 1
+    assert (
+        "FAIL  gateway uplink uplink-segment-1: VLAN tag: "
+        "expected one VLAN tag, found none" in result.output
+    )
+
+
+def test_audit_requires_one_router():
+    result = runner.invoke(make_app(), ["router", "audit"])
+
+    assert result.exit_code == 2
+    assert "Missing argument 'NAME_OR_ID'" in result.output
+
+
+def test_audit_accepts_requested_chassis_when_it_matches_binding(monkeypatch):
+    conn, tables = native_state(healthy=True, requested_chassis="infra3.example.net")
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 0
+    assert "PASS  gateway gw-1: requested-chassis: infra3.example.net" in result.output
+    assert "FAIL" not in result.output
+
+
+def test_audit_accepts_host_in_requested_chassis_list(monkeypatch):
+    conn, tables = native_state(healthy=True, requested_chassis="infra3.example.net")
+    tables["Logical_Switch_Port"][0]["options"]["requested-chassis"] = (
+        "infra2.example.net,infra3.example.net"
+    )
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 0
+    assert "FAIL" not in result.output
+
+
+def test_audit_scopes_router_rows_but_keeps_switch_membership(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    list_calls = []
+    find_calls = []
+    record_calls = []
+    patch_environment(
+        monkeypatch,
+        conn,
+        tables,
+        list_calls=list_calls,
+        find_calls=find_calls,
+        record_calls=record_calls,
+    )
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 0
+    assert list_calls == ["Logical_Switch"]
+    assert {table for table, _condition in find_calls} == {
+        "Logical_Router",
+        "HA_Chassis_Group",
+    }
+    assert record_calls == [
+        ("Logical_Router_Port", ["lrp-uuid"]),
+        ("Logical_Switch_Port", ["gw-1", "uplink-segment-1"]),
+    ]
+    assert all("options:router-port" not in condition for _, condition in find_calls)
+
+
+def test_audit_reports_empty_per_network_ha_chassis_group(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-hcg-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": [],
+        }
+    ]
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 1
+    assert (
+        "FAIL  per-network HA chassis group neutron-net-1: no HA_Chassis members"
+        in result.output
+    )
+    assert "repopulation required" in result.output
+    assert (
+        "FAIL  HA chassis repopulation source: router HA chassis group "
+        "neutron-router-1 is missing" in result.output
+    )
+
+
+def test_audit_reports_stale_only_per_network_ha_chassis_group(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-hcg-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": ["ha-uuid"],
+        }
+    ]
+    tables["HA_Chassis"] = [
+        {"_uuid": "ha-uuid", "chassis_name": "dead-chassis", "priority": 32767}
+    ]
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 1
+    assert "non-live members: dead-chassis" in result.output
+
+
+def test_audit_accepts_live_per_network_ha_chassis_group(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-hcg-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": ["ha-uuid"],
+        }
+    ]
+    tables["HA_Chassis"] = [
+        {"_uuid": "ha-uuid", "chassis_name": "live-chassis", "priority": 32767}
+    ]
+    tables["SB_Chassis"] = [{"_uuid": "sb-uuid", "name": "live-chassis"}]
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 0
+    assert (
+        "PASS  per-network HA chassis group neutron-net-1: "
+        "live members: live-chassis" in result.output
+    )
+
+
+def test_audit_loads_southbound_chassis_once(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Router"][0]["options"] = {"chassis": "live-chassis"}
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-hcg-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": ["live-ha-uuid", "dead-ha-uuid"],
+        }
+    ]
+    tables["HA_Chassis"] = [
+        {"_uuid": "live-ha-uuid", "chassis_name": "live-chassis"},
+        {"_uuid": "dead-ha-uuid", "chassis_name": "dead-chassis"},
+    ]
+    tables["SB_Chassis"] = [{"_uuid": "sb-uuid", "name": "live-chassis"}]
+    sb_list_calls = []
+    patch_environment(monkeypatch, conn, tables, sb_list_calls=sb_list_calls)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 0
+    assert sb_list_calls == ["Chassis"]
+
+
+def test_audit_uses_port_segment_for_expected_switch(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    conn.network._ports[0].device_owner = "network:router_interface"
+    tables["Logical_Switch_Port"][0]["external_ids"] = {
+        "neutron:port_segment_id": "segment-1"
+    }
+    tables["Logical_Switch"][0]["name"] = "neutron-segment-1"
+    tables["Logical_Switch"][0]["ports"] = ["lsp-uuid"]
+    tables["Logical_Switch"].append(
+        {
+            "_uuid": "network-ls-uuid",
+            "name": "neutron-net-1",
+            "ports": ["uplink-lsp-uuid"],
+        }
+    )
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 0
+    assert "attached to neutron-segment-1" in result.output
+
+
+def test_audit_rejects_segment_placement_for_gateway(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Switch_Port"][0]["external_ids"] = {
+        "neutron:port_segment_id": "segment-1"
+    }
+    tables["Logical_Switch"][0]["name"] = "neutron-segment-1"
+    patch_environment(monkeypatch, conn, tables)
+
+    audit_result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+    repair_result = runner.invoke(make_app(), ["router", "repair", "native-router"])
+
+    assert audit_result.exit_code == 1
+    assert "FAIL  gateway gw-1: LSP attachment" in audit_result.output
+    assert "expected neutron-net-1" in audit_result.output
+    assert "found ['neutron-segment-1']" in audit_result.output
+    assert repair_result.exit_code == 2
+    assert "LSP attachment is invalid" in repair_result.output
+
+
+def test_audit_reports_orphaned_attached_lrp_and_peer_lsp(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Router"][0]["ports"].append("orphan-lrp-uuid")
+    tables["Logical_Router_Port"].append(
+        {"_uuid": "orphan-lrp-uuid", "name": "lrp-deleted-port"}
+    )
+    tables["Logical_Switch_Port"].append(
+        {
+            "_uuid": "orphan-lsp-uuid",
+            "name": "deleted-port",
+            "type": "router",
+            "addresses": ["router"],
+            "options": {"router-port": "lrp-deleted-port"},
+        }
+    )
+    tables["Logical_Switch"][0]["ports"].append("orphan-lsp-uuid")
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+
+    assert result.exit_code == 1
+    assert "FAIL  orphaned LRP lrp-deleted-port" in result.output
+    assert "FAIL  orphaned peer LSP deleted-port" in result.output
+
+
+def test_repair_is_dry_run_and_preserves_unmanaged_options(monkeypatch):
+    conn, tables = native_state(requested_chassis="infra3.example.net")
+    patch_environment(monkeypatch, conn, tables)
+    calls = []
+    monkeypatch.setattr(
+        router_health.ovn, "nbctl_raw", lambda ctx, args: calls.append(args)
+    )
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router"])
+
+    assert result.exit_code == 0
+    assert "Dry run only" in result.output
+    assert "requested-chassis" not in result.output
+    assert calls == []
+
+
+def test_repair_applies_one_transaction_and_verifies(monkeypatch):
+    conn, tables = native_state(requested_chassis="infra3.example.net")
+    patch_environment(monkeypatch, conn, tables)
+    calls = []
+
+    def apply_repair(ctx, args):
+        calls.append(args)
+        lsp = tables["Logical_Switch_Port"][0]
+        lsp["type"] = "router"
+        lsp["addresses"] = ["router"]
+        lsp["options"].update(
+            {
+                "router-port": "lrp-gw-1",
+                "nat-addresses": "router",
+                "exclude-lb-vips-from-garp": "true",
+            }
+        )
+
+    monkeypatch.setattr(router_health.ovn, "nbctl_raw", apply_repair)
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router", "--apply"])
+
+    assert result.exit_code == 0
+    assert (
+        "Applied 1 LSP repair(s) and 0 HA chassis group repair(s); "
+        "verification passed." in result.output
+    )
+    assert len(calls) == 1
+    command = calls[0]
+    assert "type=router" in command
+    assert "addresses=router" in command
+    assert "options:router-port=lrp-gw-1" in command
+    assert all("requested-chassis" not in arg for arg in command)
+    assert tables["Logical_Switch_Port"][0]["options"]["requested-chassis"] == (
+        "infra3.example.net"
+    )
+
+
+def ha_repair_state():
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Router"][0]["options"] = {"chassis": "live-chassis"}
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-ha-group-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": ["stale-ha-uuid"],
+        }
+    ]
+    tables["HA_Chassis"] = [
+        {
+            "_uuid": "stale-ha-uuid",
+            "chassis_name": "dead-chassis",
+            "priority": 32767,
+        }
+    ]
+    tables["SB_Chassis"] = [{"_uuid": "sb-uuid", "name": "live-chassis"}]
+    return conn, tables
+
+
+def test_repair_repopulates_per_network_ha_chassis_group(monkeypatch):
+    conn, tables = ha_repair_state()
+    patch_environment(monkeypatch, conn, tables)
+    calls = []
+
+    def apply_repair(ctx, args):
+        calls.append(args)
+        tables["HA_Chassis_Group"][0]["ha_chassis"] = ["new-ha-uuid"]
+        tables["HA_Chassis"].append(
+            {
+                "_uuid": "new-ha-uuid",
+                "chassis_name": "live-chassis",
+                "priority": 32767,
+            }
+        )
+
+    monkeypatch.setattr(router_health.ovn, "nbctl_raw", apply_repair)
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router", "--apply"])
+
+    assert result.exit_code == 0
+    assert "remove non-live members: stale-ha-uuid" in result.output
+    assert "repopulate with live chassis: live-chassis" in result.output
+    assert (
+        "Applied 0 LSP repair(s) and 1 HA chassis group repair(s); "
+        "verification passed." in result.output
+    )
+    assert len(calls) == 1
+    command = calls[0]
+    assert "--if-exists" in command
+    assert "remove" in command
+    assert "stale-ha-uuid" in command
+    assert "--id=@ha_chassis_0" in command
+    assert "create" in command
+    assert "chassis_name=live-chassis" in command
+    assert "priority=32767" in command
+    assert "add" in command
+    assert "network-ha-group-uuid" in command
+
+
+def test_repair_verification_requires_planned_ha_chassis_target(monkeypatch):
+    conn, tables = ha_repair_state()
+    tables["SB_Chassis"].append({"_uuid": "other-sb-uuid", "name": "other-live"})
+    patch_environment(monkeypatch, conn, tables)
+
+    def apply_wrong_target(ctx, args):
+        tables["HA_Chassis_Group"][0]["ha_chassis"] = ["other-ha-uuid"]
+        tables["HA_Chassis"].append(
+            {
+                "_uuid": "other-ha-uuid",
+                "chassis_name": "other-live",
+                "priority": 32767,
+            }
+        )
+
+    monkeypatch.setattr(router_health.ovn, "nbctl_raw", apply_wrong_target)
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router", "--apply"])
+
+    assert result.exit_code == 1
+    assert "ERROR: repair verification failed" in result.output
+    assert "target chassis live-chassis is not a member" in result.output
+
+
+def test_repair_verification_checks_removed_members_and_priority(monkeypatch):
+    conn, tables = ha_repair_state()
+    patch_environment(monkeypatch, conn, tables)
+
+    def apply_incomplete_repair(ctx, args):
+        tables["HA_Chassis_Group"][0]["ha_chassis"] = [
+            "stale-ha-uuid",
+            "new-ha-uuid",
+        ]
+        tables["HA_Chassis"].append(
+            {
+                "_uuid": "new-ha-uuid",
+                "chassis_name": "live-chassis",
+                "priority": 1,
+            }
+        )
+
+    monkeypatch.setattr(router_health.ovn, "nbctl_raw", apply_incomplete_repair)
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router", "--apply"])
+
+    assert result.exit_code == 1
+    assert "removed HA_Chassis references remain: stale-ha-uuid" in result.output
+    assert "target chassis live-chassis has priority 1, expected 32767" in result.output
+
+
+def test_repair_resolves_target_from_router_ha_chassis_group(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-ha-group-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": [],
+        },
+        {
+            "_uuid": "router-ha-group-uuid",
+            "name": "neutron-router-1",
+            "external_ids": {"neutron:router_id": "router-1"},
+            "ha_chassis": ["router-ha-uuid"],
+        },
+    ]
+    tables["HA_Chassis"] = [
+        {
+            "_uuid": "router-ha-uuid",
+            "chassis_name": "live-chassis",
+            "priority": 32764,
+        }
+    ]
+    tables["SB_Chassis"] = [{"_uuid": "sb-uuid", "name": "live-chassis"}]
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router"])
+
+    assert result.exit_code == 0
+    assert "HA chassis group neutron-net-1" in result.output
+    assert "repopulate with live chassis: live-chassis" in result.output
+    assert "Dry run only" in result.output
+
+
+def test_repair_refuses_unavailable_ha_chassis_target(monkeypatch):
+    conn, tables = native_state(healthy=True)
+    tables["Logical_Router"][0]["options"] = {"chassis": "dead-chassis"}
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-ha-group-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": [],
+        }
+    ]
+    patch_environment(monkeypatch, conn, tables)
+    calls = []
+    monkeypatch.setattr(
+        router_health.ovn, "nbctl_raw", lambda ctx, args: calls.append(args)
+    )
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router", "--apply"])
+
+    assert result.exit_code == 2
+    assert "options:chassis=dead-chassis is not live" in result.output
+    assert "No changes made" in result.output
+    assert calls == []
+
+
+def test_unavailable_ha_target_does_not_block_lsp_repair(monkeypatch):
+    conn, tables = native_state()
+    tables["Logical_Router"][0]["options"] = {"chassis": "dead-chassis"}
+    tables["HA_Chassis_Group"] = [
+        {
+            "_uuid": "network-ha-group-uuid",
+            "name": "neutron-net-1",
+            "external_ids": {
+                "neutron:network_id": "net-1",
+                "neutron:router_id": "router-1",
+            },
+            "ha_chassis": [],
+        }
+    ]
+    patch_environment(monkeypatch, conn, tables)
+    calls = []
+
+    def apply_repair(ctx, args):
+        calls.append(args)
+        lsp = tables["Logical_Switch_Port"][0]
+        lsp["type"] = "router"
+        lsp["addresses"] = ["router"]
+        lsp["options"].update(
+            {
+                "router-port": "lrp-gw-1",
+                "nat-addresses": "router",
+                "exclude-lb-vips-from-garp": "true",
+            }
+        )
+
+    monkeypatch.setattr(router_health.ovn, "nbctl_raw", apply_repair)
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router", "--apply"])
+
+    assert result.exit_code == 2
+    assert "REFUSED HA chassis group repair" in result.output
+    assert "options:chassis=dead-chassis is not live" in result.output
+    assert (
+        "Applied 1 LSP repair(s) and 0 HA chassis group repair(s); "
+        "verification passed." in result.output
+    )
+    assert "Some repair domains remain refused" in result.output
+    assert len(calls) == 1
+    assert "type=router" in calls[0]
+    assert "create" not in calls[0]
+
+
+def test_repair_refuses_wrong_switch_without_writing(monkeypatch):
+    conn, tables = native_state()
+    tables["Logical_Switch"][0]["name"] = "neutron-wrong-net"
+    patch_environment(monkeypatch, conn, tables)
+    calls = []
+    monkeypatch.setattr(
+        router_health.ovn, "nbctl_raw", lambda ctx, args: calls.append(args)
+    )
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router", "--apply"])
+
+    assert result.exit_code == 2
+    assert "REFUSED" in result.output
+    assert "No changes made" in result.output
+    assert calls == []
+
+
+def test_repair_allows_segment_backed_switch(monkeypatch):
+    conn, tables = native_state()
+    conn.network._ports[0].device_owner = "network:router_interface"
+    tables["Logical_Switch_Port"][0]["external_ids"] = {
+        "neutron:port_segment_id": "segment-1"
+    }
+    tables["Logical_Switch"][0]["name"] = "neutron-segment-1"
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "repair", "native-router"])
+
+    assert result.exit_code == 0
+    assert "Dry run only" in result.output
+    assert "REFUSED" not in result.output
+
+
+@pytest.mark.parametrize(
+    "device_owner",
+    [
+        "network:router_interface_distributed",
+        "network:ha_router_replicated_interface",
+        "network:router_ha_interface",
+    ],
+)
+def test_audit_accepts_migrated_router_interface_owners(monkeypatch, device_owner):
+    conn, tables = native_state(healthy=True)
+    conn.network._ports[0].device_owner = device_owner
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+    repair_result = runner.invoke(make_app(), ["router", "repair", "native-router"])
+
+    assert result.exit_code == 0
+    assert repair_result.exit_code == 0
+    assert "PASS  internal gw-1: LRP attachment" in result.output
+    assert "orphaned LRP" not in result.output
+    assert "No repairable differences found" in repair_result.output
+
+
+def test_interface_audit_and_repair_exclude_gateway_options(monkeypatch):
+    conn, tables = native_state()
+    conn.network._ports[0].device_owner = "network:router_interface"
+    patch_environment(monkeypatch, conn, tables)
+
+    audit_result = runner.invoke(make_app(), ["router", "audit", "native-router"])
+    repair_result = runner.invoke(make_app(), ["router", "repair", "native-router"])
+
+    assert audit_result.exit_code == 1
+    assert repair_result.exit_code == 0
+    assert "FAIL  internal gw-1: LSP type" in audit_result.output
+    assert "nat-addresses" not in repair_result.output
+    assert "exclude-lb-vips-from-garp" not in repair_result.output
+
+
+def flavored_state():
+    test_router = types.SimpleNamespace(
+        id="flavored-1", name="flavored-router", flavor_id="flavor-1"
+    )
+    tables = {
+        "Logical_Router": [],
+        "Logical_Router_Port": [],
+        "Logical_Switch_Port": [],
+        "Logical_Switch": [],
+    }
+    return FakeConnection(FakeNetwork(test_router, [])), tables
+
+
+def test_audit_skips_flavored_router(monkeypatch):
+    conn, tables = flavored_state()
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(make_app(), ["router", "audit", "flavored-router"])
+
+    assert result.exit_code == 0
+    assert "SKIP  router has flavor flavor-1" in result.output
+
+
+def test_repair_refuses_flavored_router(monkeypatch):
+    conn, tables = flavored_state()
+    patch_environment(monkeypatch, conn, tables)
+
+    result = runner.invoke(
+        make_app(), ["router", "repair", "flavored-router", "--apply"]
+    )
+
+    assert result.exit_code == 2
+    assert "REFUSED: router has flavor flavor-1" in result.output

--- a/python/kubectl-us-net/us_net/commands/router.py
+++ b/python/kubectl-us-net/us_net/commands/router.py
@@ -10,15 +10,15 @@ from openstack import exceptions as os_exc
 
 from us_net import osclient
 from us_net import ovn
+from us_net.commands import router_health
+from us_net.commands.router_common import GATEWAY_DEVICE_OWNER
+from us_net.commands.router_common import NEUTRON_PREFIX
+from us_net.commands.router_common import ROUTER_INTERFACE_DEVICE_OWNERS
+from us_net.commands.router_common import rows_by_uuid
 from us_net.connection import ConnectionContext
 from us_net.connection import print_connection_banner
 
 app = typer.Typer(no_args_is_help=True, help="Inspect a Neutron router's OVN state.")
-
-NEUTRON_PREFIX = "neutron-"
-
-GATEWAY_DEVICE_OWNER = "network:router_gateway"
-INTERFACE_DEVICE_OWNER = "network:router_interface"
 
 
 def _lrp_role(
@@ -30,11 +30,6 @@ def _lrp_role(
     if port_id in interface_port_ids:
         return "internal"
     return "unknown"
-
-
-def _rows_by_uuid(rows: list[dict], uuids: set[str]) -> list[dict]:
-    """Filter a full OVN table dump down to rows referenced by a parent's uuid set."""
-    return [row for row in rows if row.get("_uuid") in uuids]
 
 
 def _chassis_physical_networks(chassis_row: dict | None) -> str:
@@ -180,7 +175,7 @@ def _localnet_tags(
     if switch_row is None:
         return "(switch not found)"
     lsp_uuids = set(ovn.as_list(switch_row.get("ports")))
-    candidate_lsps = _rows_by_uuid(all_lsp_rows, lsp_uuids)
+    candidate_lsps = rows_by_uuid(all_lsp_rows, lsp_uuids)
     tags = [
         tag
         for lsp in candidate_lsps
@@ -219,7 +214,7 @@ def show(
         port_fixed_ips[port.id] = port.fixed_ips
         if port.device_owner == GATEWAY_DEVICE_OWNER:
             gateway_port_id = port.id
-        elif port.device_owner == INTERFACE_DEVICE_OWNER:
+        elif port.device_owner in ROUTER_INTERFACE_DEVICE_OWNERS:
             interface_port_ids.add(port.id)
 
     ovn_name = f"{NEUTRON_PREFIX}{router.id}"
@@ -246,7 +241,7 @@ def show(
 
     lrp_uuids = set(ovn.as_list(lr.get("ports")))
     all_lrps = ovn.nbctl_list(conn_ctx, "Logical_Router_Port")
-    lrps = _rows_by_uuid(all_lrps, lrp_uuids)
+    lrps = rows_by_uuid(all_lrps, lrp_uuids)
 
     hcg_rows = {
         row["_uuid"]: row for row in ovn.nbctl_list(conn_ctx, "HA_Chassis_Group")
@@ -337,7 +332,7 @@ def show(
     print("\nNAT rules:")
     nat_uuids = set(ovn.as_list(lr.get("nat")))
     all_nat_rows = ovn.nbctl_list(conn_ctx, "NAT")
-    nat_rows = _rows_by_uuid(all_nat_rows, nat_uuids)
+    nat_rows = rows_by_uuid(all_nat_rows, nat_uuids)
     resolved_ports: dict[str, Any] = {}
     if not nat_rows:
         print("  (none)")
@@ -430,3 +425,6 @@ def list_routers(ctx: typer.Context) -> None:
         id_col = f"{router_id:<{id_width}}"
         os_col = f"{in_openstack:<9}"
         print(f"{name_col}  {id_col}  {os_col}  {in_ovn}")
+
+
+router_health.register(app)

--- a/python/kubectl-us-net/us_net/commands/router_common.py
+++ b/python/kubectl-us-net/us_net/commands/router_common.py
@@ -1,0 +1,18 @@
+"""Shared constants and helpers for router inspection commands."""
+
+NEUTRON_PREFIX = "neutron-"
+GATEWAY_DEVICE_OWNER = "network:router_gateway"
+INTERFACE_DEVICE_OWNER = "network:router_interface"
+ROUTER_INTERFACE_DEVICE_OWNERS = frozenset(
+    {
+        INTERFACE_DEVICE_OWNER,
+        "network:router_interface_distributed",
+        "network:ha_router_replicated_interface",
+        "network:router_ha_interface",
+    }
+)
+
+
+def rows_by_uuid(rows: list[dict], uuids: set[str]) -> list[dict]:
+    """Return OVN rows referenced by a set of UUIDs."""
+    return [row for row in rows if row.get("_uuid") in uuids]

--- a/python/kubectl-us-net/us_net/commands/router_health.py
+++ b/python/kubectl-us-net/us_net/commands/router_health.py
@@ -1,0 +1,1001 @@
+"""Audit and narrowly repair Neutron router realization state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import typer
+
+from us_net import osclient
+from us_net import ovn
+from us_net.commands.router_common import GATEWAY_DEVICE_OWNER
+from us_net.commands.router_common import NEUTRON_PREFIX
+from us_net.commands.router_common import ROUTER_INTERFACE_DEVICE_OWNERS
+from us_net.commands.router_common import rows_by_uuid
+from us_net.connection import ConnectionContext
+from us_net.connection import print_connection_banner
+
+OVN_NETWORK_ID_EXT_ID_KEY = "neutron:network_id"
+OVN_ROUTER_ID_EXT_ID_KEY = "neutron:router_id"
+HA_CHASSIS_GROUP_HIGHEST_PRIORITY = 32767
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One audit assertion."""
+
+    status: str
+    check: str
+    detail: str
+
+
+@dataclass
+class OvnInventory:
+    """Relevant NB state, loaded once per command."""
+
+    routers: dict[str, dict]
+    router_ports: dict[str, dict]
+    switch_ports: dict[str, dict]
+    switch_port_parents: dict[str, list[str]]
+
+
+@dataclass
+class RouterHaChassisInventory:
+    """Router-owned HA chassis groups, their members, and SB liveness."""
+
+    groups: list[dict]
+    members_by_uuid: dict[str, dict]
+    live_chassis_names: set[str]
+
+
+@dataclass(frozen=True)
+class RepairOperation:
+    """A single safe Logical_Switch_Port update."""
+
+    port_id: str
+    assignments: tuple[str, ...]
+    changes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HaChassisGroupRepairOperation:
+    """A safe repopulation of one router-owned per-network HA chassis group."""
+
+    group_uuid: str
+    group_name: str
+    target_chassis: str
+    remove_member_uuids: tuple[str, ...]
+
+
+def _value(resource: Any, key: str, default=None):
+    """Read an SDK resource or dict without depending on its concrete type."""
+    value = getattr(resource, key, None)
+    if value is not None:
+        return value
+    getter = getattr(resource, "get", None)
+    return getter(key, default) if getter else default
+
+
+def _find_rows(
+    conn_ctx: ConnectionContext, table: str, column: str, values: set[str]
+) -> list[dict]:
+    """Find a small set of rows and de-duplicate overlapping queries."""
+    if not values:
+        return []
+    if column in {"_uuid", "name"}:
+        return ovn.nbctl_list_records(conn_ctx, table, sorted(values))
+    rows: dict[str, dict] = {}
+    for value in sorted(values):
+        for row in ovn.nbctl_find(conn_ctx, table, f"{column}={value}"):
+            rows[row.get("_uuid") or row.get("name", "")] = row
+    return list(rows.values())
+
+
+def _load_inventory(
+    conn_ctx: ConnectionContext,
+    router_id: str,
+    ports: list[Any],
+    additional_lsp_names: set[str] | None = None,
+) -> OvnInventory:
+    """Load router-scoped rows while retaining exact switch membership."""
+    lr_name = f"{NEUTRON_PREFIX}{router_id}"
+    lr_rows = ovn.nbctl_find(conn_ctx, "Logical_Router", f"name={lr_name}")
+    routers = {row.get("name", ""): row for row in lr_rows}
+
+    attached_lrp_uuids = {
+        uuid for lr in lr_rows for uuid in ovn.as_list(lr.get("ports"))
+    }
+    lrp_rows = _find_rows(conn_ctx, "Logical_Router_Port", "_uuid", attached_lrp_uuids)
+    expected_lrp_names = {f"lrp-{_value(port, 'id')}" for port in ports}
+    found_lrp_names = {row.get("name", "") for row in lrp_rows}
+    lrp_rows.extend(
+        _find_rows(
+            conn_ctx,
+            "Logical_Router_Port",
+            "name",
+            expected_lrp_names - found_lrp_names,
+        )
+    )
+    router_ports = {row.get("name", ""): row for row in lrp_rows}
+
+    lsp_names = {_value(port, "id") for port in ports if _value(port, "id") is not None}
+    lsp_names.update(additional_lsp_names or set())
+    lsp_names.update(
+        name.removeprefix("lrp-") for name in router_ports if name.startswith("lrp-")
+    )
+    lsp_rows = _find_rows(conn_ctx, "Logical_Switch_Port", "name", lsp_names)
+    switch_ports = {row.get("name", ""): row for row in lsp_rows}
+
+    switch_port_parents: dict[str, list[str]] = {}
+    # A complete switch membership map is required to prove an LSP is attached
+    # to exactly one switch, rather than merely finding it on the expected one.
+    for switch in ovn.nbctl_list(conn_ctx, "Logical_Switch"):
+        for port_uuid in ovn.as_list(switch.get("ports")):
+            switch_port_parents.setdefault(port_uuid, []).append(switch.get("name", ""))
+    return OvnInventory(
+        routers=routers,
+        router_ports=router_ports,
+        switch_ports=switch_ports,
+        switch_port_parents=switch_port_parents,
+    )
+
+
+def _load_router_ha_chassis_inventory(
+    conn_ctx: ConnectionContext,
+    router_id: str,
+    candidate_chassis_names: set[str] | None = None,
+) -> RouterHaChassisInventory:
+    """Load router-owned HA group members and relevant chassis liveness."""
+    escaped_key = OVN_ROUTER_ID_EXT_ID_KEY.replace(":", r"\:")
+    groups = ovn.nbctl_find(
+        conn_ctx,
+        "HA_Chassis_Group",
+        f"external_ids:{escaped_key}={router_id}",
+    )
+    member_uuids = {
+        member_uuid
+        for group in groups
+        for member_uuid in ovn.as_list(group.get("ha_chassis"))
+    }
+    members = (
+        ovn.nbctl_list_records(conn_ctx, "HA_Chassis", sorted(member_uuids))
+        if member_uuids
+        else []
+    )
+    members_by_uuid = {member["_uuid"]: member for member in members}
+    chassis_names = {
+        member.get("chassis_name", "")
+        for member in members
+        if member.get("chassis_name")
+    }
+    chassis_names.update(candidate_chassis_names or set())
+    live_chassis_names = (
+        {
+            row.get("name", "")
+            for row in ovn.sbctl_list(conn_ctx, "Chassis")
+            if row.get("name") in chassis_names
+        }
+        if chassis_names
+        else set()
+    )
+    return RouterHaChassisInventory(groups, members_by_uuid, live_chassis_names)
+
+
+def _group_members(
+    group: dict, inventory: RouterHaChassisInventory
+) -> tuple[set[str], list[dict], list[str]]:
+    member_uuids = set(ovn.as_list(group.get("ha_chassis")))
+    members = [
+        inventory.members_by_uuid[member_uuid]
+        for member_uuid in member_uuids
+        if member_uuid in inventory.members_by_uuid
+    ]
+    live_names = sorted(
+        {
+            member.get("chassis_name", "")
+            for member in members
+            if member.get("chassis_name") in inventory.live_chassis_names
+        }
+    )
+    return member_uuids, members, live_names
+
+
+def _audit_network_ha_chassis_groups(
+    inventory: RouterHaChassisInventory,
+) -> list[Finding]:
+    """Check router-owned per-network HA groups have a live member."""
+    findings: list[Finding] = []
+    for group in inventory.groups:
+        external_ids = group.get("external_ids") or {}
+        network_id = external_ids.get(OVN_NETWORK_ID_EXT_ID_KEY)
+        if not network_id:
+            continue
+
+        member_uuids, members, live_names = _group_members(group, inventory)
+        resolved_uuids = {member.get("_uuid") for member in members}
+        missing_uuids = sorted(member_uuids - resolved_uuids)
+        stale_names = sorted(
+            member.get("chassis_name") or "(unnamed)"
+            for member in members
+            if member.get("chassis_name") not in inventory.live_chassis_names
+        )
+
+        group_name = group.get("name") or f"neutron-{network_id}"
+        if live_names:
+            findings.append(
+                Finding(
+                    "PASS",
+                    f"per-network HA chassis group {group_name}",
+                    f"live members: {', '.join(sorted(live_names))}",
+                )
+            )
+            continue
+
+        details: list[str] = []
+        if not member_uuids:
+            details.append("no HA_Chassis members")
+        if stale_names:
+            details.append(f"non-live members: {', '.join(sorted(stale_names))}")
+        if missing_uuids:
+            details.append(f"missing HA_Chassis rows: {', '.join(missing_uuids)}")
+        findings.append(
+            Finding(
+                "FAIL",
+                f"per-network HA chassis group {group_name}",
+                "; ".join(details) + "; repopulation required",
+            )
+        )
+    return findings
+
+
+def _ha_chassis_repopulation_target(
+    router,
+    inventory: OvnInventory,
+    ha_inventory: RouterHaChassisInventory,
+) -> tuple[str | None, str | None]:
+    """Resolve the one live chassis safe for per-network group repair."""
+    router_id = _value(router, "id")
+    lr = inventory.routers.get(f"{NEUTRON_PREFIX}{router_id}")
+    if lr is None:
+        return None, f"logical router {NEUTRON_PREFIX}{router_id} is missing"
+
+    centralized_chassis = (lr.get("options") or {}).get("chassis")
+    if centralized_chassis:
+        if centralized_chassis in ha_inventory.live_chassis_names:
+            return centralized_chassis, None
+        return (
+            None,
+            f"logical router options:chassis={centralized_chassis} is not live",
+        )
+
+    router_group_name = f"{NEUTRON_PREFIX}{router_id}"
+    router_group = next(
+        (
+            group
+            for group in ha_inventory.groups
+            if group.get("name") == router_group_name
+        ),
+        None,
+    )
+    if router_group is None:
+        return None, f"router HA chassis group {router_group_name} is missing"
+
+    live_names = _group_members(router_group, ha_inventory)[2]
+    if len(live_names) == 1:
+        return live_names[0], None
+    return (
+        None,
+        f"router HA chassis group {router_group_name} resolves to "
+        f"{len(live_names)} live chassis; expected exactly one",
+    )
+
+
+def _audit_ha_chassis_repopulation_source(
+    router,
+    inventory: OvnInventory,
+    ha_inventory: RouterHaChassisInventory,
+) -> list[Finding]:
+    """Report whether failed per-network groups have a repair source."""
+    needs_repopulation = any(
+        (group.get("external_ids") or {}).get(OVN_NETWORK_ID_EXT_ID_KEY)
+        and not _group_members(group, ha_inventory)[2]
+        for group in ha_inventory.groups
+    )
+    if not needs_repopulation:
+        return []
+
+    target, error = _ha_chassis_repopulation_target(router, inventory, ha_inventory)
+    return [
+        Finding(
+            "PASS" if target else "FAIL",
+            "HA chassis repopulation source",
+            f"live chassis: {target}" if target else error or "unavailable",
+        )
+    ]
+
+
+def _binding_host(port) -> str:
+    return _value(port, "binding_host_id") or _value(port, "binding:host_id") or ""
+
+
+def _router_ports(conn, router_id: str) -> list[Any]:
+    return [
+        port
+        for port in conn.network.ports(device_id=router_id)
+        if _value(port, "device_owner")
+        in {GATEWAY_DEVICE_OWNER, *ROUTER_INTERFACE_DEVICE_OWNERS}
+    ]
+
+
+def _network_uplink_ports(conn, ports: list[Any]) -> dict[str, list[Any]]:
+    """Return UnderStack's shared uplink port intent per router network."""
+    uplinks: dict[str, list[Any]] = {}
+    network_ids = {
+        _value(port, "network_id") for port in ports if _value(port, "network_id")
+    }
+    for network_id in sorted(network_ids):
+        uplinks[network_id] = [
+            port
+            for port in conn.network.ports(network_id=network_id)
+            if (_value(port, "name") or "").startswith("uplink-")
+        ]
+    return uplinks
+
+
+def _expected_switch(port, lsp: dict | None) -> str:
+    switch_id = _value(port, "network_id")
+    if _value(port, "device_owner") != GATEWAY_DEVICE_OWNER:
+        # Router interfaces are not currently host-bound, so ML2/OVN cannot
+        # segment-place them today. Honor a future segment stamp defensively.
+        segment_id = ((lsp or {}).get("external_ids") or {}).get(
+            "neutron:port_segment_id"
+        )
+        switch_id = segment_id or switch_id
+    return f"{NEUTRON_PREFIX}{switch_id}"
+
+
+def _requested_chassis_matches(requested: str, host: str) -> bool:
+    requested_hosts = {item.strip() for item in requested.split(",") if item.strip()}
+    return host in requested_hosts if host else not requested_hosts
+
+
+def _attached_names(
+    parent: dict | None, column: str, rows: dict[str, dict]
+) -> set[str]:
+    if not parent:
+        return set()
+    uuids = set(ovn.as_list(parent.get(column)))
+    return {row.get("name", "") for row in rows_by_uuid(list(rows.values()), uuids)}
+
+
+def _switches_for_lsp(lsp: dict | None, inventory: OvnInventory) -> list[str]:
+    if not lsp:
+        return []
+    return inventory.switch_port_parents.get(lsp.get("_uuid"), [])
+
+
+def _check(
+    findings: list[Finding], condition: bool, name: str, good: str, bad: str
+) -> None:
+    findings.append(
+        Finding("PASS" if condition else "FAIL", name, good if condition else bad)
+    )
+
+
+def _audit_native_router(
+    router,
+    ports: list[Any],
+    inventory: OvnInventory,
+    uplink_ports: dict[str, list[Any]],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    router_id = _value(router, "id")
+    lr_name = f"{NEUTRON_PREFIX}{router_id}"
+    lr = inventory.routers.get(lr_name)
+    _check(
+        findings,
+        lr is not None,
+        "logical router",
+        lr_name,
+        f"missing {lr_name}",
+    )
+    if lr is None:
+        return findings
+
+    attached_lrps = _attached_names(lr, "ports", inventory.router_ports)
+    expected_lrps = {f"lrp-{_value(port, 'id')}" for port in ports}
+    for lrp_name in sorted(attached_lrps - expected_lrps):
+        findings.append(
+            Finding(
+                "FAIL",
+                f"orphaned LRP {lrp_name}",
+                "attached to the logical router without a Neutron router port",
+            )
+        )
+        orphan_lsps = [
+            lsp
+            for lsp in inventory.switch_ports.values()
+            if (lsp.get("options") or {}).get("router-port") == lrp_name
+        ]
+        for lsp in orphan_lsps:
+            findings.append(
+                Finding(
+                    "FAIL",
+                    f"orphaned peer LSP {lsp.get('name', '(unnamed)')}",
+                    f"references attached {lrp_name} without a Neutron router port",
+                )
+            )
+
+    audited_networks: set[str] = set()
+    for port in sorted(
+        ports,
+        key=lambda item: (
+            _value(item, "device_owner") != GATEWAY_DEVICE_OWNER,
+            _value(item, "id"),
+        ),
+    ):
+        port_id = _value(port, "id")
+        owner = _value(port, "device_owner")
+        role = "gateway" if owner == GATEWAY_DEVICE_OWNER else "internal"
+        network_id = _value(port, "network_id")
+        lrp_name = f"lrp-{port_id}"
+        lrp = inventory.router_ports.get(lrp_name)
+        _check(
+            findings,
+            lrp is not None and lrp_name in attached_lrps,
+            f"{role} {port_id}: LRP attachment",
+            f"{lrp_name} attached to {lr_name}",
+            f"{lrp_name} missing or not attached to {lr_name}",
+        )
+
+        lsp = inventory.switch_ports.get(port_id)
+        actual_switches = _switches_for_lsp(lsp, inventory)
+        expected_switch = _expected_switch(port, lsp)
+        _check(
+            findings,
+            lsp is not None and actual_switches == [expected_switch],
+            f"{role} {port_id}: LSP attachment",
+            f"attached to {expected_switch}",
+            f"expected {expected_switch}, found {actual_switches or 'no attachment'}",
+        )
+        if lsp is None:
+            if network_id not in audited_networks:
+                findings.extend(
+                    _audit_network_uplink(
+                        role,
+                        network_id,
+                        uplink_ports.get(network_id, []),
+                        inventory,
+                    )
+                )
+                audited_networks.add(network_id)
+            continue
+
+        _check(
+            findings,
+            lsp.get("type") == "router",
+            f"{role} {port_id}: LSP type",
+            "router",
+            f"expected router, found {lsp.get('type') or '(empty)'}",
+        )
+        addresses = ovn.as_list(lsp.get("addresses"))
+        _check(
+            findings,
+            addresses == ["router"],
+            f"{role} {port_id}: LSP addresses",
+            "router",
+            f"expected ['router'], found {addresses}",
+        )
+        options = lsp.get("options") or {}
+        _check(
+            findings,
+            options.get("router-port") == lrp_name,
+            f"{role} {port_id}: router-port option",
+            lrp_name,
+            f"expected {lrp_name}, found {options.get('router-port') or '(missing)'}",
+        )
+        if role == "gateway":
+            _check(
+                findings,
+                options.get("nat-addresses") == "router",
+                f"gateway {port_id}: nat-addresses option",
+                "router",
+                f"expected router, found {options.get('nat-addresses') or '(missing)'}",
+            )
+            _check(
+                findings,
+                options.get("exclude-lb-vips-from-garp") == "true",
+                f"gateway {port_id}: exclude-lb-vips-from-garp option",
+                "true",
+                "expected true, found "
+                f"{options.get('exclude-lb-vips-from-garp') or '(missing)'}",
+            )
+
+        requested = options.get("requested-chassis", "")
+        host = _binding_host(port)
+        _check(
+            findings,
+            _requested_chassis_matches(requested, host),
+            f"{role} {port_id}: requested-chassis",
+            requested or "not requested (port is not host-bound)",
+            f"Neutron binding:host_id={host or '(empty)'}, "
+            f"OVN requested-chassis={requested or '(empty)'}",
+        )
+        if network_id not in audited_networks:
+            findings.extend(
+                _audit_network_uplink(
+                    role,
+                    network_id,
+                    uplink_ports.get(network_id, []),
+                    inventory,
+                )
+            )
+            audited_networks.add(network_id)
+    return findings
+
+
+def _audit_network_uplink(
+    role: str,
+    network_id: str,
+    ports: list[Any],
+    inventory: OvnInventory,
+) -> list[Finding]:
+    """Check one router network's shared uplink and localnet LSP."""
+    findings: list[Finding] = []
+    names = sorted(name for port in ports if (name := _value(port, "name")) is not None)
+    count_ok = len(names) == 1
+    _check(
+        findings,
+        count_ok,
+        f"{role} network {network_id}: uplink port intent",
+        names[0] if count_ok else "",
+        f"expected exactly one uplink-* Neutron port, found {names or 'none'}",
+    )
+    for name in names:
+        lsp = inventory.switch_ports.get(name)
+        actual_switches = _switches_for_lsp(lsp, inventory)
+        expected_switch = f"{NEUTRON_PREFIX}{network_id}"
+        _check(
+            findings,
+            lsp is not None and actual_switches == [expected_switch],
+            f"{role} uplink {name}: LSP attachment",
+            f"attached to {expected_switch}",
+            f"expected {expected_switch}, found {actual_switches or 'no attachment'}",
+        )
+        if lsp is None:
+            continue
+        _check(
+            findings,
+            lsp.get("type") == "localnet",
+            f"{role} uplink {name}: LSP type",
+            "localnet",
+            f"expected localnet, found {lsp.get('type') or '(empty)'}",
+        )
+        addresses = ovn.as_list(lsp.get("addresses"))
+        _check(
+            findings,
+            addresses == ["unknown"],
+            f"{role} uplink {name}: LSP addresses",
+            "unknown",
+            f"expected ['unknown'], found {addresses}",
+        )
+        tags = ovn.as_list(lsp.get("tag"))
+        _check(
+            findings,
+            len(tags) == 1,
+            f"{role} uplink {name}: VLAN tag",
+            str(tags[0]) if len(tags) == 1 else "",
+            f"expected one VLAN tag, found {tags or 'none'}",
+        )
+    return findings
+
+
+def _print_audit(router, findings: list[Finding]) -> None:
+    print(f"\nRouter {_value(router, 'name') or '(unnamed)'} ({_value(router, 'id')})")
+    print("Backend: native OVN")
+    for finding in findings:
+        print(f"  {finding.status:<4}  {finding.check}: {finding.detail}")
+
+
+def audit(
+    ctx: typer.Context,
+    name_or_id: str = typer.Argument(..., help="Neutron router name or ID"),
+) -> None:
+    """Compare Neutron router intent with native OVN realization."""
+    conn_ctx: ConnectionContext = ctx.obj
+    print_connection_banner(conn_ctx, include_openstack=True)
+    try:
+        conn = osclient.get_connection(conn_ctx.os_cloud)
+        router = osclient.resolve_router(conn, name_or_id)
+        flavor_id = _value(router, "flavor_id")
+        if flavor_id:
+            print(
+                f"\nRouter {_value(router, 'name') or '(unnamed)'} "
+                f"({_value(router, 'id')})"
+            )
+            print(
+                f"  SKIP  router has flavor {flavor_id}; "
+                "only unflavored native OVN routers are supported"
+            )
+            return
+        ports = _router_ports(conn, _value(router, "id"))
+        uplink_ports = _network_uplink_ports(conn, ports)
+        inventory = _load_inventory(
+            conn_ctx,
+            _value(router, "id"),
+            ports,
+            {
+                name
+                for network_ports in uplink_ports.values()
+                for port in network_ports
+                if (name := _value(port, "name"))
+            },
+        )
+        findings = _audit_native_router(router, ports, inventory, uplink_ports)
+        lr = inventory.routers.get(f"{NEUTRON_PREFIX}{_value(router, 'id')}")
+        centralized_chassis = (lr.get("options") or {}).get("chassis") if lr else None
+        ha_inventory = _load_router_ha_chassis_inventory(
+            conn_ctx,
+            _value(router, "id"),
+            {centralized_chassis} if centralized_chassis else None,
+        )
+        findings.extend(_audit_network_ha_chassis_groups(ha_inventory))
+        findings.extend(
+            _audit_ha_chassis_repopulation_source(router, inventory, ha_inventory)
+        )
+        _print_audit(router, findings)
+    except Exception as exc:
+        typer.echo(f"ERROR: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    else:
+        if any(finding.status == "FAIL" for finding in findings):
+            raise typer.Exit(1)
+
+
+def _repair_operations(
+    router,
+    ports: list[Any],
+    inventory: OvnInventory,
+) -> tuple[list[RepairOperation], list[str]]:
+    operations: list[RepairOperation] = []
+    refused: list[str] = []
+    router_id = _value(router, "id")
+    lr_name = f"{NEUTRON_PREFIX}{router_id}"
+    lr = inventory.routers.get(lr_name)
+    if lr is None:
+        return [], [f"logical router {lr_name} is missing"]
+    attached_lrps = _attached_names(lr, "ports", inventory.router_ports)
+    expected_lrps = {f"lrp-{_value(port, 'id')}" for port in ports}
+    for lrp_name in sorted(attached_lrps - expected_lrps):
+        refused.append(
+            f"{lrp_name} is attached to {lr_name} without a Neutron router port"
+        )
+
+    for port in ports:
+        owner = _value(port, "device_owner")
+        port_id = _value(port, "id")
+        lrp_name = f"lrp-{port_id}"
+        lrp = inventory.router_ports.get(lrp_name)
+        lsp = inventory.switch_ports.get(port_id)
+        switches = _switches_for_lsp(lsp, inventory)
+        expected_switch = _expected_switch(port, lsp)
+        if lrp is None or lrp_name not in attached_lrps:
+            refused.append(
+                f"{port_id}: {lrp_name} is missing or not attached to {lr_name}"
+            )
+            continue
+        if lsp is None or switches != [expected_switch]:
+            refused.append(
+                f"{port_id}: LSP attachment is invalid: "
+                f"expected {expected_switch}, found {switches or 'no attachment'}"
+            )
+            continue
+
+        assignments: list[str] = []
+        changes: list[str] = []
+        if lsp.get("type") != "router":
+            assignments.append("type=router")
+            changes.append(f"type: {lsp.get('type') or '(empty)'} -> router")
+        addresses = ovn.as_list(lsp.get("addresses"))
+        if addresses != ["router"]:
+            assignments.append("addresses=router")
+            changes.append(f"addresses: {addresses} -> ['router']")
+        options = lsp.get("options") or {}
+        required_options = {"router-port": lrp_name}
+        if owner == GATEWAY_DEVICE_OWNER:
+            required_options.update(
+                {
+                    "nat-addresses": "router",
+                    "exclude-lb-vips-from-garp": "true",
+                }
+            )
+        for key, expected in required_options.items():
+            if options.get(key) != expected:
+                assignments.append(f"options:{key}={expected}")
+                changes.append(
+                    f"options:{key}: {options.get(key) or '(missing)'} -> {expected}"
+                )
+        if assignments:
+            operations.append(
+                RepairOperation(port_id, tuple(assignments), tuple(changes))
+            )
+    return operations, refused
+
+
+def _ha_chassis_group_repair_operations(
+    router,
+    inventory: OvnInventory,
+    ha_inventory: RouterHaChassisInventory,
+) -> tuple[list[HaChassisGroupRepairOperation], list[str]]:
+    """Plan repopulation of empty or stale-only per-network HA groups."""
+    router_id = _value(router, "id")
+    lr_name = f"{NEUTRON_PREFIX}{router_id}"
+    lr = inventory.routers.get(lr_name)
+    if lr is None:
+        return [], []
+
+    network_groups = [
+        group
+        for group in ha_inventory.groups
+        if (group.get("external_ids") or {}).get(OVN_NETWORK_ID_EXT_ID_KEY)
+    ]
+    groups_needing_repopulation = [
+        group for group in network_groups if not _group_members(group, ha_inventory)[2]
+    ]
+    if not groups_needing_repopulation:
+        return [], []
+
+    target_chassis, target_error = _ha_chassis_repopulation_target(
+        router, inventory, ha_inventory
+    )
+
+    operations: list[HaChassisGroupRepairOperation] = []
+    refused: list[str] = []
+    for group in groups_needing_repopulation:
+        group_name = group.get("name") or "(unnamed)"
+        group_uuid = group.get("_uuid")
+        if not group_uuid:
+            refused.append(f"{group_name}: HA chassis group UUID is missing")
+        elif target_chassis is None:
+            refused.append(f"{group_name}: {target_error}")
+        else:
+            operations.append(
+                HaChassisGroupRepairOperation(
+                    group_uuid=group_uuid,
+                    group_name=group_name,
+                    target_chassis=target_chassis,
+                    remove_member_uuids=tuple(
+                        sorted(ovn.as_list(group.get("ha_chassis")))
+                    ),
+                )
+            )
+    return operations, refused
+
+
+def _verify_ha_chassis_group_repairs(
+    operations: list[HaChassisGroupRepairOperation],
+    inventory: RouterHaChassisInventory,
+) -> list[str]:
+    """Verify each applied HA chassis group operation against its plan."""
+    errors: list[str] = []
+    groups_by_uuid = {group.get("_uuid"): group for group in inventory.groups}
+    for operation in operations:
+        group = groups_by_uuid.get(operation.group_uuid)
+        if group is None:
+            errors.append(f"{operation.group_name}: HA chassis group is missing")
+            continue
+
+        member_uuids = set(ovn.as_list(group.get("ha_chassis")))
+        stale_uuids = sorted(member_uuids.intersection(operation.remove_member_uuids))
+        if stale_uuids:
+            errors.append(
+                f"{operation.group_name}: removed HA_Chassis references remain: "
+                f"{', '.join(stale_uuids)}"
+            )
+
+        target_members = [
+            inventory.members_by_uuid[member_uuid]
+            for member_uuid in member_uuids
+            if member_uuid in inventory.members_by_uuid
+            and inventory.members_by_uuid[member_uuid].get("chassis_name")
+            == operation.target_chassis
+        ]
+        if not target_members:
+            errors.append(
+                f"{operation.group_name}: target chassis "
+                f"{operation.target_chassis} is not a member"
+            )
+            continue
+        if not any(
+            member.get("priority") == HA_CHASSIS_GROUP_HIGHEST_PRIORITY
+            for member in target_members
+        ):
+            priorities = sorted(
+                str(member.get("priority", "(missing)")) for member in target_members
+            )
+            errors.append(
+                f"{operation.group_name}: target chassis {operation.target_chassis} "
+                f"has priority {', '.join(priorities)}, expected "
+                f"{HA_CHASSIS_GROUP_HIGHEST_PRIORITY}"
+            )
+    return errors
+
+
+def repair(
+    ctx: typer.Context,
+    name_or_id: str = typer.Argument(..., help="Neutron router name or ID"),
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Apply the displayed plan; without this flag no changes are made",
+    ),
+) -> None:
+    """Repair safe native-OVN router LSP and HA chassis group state."""
+    conn_ctx: ConnectionContext = ctx.obj
+    print_connection_banner(conn_ctx, include_openstack=True)
+    try:
+        conn = osclient.get_connection(conn_ctx.os_cloud)
+        router = osclient.resolve_router(conn, name_or_id)
+        flavor_id = _value(router, "flavor_id")
+        if flavor_id:
+            typer.echo(
+                f"REFUSED: router has flavor {flavor_id}; this repair only "
+                "supports unflavored native OVN routers",
+                err=True,
+            )
+            raise typer.Exit(2)
+        ports = _router_ports(conn, _value(router, "id"))
+        inventory = _load_inventory(conn_ctx, _value(router, "id"), ports)
+        operations, lsp_refused = _repair_operations(router, ports, inventory)
+        lr = inventory.routers.get(f"{NEUTRON_PREFIX}{_value(router, 'id')}")
+        centralized_chassis = (lr.get("options") or {}).get("chassis") if lr else None
+        ha_inventory = _load_router_ha_chassis_inventory(
+            conn_ctx,
+            _value(router, "id"),
+            {centralized_chassis} if centralized_chassis else None,
+        )
+        ha_group_operations, ha_refused = _ha_chassis_group_repair_operations(
+            router,
+            inventory,
+            ha_inventory,
+        )
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"ERROR: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    print(f"\nRouter {_value(router, 'name') or '(unnamed)'} ({_value(router, 'id')})")
+    print(
+        "Repair scope: attached router peer LSP fields and unambiguous "
+        "per-network HA chassis group repopulation"
+    )
+    for reason in lsp_refused:
+        print(f"  REFUSED LSP repair  {reason}")
+    for reason in ha_refused:
+        print(f"  REFUSED HA chassis group repair  {reason}")
+
+    allowed_operations = [] if lsp_refused else operations
+    allowed_ha_group_operations = [] if ha_refused else ha_group_operations
+    for operation in allowed_operations:
+        print(f"  LSP {operation.port_id}")
+        for change in operation.changes:
+            print(f"    {change}")
+    for operation in allowed_ha_group_operations:
+        print(f"  HA chassis group {operation.group_name}")
+        if operation.remove_member_uuids:
+            print(
+                "    remove non-live members: "
+                f"{', '.join(operation.remove_member_uuids)}"
+            )
+        print(f"    repopulate with live chassis: {operation.target_chassis}")
+
+    has_refusals = bool(lsp_refused or ha_refused)
+    if not allowed_operations and not allowed_ha_group_operations:
+        if not has_refusals:
+            print("\nNo repairable differences found.")
+            return
+        typer.echo(
+            "\nNo changes made: all required repair domains are either clean "
+            "or refused.",
+            err=True,
+        )
+        raise typer.Exit(2)
+    if not apply:
+        print("\nDry run only. Re-run with --apply to make these changes.")
+        if has_refusals:
+            raise typer.Exit(2)
+        return
+
+    args: list[str] = []
+    for operation in allowed_operations:
+        args.extend(
+            [
+                "--",
+                "set",
+                "Logical_Switch_Port",
+                operation.port_id,
+                *operation.assignments,
+            ]
+        )
+    for index, operation in enumerate(allowed_ha_group_operations):
+        for member_uuid in operation.remove_member_uuids:
+            args.extend(
+                [
+                    "--",
+                    "--if-exists",
+                    "remove",
+                    "HA_Chassis_Group",
+                    operation.group_uuid,
+                    "ha_chassis",
+                    member_uuid,
+                ]
+            )
+        row_id = f"@ha_chassis_{index}"
+        args.extend(
+            [
+                "--",
+                f"--id={row_id}",
+                "create",
+                "HA_Chassis",
+                f"chassis_name={operation.target_chassis}",
+                f"priority={HA_CHASSIS_GROUP_HIGHEST_PRIORITY}",
+                "--",
+                "add",
+                "HA_Chassis_Group",
+                operation.group_uuid,
+                "ha_chassis",
+                row_id,
+            ]
+        )
+    ovn.nbctl_raw(conn_ctx, args)
+
+    refreshed = _load_inventory(conn_ctx, _value(router, "id"), ports)
+    remaining: list[RepairOperation] = []
+    structural: list[str] = []
+    if allowed_operations:
+        remaining, structural = _repair_operations(router, ports, refreshed)
+    ha_verification_errors: list[str] = []
+    if allowed_ha_group_operations:
+        refreshed_lr = refreshed.routers.get(f"{NEUTRON_PREFIX}{_value(router, 'id')}")
+        refreshed_chassis = (
+            (refreshed_lr.get("options") or {}).get("chassis") if refreshed_lr else None
+        )
+        refreshed_ha = _load_router_ha_chassis_inventory(
+            conn_ctx,
+            _value(router, "id"),
+            {refreshed_chassis} if refreshed_chassis else None,
+        )
+        ha_verification_errors = _verify_ha_chassis_group_repairs(
+            allowed_ha_group_operations,
+            refreshed_ha,
+        )
+    if structural or remaining or ha_verification_errors:
+        typer.echo("ERROR: repair verification failed", err=True)
+        for reason in structural:
+            typer.echo(f"  {reason}", err=True)
+        for operation in remaining:
+            typer.echo(
+                f"  {operation.port_id}: {', '.join(operation.changes)}", err=True
+            )
+        for reason in ha_verification_errors:
+            typer.echo(f"  {reason}", err=True)
+        raise typer.Exit(1)
+    print(
+        f"\nApplied {len(allowed_operations)} LSP repair(s) and "
+        f"{len(allowed_ha_group_operations)} HA chassis group repair(s); "
+        "verification passed."
+    )
+    if has_refusals:
+        typer.echo(
+            "Some repair domains remain refused and require manual investigation.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+
+def register(app: typer.Typer) -> None:
+    """Register health commands on the router command group."""
+    app.command("audit")(audit)
+    app.command("repair")(repair)

--- a/python/kubectl-us-net/us_net/ovn.py
+++ b/python/kubectl-us-net/us_net/ovn.py
@@ -73,6 +73,20 @@ def nbctl_list(ctx: ConnectionContext, table: str) -> list[dict]:
     return parse_ovn_json(nbctl_raw(ctx, ["--format=json", "list", table]))
 
 
+def nbctl_list_records(
+    ctx: ConnectionContext, table: str, records: list[str]
+) -> list[dict]:
+    """List specific NB records by name or UUID, ignoring missing records."""
+    if not records:
+        return []
+    return parse_ovn_json(
+        nbctl_raw(
+            ctx,
+            ["--format=json", "--if-exists", "list", table, *records],
+        )
+    )
+
+
 def sbctl_list(ctx: ConnectionContext, table: str) -> list[dict]:
     """`ovn-sbctl list <table>` as parsed JSON rows."""
     return parse_ovn_json(sbctl_raw(ctx, ["--format=json", "list", table]))


### PR DESCRIPTION
Audit native OVN LRP and LSP realization against Neutron port state, including role-aware switch attachments, orphaned peers, required options, and requested chassis membership.

Check router-owned per-network HA chassis groups for a live member. Use UUID-addressed list commands for scoped record reads supported by OVN.

Repair existing, correctly attached router switch ports and safely repopulate empty or stale-only per-network HA chassis groups when the target is unambiguous. Preserve unrelated state and verify atomic updates.

Document the audit and narrowly scoped repair workflows.

<!--
Pull request titles must follow conventional commits and are checked by CI:
  feat|fix|docs|test|ci|chore(optional-scope): description
Append `!` (for example `feat(neutron)!:`) for a change that requires operator
action to upgrade.
-->

## What does this change do?

## Upgrade impact

- [ ] This change requires operator action to upgrade. If checked, add the
      `upgrade-impact` label and a release note: run `scriv create` from the
      repository root and describe the required action in the generated
      `changelog.d/` file. See [RELEASING.md](../RELEASING.md).

Operator action means anything a deployment has to do beyond a normal resync:
deploy repo or values changes, new or removed secrets, enabling or disabling a
component, or a manual one-time step.
